### PR TITLE
Type stuff

### DIFF
--- a/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.api;
 
-import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.trellisldp.api.RDFUtils.TRELLIS_BNODE_PREFIX;
 import static org.trellisldp.api.RDFUtils.TRELLIS_DATA_PREFIX;

--- a/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -48,7 +48,7 @@ public interface ResourceService {
      * @param identifier the resource identifier
      * @return the resource
      */
-    Optional<Resource> get(IRI identifier);
+    Optional<? extends Resource> get(IRI identifier);
 
     /**
      * Get a resource from the given location and time.
@@ -57,7 +57,7 @@ public interface ResourceService {
      * @param time the time
      * @return the resource
      */
-    Optional<Resource> get(IRI identifier, Instant time);
+    Optional<? extends Resource> get(IRI identifier, Instant time);
 
     /**
      * Put a resource into the server.

--- a/trellis-api/src/test/java/org/trellisldp/api/ConstraintServiceTest.java
+++ b/trellis-api/src/test/java/org/trellisldp/api/ConstraintServiceTest.java
@@ -19,8 +19,6 @@ import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.trellisldp.vocabulary.RDF.type;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/trellis-api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/trellis-api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -28,6 +28,7 @@ import static org.trellisldp.vocabulary.RDF.type;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.trellisldp.vocabulary.DC;
 import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.Trellis;
@@ -102,7 +104,7 @@ public class ResourceServiceTest {
         when(mockResource.getIdentifier()).thenReturn(existing);
         when(mockResource.stream(eq(graphs))).thenAnswer(inv ->
                 Stream.of(rdf.createTriple(existing, DC.title, rdf.createLiteral("A title"))));
-        when(mockResourceService.get(eq(existing))).thenReturn(of(mockResource));
+        Mockito.<Optional<? extends Resource>>when(mockResourceService.get(eq(existing))).thenReturn(of(mockResource));
 
         final List<Quad> export = mockResourceService.export(graphs).collect(toList());
         assertEquals(1L, export.size());

--- a/trellis-event-serialization/src/test/java/org/trellisldp/event/EventSerializerTest.java
+++ b/trellis-event-serialization/src/test/java/org/trellisldp/event/EventSerializerTest.java
@@ -97,13 +97,13 @@ public class EventSerializerTest {
         assertTrue(map.containsKey("object"));
         assertTrue(map.containsKey("published"));
 
-        final List types = (List) map.get("type");
+        final List<?> types = (List<?>) map.get("type");
         assertTrue(types.contains("Create"));
         assertTrue(types.contains(Activity.getIRIString()));
 
         assertTrue(AS.URI.contains((String) map.get("@context")));
 
-        final List actor = (List) map.get("actor");
+        final List<?> actor = (List<?>) map.get("actor");
         assertTrue(actor.contains("info:user/test"));
 
         assertTrue(map.get("id").equals("info:event/12345"));
@@ -131,7 +131,7 @@ public class EventSerializerTest {
         assertTrue(map.containsKey("object"));
         assertTrue(map.containsKey("published"));
 
-        final List types = (List) map.get("type");
+        final List<?> types = (List<?>) map.get("type");
         assertTrue(types.contains("Create"));
 
         @SuppressWarnings("unchecked")

--- a/trellis-http/src/main/java/org/trellisldp/http/LdpResource.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/LdpResource.java
@@ -335,7 +335,7 @@ public class LdpResource implements ContainerRequestFilter {
         final String separator = path.isEmpty() ? "" : "/";
 
         // First check if this is a container
-        final Optional<Resource> parent = resourceService.get(rdf.createIRI(TRELLIS_DATA_PREFIX + path));
+        final Optional<? extends Resource> parent = resourceService.get(rdf.createIRI(TRELLIS_DATA_PREFIX + path));
         if (parent.isPresent()) {
             final Optional<IRI> ixModel = parent.map(Resource::getInteractionModel);
             if (ixModel.filter(type -> ldpResourceTypes(type).anyMatch(LDP.Container::equals)).isPresent()) {

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -24,8 +24,6 @@ import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
 import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.trellisldp.api.RDFUtils.getInstance;
-import static org.trellisldp.vocabulary.LDP.Resource;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/MementoResource.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/MementoResource.java
@@ -19,7 +19,6 @@ import static java.time.ZonedDateTime.ofInstant;
 import static java.time.ZonedDateTime.parse;
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Objects.nonNull;
-import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;

--- a/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -93,6 +93,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -119,7 +120,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-
+import org.mockito.Mockito;
+import org.mockito.stubbing.OngoingStubbing;
 import org.trellisldp.api.AccessControlService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.Binary;
@@ -233,28 +235,33 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
         super.tearDown();
     }
 
+    private static OngoingStubbing<Optional<? extends Resource>> whenResource(
+                    final Optional<? extends Resource> methodCall) {
+        return Mockito.<Optional<? extends Resource>>when(methodCall);
+    }
+
     @BeforeEach
     public void setUpMocks() {
-        when(mockResourceService.get(any(IRI.class), any(Instant.class)))
+        whenResource(mockResourceService.get(any(IRI.class), any(Instant.class)))
             .thenReturn(of(mockVersionedResource));
-        when(mockResourceService.get(eq(identifier))).thenReturn(of(mockResource));
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "repository/resource"))))
+        whenResource(mockResourceService.get(eq(identifier))).thenReturn(of(mockResource));
+        whenResource(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "repository/resource"))))
             .thenReturn(of(mockResource));
-        when(mockResourceService.get(eq(root))).thenReturn(of(mockResource));
+        whenResource(mockResourceService.get(eq(root))).thenReturn(of(mockResource));
         when(mockResourceService.get(eq(childIdentifier))).thenReturn(empty());
         when(mockResourceService.get(eq(childIdentifier), any(Instant.class))).thenReturn(empty());
-        when(mockResourceService.get(eq(binaryIdentifier))).thenReturn(of(mockBinaryResource));
-        when(mockResourceService.get(eq(binaryIdentifier), any(Instant.class)))
+        whenResource(mockResourceService.get(eq(binaryIdentifier))).thenReturn(of(mockBinaryResource));
+        whenResource(mockResourceService.get(eq(binaryIdentifier), any(Instant.class)))
             .thenReturn(of(mockBinaryVersionedResource));
         when(mockResourceService.get(eq(nonexistentIdentifier))).thenReturn(empty());
         when(mockResourceService.get(eq(nonexistentIdentifier), any(Instant.class))).thenReturn(empty());
-        when(mockResourceService.get(eq(deletedIdentifier))).thenReturn(of(mockDeletedResource));
-        when(mockResourceService.get(eq(deletedIdentifier), any(Instant.class)))
+        whenResource(mockResourceService.get(eq(deletedIdentifier))).thenReturn(of(mockDeletedResource));
+        whenResource(mockResourceService.get(eq(deletedIdentifier), any(Instant.class)))
             .thenReturn(of(mockDeletedResource));
         when(mockResourceService.getIdentifierSupplier()).thenReturn(() -> RANDOM_VALUE);
 
-        when(mockResourceService.get(eq(userDeletedIdentifier))).thenReturn(of(mockUserDeletedResource));
-        when(mockResourceService.get(eq(userDeletedIdentifier), any(Instant.class)))
+        whenResource(mockResourceService.get(eq(userDeletedIdentifier))).thenReturn(of(mockUserDeletedResource));
+        whenResource(mockResourceService.get(eq(userDeletedIdentifier), any(Instant.class)))
             .thenReturn(of(mockUserDeletedResource));
 
         when(mockAgentService.asAgent(anyString())).thenReturn(agent);

--- a/trellis-http/src/test/java/org/trellisldp/http/CORSResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/CORSResourceTest.java
@@ -41,6 +41,7 @@ import static org.trellisldp.vocabulary.RDF.type;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -63,7 +64,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-
+import org.mockito.Mockito;
+import org.mockito.stubbing.OngoingStubbing;
 import org.trellisldp.api.AccessControlService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.Binary;
@@ -179,16 +181,21 @@ public class CORSResourceTest extends JerseyTest {
         super.tearDown();
     }
 
+    private static OngoingStubbing<Optional<? extends Resource>> whenResource(
+                    final Optional<? extends Resource> methodCall) {
+        return Mockito.<Optional<? extends Resource>>when(methodCall);
+    }
+
     @BeforeEach
     public void setUpMocks() {
-        when(mockResourceService.get(any(IRI.class), any(Instant.class)))
+        whenResource(mockResourceService.get(any(IRI.class), any(Instant.class)))
             .thenReturn(of(mockVersionedResource));
-        when(mockResourceService.get(eq(identifier))).thenReturn(of(mockResource));
-        when(mockResourceService.get(eq(root))).thenReturn(of(mockResource));
+        whenResource(mockResourceService.get(eq(identifier))).thenReturn(of(mockResource));
+        whenResource(mockResourceService.get(eq(root))).thenReturn(of(mockResource));
         when(mockResourceService.get(eq(childIdentifier))).thenReturn(empty());
         when(mockResourceService.get(eq(childIdentifier), any(Instant.class))).thenReturn(empty());
-        when(mockResourceService.get(eq(binaryIdentifier))).thenReturn(of(mockBinaryResource));
-        when(mockResourceService.get(eq(binaryIdentifier), any(Instant.class)))
+        whenResource(mockResourceService.get(eq(binaryIdentifier))).thenReturn(of(mockBinaryResource));
+        whenResource(mockResourceService.get(eq(binaryIdentifier), any(Instant.class)))
             .thenReturn(of(mockBinaryVersionedResource));
         when(mockResourceService.get(eq(nonexistentIdentifier))).thenReturn(empty());
         when(mockResourceService.get(eq(nonexistentIdentifier), any(Instant.class))).thenReturn(empty());

--- a/trellis-http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
@@ -37,6 +37,7 @@ import static org.trellisldp.http.domain.RdfMediaType.APPLICATION_N_TRIPLES_TYPE
 import static org.trellisldp.http.domain.RdfMediaType.APPLICATION_SPARQL_UPDATE_TYPE;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.ws.rs.core.Application;
@@ -58,7 +59,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-
+import org.mockito.Mockito;
 import org.trellisldp.api.AccessControlService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.BinaryService;
@@ -139,8 +140,10 @@ public class LdpForbiddenResourceTest extends JerseyTest {
 
     @BeforeEach
     public void setUpMocks() {
-        when(mockResourceService.get(any(IRI.class), any(Instant.class))).thenReturn(of(mockVersionedResource));
-        when(mockResourceService.get(any(IRI.class))).thenReturn(of(mockResource));
+        Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class), any(Instant.class)))
+                        .thenReturn(of(mockVersionedResource));
+        Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class)))
+                        .thenReturn(of(mockResource));
         when(mockResourceService.getMementos(any())).thenReturn(emptyList());
 
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());

--- a/trellis-http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
@@ -40,6 +40,7 @@ import static org.trellisldp.http.domain.RdfMediaType.APPLICATION_N_TRIPLES_TYPE
 import static org.trellisldp.http.domain.RdfMediaType.APPLICATION_SPARQL_UPDATE_TYPE;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.ws.rs.core.Application;
@@ -60,7 +61,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-
+import org.mockito.Mockito;
 import org.trellisldp.api.AccessControlService;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
@@ -139,8 +140,10 @@ public class LdpUnauthorizedResourceTest extends JerseyTest {
 
     @BeforeEach
     public void setUpMocks() {
-        when(mockResourceService.get(any(IRI.class), any(Instant.class))).thenReturn(of(mockVersionedResource));
-        when(mockResourceService.get(any(IRI.class))).thenReturn(of(mockResource));
+        Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class), any(Instant.class)))
+                        .thenReturn(of(mockVersionedResource));
+        Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class)))
+                        .thenReturn(of(mockResource));
         when(mockResourceService.getMementos(any())).thenReturn(emptyList());
 
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());

--- a/trellis-io-jena/src/test/java/org/trellisldp/io/IOServiceTest.java
+++ b/trellis-io-jena/src/test/java/org/trellisldp/io/IOServiceTest.java
@@ -132,8 +132,8 @@ public class IOServiceTest {
         when(mockNamespaceService.getPrefix(eq("http://purl.org/dc/dcmitype/")))
             .thenReturn(Optional.of("dcmitype"));
         when(mockCache.get(anyString(), any(Function.class))).thenAnswer(inv -> {
-            final String key = (String) inv.getArgument(0);
-            final Function mapper = (Function<String, String>) inv.getArgument(1);
+            final String key = inv.getArgument(0);
+            final Function<String, String> mapper = inv.getArgument(1);
             return mapper.apply(key);
         });
     }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/ACLTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/ACLTest.java
@@ -25,7 +25,7 @@ public class ACLTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<ACL> vocabulary() {
         return ACL.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/ASTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/ASTest.java
@@ -25,11 +25,13 @@ import org.junit.Test;
  */
 public class ASTest extends AbstractVocabularyTest {
 
+    @Override
     public String namespace() {
         return "https://www.w3.org/ns/activitystreams#";
     }
 
-    public Class vocabulary() {
+    @Override
+    public Class<AS> vocabulary() {
         return AS.class;
     }
 

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/AbstractVocabularyTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/AbstractVocabularyTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractVocabularyTest {
 
     public abstract String namespace();
 
-    public abstract Class vocabulary();
+    public abstract Class<?> vocabulary();
 
     public Boolean isStrict() {
         return true;

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/DCTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/DCTest.java
@@ -25,7 +25,7 @@ public class DCTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<DC> vocabulary() {
         return DC.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/FOAFTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/FOAFTest.java
@@ -25,7 +25,7 @@ public class FOAFTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<FOAF> vocabulary() {
         return FOAF.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/JSONLDTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/JSONLDTest.java
@@ -30,7 +30,7 @@ public class JSONLDTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<JSONLD> vocabulary() {
         return JSONLD.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/LDPTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/LDPTest.java
@@ -25,7 +25,7 @@ public class LDPTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<LDP> vocabulary() {
         return LDP.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/MementoTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/MementoTest.java
@@ -25,7 +25,7 @@ public class MementoTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<Memento> vocabulary() {
         return Memento.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/OATest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/OATest.java
@@ -25,7 +25,7 @@ public class OATest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<OA> vocabulary() {
         return OA.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/PROVTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/PROVTest.java
@@ -25,7 +25,7 @@ public class PROVTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<PROV> vocabulary() {
         return PROV.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/RDFSTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/RDFSTest.java
@@ -25,7 +25,7 @@ public class RDFSTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<RDFS> vocabulary() {
         return RDFS.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/RDFTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/RDFTest.java
@@ -25,7 +25,7 @@ public class RDFTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<RDF> vocabulary() {
         return RDF.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/SKOSTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/SKOSTest.java
@@ -25,7 +25,7 @@ public class SKOSTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<SKOS> vocabulary() {
         return SKOS.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/TimeTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/TimeTest.java
@@ -25,7 +25,7 @@ public class TimeTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<Time> vocabulary() {
         return Time.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/TrellisTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/TrellisTest.java
@@ -25,7 +25,7 @@ public class TrellisTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<Trellis> vocabulary() {
         return Trellis.class;
     }
 }

--- a/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/VCARDTest.java
+++ b/trellis-vocabulary/src/test/java/org/trellisldp/vocabulary/VCARDTest.java
@@ -25,7 +25,7 @@ public class VCARDTest extends AbstractVocabularyTest {
     }
 
     @Override
-    public Class vocabulary() {
+    public Class<VCARD> vocabulary() {
         return VCARD.class;
     }
 }

--- a/trellis-webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/trellis-webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -131,8 +131,8 @@ public class WebACService implements AccessControlService {
             .collect(toSet());
     }
 
-    private Optional<Resource> getNearestResource(final IRI identifier) {
-        final Optional<Resource> res = resourceService.get(identifier);
+    private Optional<? extends Resource> getNearestResource(final IRI identifier) {
+        final Optional<? extends Resource> res = resourceService.get(identifier);
         // TODO -- JDK9 refactor with Optional::or
         if (res.isPresent()) {
             return res;

--- a/trellis-webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/trellis-webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -19,7 +19,6 @@ import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static java.util.stream.Stream.empty;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.RDFUtils.getInstance;
 import static org.trellisldp.api.RDFUtils.toGraph;

--- a/trellis-webac/src/test/java/org/trellisldp/webac/WebACServiceTest.java
+++ b/trellis-webac/src/test/java/org/trellisldp/webac/WebACServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.vocabulary.RDF.type;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -36,6 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.stubbing.OngoingStubbing;
 import org.trellisldp.api.AccessControlService;
 import org.trellisldp.api.CacheService;
 import org.trellisldp.api.Resource;
@@ -108,6 +111,12 @@ public class WebACServiceTest {
 
     private static final IRI groupIRI2 = rdf.createIRI("trellis:repository/group/test/");
 
+
+    private static OngoingStubbing<Optional<? extends Resource>> whenResource(
+                    final Optional<? extends Resource> methodCall) {
+        return Mockito.<Optional<? extends Resource>>when(methodCall);
+    }
+
     @BeforeEach
     @SuppressWarnings("unchecked")
     public void setUp() {
@@ -165,11 +174,11 @@ public class WebACServiceTest {
                 rdf.createTriple(authIRI8, ACL.mode, ACL.Write)));
 
         when(mockResourceService.get(eq(nonexistentIRI))).thenReturn(empty());
-        when(mockResourceService.get(eq(resourceIRI))).thenReturn(of(mockResource));
-        when(mockResourceService.get(eq(childIRI))).thenReturn(of(mockChildResource));
-        when(mockResourceService.get(eq(parentIRI))).thenReturn(of(mockParentResource));
-        when(mockResourceService.get(eq(rootIRI))).thenReturn(of(mockRootResource));
-        when(mockResourceService.get(eq(groupIRI))).thenReturn(of(mockGroupResource));
+        whenResource(mockResourceService.get(eq(resourceIRI))).thenReturn(of(mockResource));
+        whenResource(mockResourceService.get(eq(childIRI))).thenReturn(of(mockChildResource));
+        whenResource(mockResourceService.get(eq(parentIRI))).thenReturn(of(mockParentResource));
+        whenResource(mockResourceService.get(eq(rootIRI))).thenReturn(of(mockRootResource));
+        whenResource(mockResourceService.get(eq(groupIRI))).thenReturn(of(mockGroupResource));
         when(mockResourceService.getContainer(nonexistentIRI)).thenReturn(of(resourceIRI));
         when(mockResourceService.getContainer(resourceIRI)).thenReturn(of(childIRI));
         when(mockResourceService.getContainer(childIRI)).thenReturn(of(parentIRI));

--- a/trellis-webac/src/test/java/org/trellisldp/webac/WebACServiceTest.java
+++ b/trellis-webac/src/test/java/org/trellisldp/webac/WebACServiceTest.java
@@ -116,8 +116,8 @@ public class WebACServiceTest {
         testService = new WebACService(mockResourceService);
 
         when(mockCache.get(anyString(), any(Function.class))).thenAnswer(inv -> {
-            final String key = (String) inv.getArgument(0);
-            final Function mapper = (Function<String, String>) inv.getArgument(1);
+            final String key = inv.getArgument(0);
+            final Function<String, String> mapper = inv.getArgument(1);
             return mapper.apply(key);
         });
 


### PR DESCRIPTION
Two commits here: the first will be uncontroversial, I think-- it just adds in some type params to avoid compiler warnings. Maybe there's a reason not to, and if so, let's just skip it.

The other widens the return type of `ResourceService::get` (in both forms) in order to deal with Java's craptacular generics and their lack of proper co/contravariance control. Because `ResourceService::get` returns `Optional<Resource>`, I can't impl it with `Optional<MyTypeThatImplsResource>` because Java doesn't understand that `Optional<MyTypeThatImplsResource> "extends" Optional<Resource>`. So now I can, at the cost of making some test mocking code look pretty gross... this lets impls of `ResourceService` use `get` in their own code and get the actual type of `Resource` at stake. _This_ is useful because `MyTypeThatImplsResource` can have extra fresh members (in my case for Cassandra, a member that gives the Basic Containment container for that resource).

Does that make sense?