### PR TITLE
Add session information to API methods

### DIFF
--- a/trellis-api/src/main/java/org/trellisldp/api/ImmutableDataService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/ImmutableDataService.java
@@ -29,8 +29,9 @@ public interface ImmutableDataService<T, U> extends RetrievalService<T, U> {
 
     /**
      * @param identifier the identifier under which to persist a resource
+     * @param session the session context for this operation
      * @param resource a resource to persist
      * @return whether the resource was successfully persisted
      */
-    Future<Boolean> add(T identifier, U resource);
+    Future<Boolean> add(T identifier, Session session, U resource);
 }

--- a/trellis-api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -37,13 +37,13 @@ public abstract class JoiningResourceService implements ResourceService {
 
     private final ImmutableDataService<IRI, Resource> immutableData;
 
-    private final MutableDataService<IRI, Resource> mutableData;
+    private final MutableDataService<IRI, Session, Resource> mutableData;
 
     /**
      * @param mutableData service in which to persist mutable data
      * @param immutableData service in which to persist immutable data
      */
-    public JoiningResourceService(final MutableDataService<IRI, Resource> mutableData,
+    public JoiningResourceService(final MutableDataService<IRI, Session, Resource> mutableData,
                     final ImmutableDataService<IRI, Resource> immutableData) {
         this.immutableData = immutableData;
         this.mutableData = mutableData;
@@ -66,19 +66,21 @@ public abstract class JoiningResourceService implements ResourceService {
     }
 
     @Override
-    public Future<Boolean> create(final IRI id, final IRI ixnModel, final Dataset dataset) {
-        return mutableData.create(id, new PersistableResource(id, ixnModel, dataset));
+    public Future<Boolean> create(final IRI id, final Session session, final IRI ixnModel,
+            final Dataset dataset) {
+        return mutableData.create(id, session, new PersistableResource(id, ixnModel, dataset));
     }
 
     @Override
-    public Future<Boolean> replace(final IRI id, final IRI ixnModel, final Dataset dataset) {
-        return mutableData.replace(id, new PersistableResource(id, ixnModel, dataset));
-
+    public Future<Boolean> replace(final IRI id, final Session session, final IRI ixnModel,
+            final Dataset dataset) {
+        return mutableData.replace(id, session, new PersistableResource(id, ixnModel, dataset));
     }
 
     @Override
-    public Future<Boolean> delete(final IRI id, final IRI ixnModel, final Dataset dataset) {
-        return mutableData.delete(id, new PersistableResource(id, ixnModel, dataset));
+    public Future<Boolean> delete(final IRI id, final Session session, final IRI ixnModel,
+            final Dataset dataset) {
+        return mutableData.delete(id, session, new PersistableResource(id, ixnModel, dataset));
     }
 
     /**

--- a/trellis-api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -61,8 +61,8 @@ public abstract class JoiningResourceService implements ResourceService {
     }
 
     @Override
-    public Future<Boolean> add(final IRI id, final Dataset dataset) {
-        return immutableData.add(id, new PersistableResource(id, null, dataset));
+    public Future<Boolean> add(final IRI id, final Session session, final Dataset dataset) {
+        return immutableData.add(id, session, new PersistableResource(id, null, dataset));
     }
 
     @Override

--- a/trellis-api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -37,13 +37,13 @@ public abstract class JoiningResourceService implements ResourceService {
 
     private final ImmutableDataService<IRI, Resource> immutableData;
 
-    private final MutableDataService<IRI, Session, Resource> mutableData;
+    private final MutableDataService<IRI, Resource> mutableData;
 
     /**
      * @param mutableData service in which to persist mutable data
      * @param immutableData service in which to persist immutable data
      */
-    public JoiningResourceService(final MutableDataService<IRI, Session, Resource> mutableData,
+    public JoiningResourceService(final MutableDataService<IRI, Resource> mutableData,
                     final ImmutableDataService<IRI, Resource> immutableData) {
         this.immutableData = immutableData;
         this.mutableData = mutableData;

--- a/trellis-api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -21,10 +21,9 @@ import java.util.concurrent.Future;
  *
  * @author ajs6f
  * @param <T> the type of identifier used by this service
- * @param <U> the type of session context used by this service
- * @param <V> the type of resource that can be persisted by this service
+ * @param <U> the type of resource that can be persisted by this service
  */
-public interface MutableDataService<T, U, V> extends RetrievalService<T, V> {
+public interface MutableDataService<T, U> extends RetrievalService<T, U> {
 
     /**
      * @param identifier the identifier for the resource to persist
@@ -32,7 +31,7 @@ public interface MutableDataService<T, U, V> extends RetrievalService<T, V> {
      * @param resource a resource to persist
      * @return whether the resource was successfully persisted
      */
-    Future<Boolean> create(T identifier, U session, V resource);
+    Future<Boolean> create(T identifier, Session session, U resource);
 
     /**
      * @param identifier the identifier for the resource to persist
@@ -40,7 +39,7 @@ public interface MutableDataService<T, U, V> extends RetrievalService<T, V> {
      * @param resource a resource to persist
      * @return whether the resource was successfully persisted
      */
-    Future<Boolean> replace(T identifier, U session, V resource);
+    Future<Boolean> replace(T identifier, Session session, U resource);
 
     /**
      * @param identifier the identifier for the resource to delete
@@ -48,6 +47,6 @@ public interface MutableDataService<T, U, V> extends RetrievalService<T, V> {
      * @param resource a resource to delete
      * @return whether the resource was successfully deleted
      */
-    Future<Boolean> delete(T identifier, U session, V resource);
+    Future<Boolean> delete(T identifier, Session session, U resource);
 
 }

--- a/trellis-api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -18,32 +18,36 @@ import java.util.concurrent.Future;
 
 /**
  * A service that persists resources by <i>replacing</i> their records.
- * 
+ *
  * @author ajs6f
  * @param <T> the type of identifier used by this service
- * @param <U> the type of resource that can be persisted by this service
+ * @param <U> the type of session context used by this service
+ * @param <V> the type of resource that can be persisted by this service
  */
-public interface MutableDataService<T, U> extends RetrievalService<T, U> {
+public interface MutableDataService<T, U, V> extends RetrievalService<T, V> {
 
     /**
      * @param identifier the identifier for the resource to persist
+     * @param session the session context for this operation
      * @param resource a resource to persist
      * @return whether the resource was successfully persisted
      */
-    Future<Boolean> create(T identifier, U resource);
+    Future<Boolean> create(T identifier, U session, V resource);
 
     /**
      * @param identifier the identifier for the resource to persist
+     * @param session the session context for this operation
      * @param resource a resource to persist
      * @return whether the resource was successfully persisted
      */
-    Future<Boolean> replace(T identifier, U resource);
+    Future<Boolean> replace(T identifier, U session, V resource);
 
     /**
      * @param identifier the identifier for the resource to delete
+     * @param session the session context for this operation
      * @param resource a resource to delete
      * @return whether the resource was successfully deleted
      */
-    Future<Boolean> delete(T identifier, U resource);
+    Future<Boolean> delete(T identifier, U session, V resource);
 
 }

--- a/trellis-api/src/main/java/org/trellisldp/api/RDFUtils.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/RDFUtils.java
@@ -68,6 +68,11 @@ public final class RDFUtils {
     public static final String TRELLIS_SESSION_PREFIX = TRELLIS_SCHEME + "session/";
 
     /**
+     * The session property for a baseURL.
+     */
+    public static final String TRELLIS_SESSION_BASE_URL = "baseURL";
+
+    /**
      * Get the Commons RDF instance in use.
      *
      * @return the RDF instance

--- a/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -39,7 +39,7 @@ import org.apache.commons.rdf.api.Triple;
  *
  * @author acoburn
  */
-public interface ResourceService extends MutableDataService<IRI, Session, Resource>,
+public interface ResourceService extends MutableDataService<IRI, Resource>,
        ImmutableDataService<IRI, Resource> {
 
     @Override

--- a/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -43,16 +43,17 @@ public interface ResourceService extends MutableDataService<IRI, Resource>,
        ImmutableDataService<IRI, Resource> {
 
     @Override
-    default Future<Boolean> add(IRI identifier, Resource resource) {
-        return add(identifier, resource.dataset());
+    default Future<Boolean> add(IRI identifier, Session session, Resource resource) {
+        return add(identifier, session, resource.dataset());
     }
 
     /**
      * @param identifier the identifier under which to persist a dataset
+     * @param session the session context for this operation
      * @param dataset a dataset to persist
      * @return whether the resource was successfully persisted
      */
-    Future<Boolean> add(IRI identifier, Dataset dataset);
+    Future<Boolean> add(IRI identifier, Session session, Dataset dataset);
 
     @Override
     default Future<Boolean> create(IRI id, Session session, Resource res) {

--- a/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -39,7 +39,8 @@ import org.apache.commons.rdf.api.Triple;
  *
  * @author acoburn
  */
-public interface ResourceService extends MutableDataService<IRI, Resource>, ImmutableDataService<IRI, Resource> {
+public interface ResourceService extends MutableDataService<IRI, Session, Resource>,
+       ImmutableDataService<IRI, Resource> {
 
     @Override
     default Future<Boolean> add(IRI identifier, Resource resource) {
@@ -54,49 +55,52 @@ public interface ResourceService extends MutableDataService<IRI, Resource>, Immu
     Future<Boolean> add(IRI identifier, Dataset dataset);
 
     @Override
-    default Future<Boolean> create(IRI id, Resource res) {
-        return create(id, res.getInteractionModel(), res.dataset());
+    default Future<Boolean> create(IRI id, Session session, Resource res) {
+        return create(id, session, res.getInteractionModel(), res.dataset());
     }
 
     /**
      * Put a resource into the server.
      *
      * @param identifier the identifier for the new resource
+     * @param session the session context for this operation
      * @param ixnModel the LDP interaction model for this resource
      * @param dataset the dataset
      * @return whether the resource was added
      */
-    Future<Boolean> create(IRI identifier, IRI ixnModel, Dataset dataset);
+    Future<Boolean> create(IRI identifier, Session session, IRI ixnModel, Dataset dataset);
 
     @Override
-    default Future<Boolean> replace(IRI id, Resource res) {
-        return replace(id, res.getInteractionModel(), res.dataset());
+    default Future<Boolean> replace(IRI id, Session session, Resource res) {
+        return replace(id, session, res.getInteractionModel(), res.dataset());
     }
 
     /**
      * Replace a resource in the server.
      *
      * @param identifier the identifier for the new resource
+     * @param session the session context for this operation
      * @param ixnModel the LDP interaction model for this resource
      * @param dataset the dataset
      * @return whether the resource was replaced
      */
-    Future<Boolean> replace(IRI identifier, IRI ixnModel, Dataset dataset);
+    Future<Boolean> replace(IRI identifier, Session session, IRI ixnModel, Dataset dataset);
 
     @Override
-    default Future<Boolean> delete(IRI id, Resource res) {
-        return delete(id, res.getInteractionModel(), res.dataset());
+    default Future<Boolean> delete(IRI id, Session session, Resource res) {
+        return delete(id, session, res.getInteractionModel(), res.dataset());
     }
 
     /**
      * Delete a resource from the server.
      *
      * @param identifier the identifier for the new resource
+     * @param session the session context for this operation
      * @param ixnModel the new LDP interaction model for this resource
      * @param dataset the dataset
      * @return whether the resource was deleted
      */
-    Future<Boolean> delete(IRI identifier, IRI ixnModel, Dataset dataset);
+    Future<Boolean> delete(IRI identifier, Session session, IRI ixnModel, Dataset dataset);
 
     /**
      * Get the identifier for the structurally-logical container for the resource.

--- a/trellis-api/src/main/java/org/trellisldp/api/Session.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/Session.java
@@ -54,4 +54,20 @@ public interface Session {
      * @return the creation date
      */
     Instant getCreated();
+
+    /**
+     * Set a session-related property.
+     *
+     * @param key the key
+     * @param value the value
+     */
+    void setProperty(String key, String value);
+
+    /**
+     * Get a session-related property.
+     *
+     * @param key the key
+     * @return the value associated with the provided key, if one exists
+     */
+    Optional<String> getProperty(String key);
 }

--- a/trellis-api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/trellis-api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -85,7 +85,7 @@ public class JoiningResourceServiceTest {
                     implements ImmutableDataService<IRI, Resource> {
 
         @Override
-        public Future<Boolean> add(final IRI identifier, final Resource newRes) {
+        public Future<Boolean> add(final IRI identifier, final Session session, final Resource newRes) {
             resources.compute(identifier, (id, old) -> old == null ? newRes : new RetrievableResource(old, newRes));
             return isntBadId(identifier);
         }
@@ -226,7 +226,7 @@ public class JoiningResourceServiceTest {
         assertTrue(testable.create(testResourceId2, mockSession, testMutableResource).get(),
                 "Couldn't create a mutable resource!");
         final Resource testImmutableResource = new TestResource(testResourceId2, testImmutableQuad);
-        assertTrue(testable.add(testResourceId2, testImmutableResource).get(),
+        assertTrue(testable.add(testResourceId2, mockSession, testImmutableResource).get(),
                         "Couldn't create an immutable resource!");
 
         final Resource retrieved = testable.get(testResourceId2).orElseThrow(AssertionError::new);
@@ -255,9 +255,11 @@ public class JoiningResourceServiceTest {
 
         // store some data in mutable and immutable sides under the same resource ID
         final Resource testFirstResource = new TestResource(testResourceId3, testFirstQuad);
-        assertTrue(testable.add(testResourceId3, testFirstResource).get(), "Couldn't create an immutable resource!");
+        assertTrue(testable.add(testResourceId3, mockSession, testFirstResource).get(),
+                "Couldn't create an immutable resource!");
         final Resource testSecondResource = new TestResource(testResourceId3, testSecondQuad);
-        assertTrue(testable.add(testResourceId3, testSecondResource).get(), "Couldn't add to an immutable resource!");
+        assertTrue(testable.add(testResourceId3, mockSession, testSecondResource).get(),
+                "Couldn't add to an immutable resource!");
 
         final Resource retrieved = testable.get(testResourceId3).orElseThrow(AssertionError::new);
         assertEquals(testResourceId3, retrieved.getIdentifier(), "Resource was retrieved with wrong ID!");

--- a/trellis-api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/trellis-api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -94,7 +94,7 @@ public class JoiningResourceServiceTest {
     private final ImmutableDataService<IRI, Resource> testImmutableService = new TestableImmutableService();
 
     private static class TestableMutableDataService extends TestableRetrievalService
-                    implements MutableDataService<IRI, Session, Resource> {
+                    implements MutableDataService<IRI, Resource> {
 
         @Override
         public Future<Boolean> create(final IRI identifier, final Session session, final Resource resource) {
@@ -115,12 +115,12 @@ public class JoiningResourceServiceTest {
         }
     };
 
-    private final MutableDataService<IRI, Session, Resource> testMutableService = new TestableMutableDataService();
+    private final MutableDataService<IRI, Resource> testMutableService = new TestableMutableDataService();
 
     private static class TestableJoiningResourceService extends JoiningResourceService {
 
         public TestableJoiningResourceService(final ImmutableDataService<IRI, Resource> immutableData,
-                        final MutableDataService<IRI, Session, Resource> mutableData) {
+                        final MutableDataService<IRI, Resource> mutableData) {
             super(mutableData, immutableData);
         }
 

--- a/trellis-app/build.gradle
+++ b/trellis-app/build.gradle
@@ -41,13 +41,14 @@ dependencies {
 
     testCompile group: 'io.dropwizard', name: 'dropwizard-client', version: dropwizardVersion
     testCompile group: 'io.dropwizard', name: 'dropwizard-testing', version: dropwizardVersion
+    testCompile group: 'org.apache.activemq', name: 'activemq-broker', version: activeMqVersion
     testCompile group: 'org.apiguardian', name: 'apiguardian-api', version: apiguardianVersion
-    testImplementation group: 'org.apache.tamaya', name: 'tamaya-core', version: tamayaVersion
-    testImplementation group: 'org.awaitility', name: 'awaitility', version: awaitilityVersion
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
-    testImplementation group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitVersion
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+    testCompile group: 'org.apache.tamaya', name: 'tamaya-core', version: tamayaVersion
+    testCompile group: 'org.awaitility', name: 'awaitility', version: awaitilityVersion
+    testCompile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
+    testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: junitPlatformVersion
+    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitVersion
+    testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
 }
 
 artifacts {

--- a/trellis-app/src/test/java/org/trellisldp/app/TrellisEventTest.java
+++ b/trellis-app/src/test/java/org/trellisldp/app/TrellisEventTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.app;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static javax.ws.rs.client.Entity.entity;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.Link.fromUri;
+import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
+import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.slf4j.LoggerFactory.getLogger;
+import static org.trellisldp.http.domain.RdfMediaType.TEXT_TURTLE;
+import static org.trellisldp.vocabulary.RDF.type;
+
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.jena.JenaRDF;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.trellisldp.api.IOService;
+import org.trellisldp.api.NamespaceService;
+import org.trellisldp.app.config.TrellisConfiguration;
+import org.trellisldp.io.JenaIOService;
+import org.trellisldp.namespaces.NamespacesJsonContext;
+import org.trellisldp.vocabulary.AS;
+import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.PROV;
+import org.trellisldp.vocabulary.Trellis;
+
+/**
+ * Audit tests
+ *
+ * @author acoburn
+ */
+@RunWith(JUnitPlatform.class)
+public class TrellisEventTest implements MessageListener {
+
+    private static final Logger LOGGER = getLogger(TrellisEventTest.class);
+
+    private static final BrokerService BROKER = new BrokerService();
+
+    private static final DropwizardTestSupport<TrellisConfiguration> APP
+        = new DropwizardTestSupport<TrellisConfiguration>(TrellisApplication.class,
+                resourceFilePath("trellis-config.yml"),
+                config("notifications.type", "JMS"),
+                config("notifications.connectionString", "vm://localhost"),
+                config("binaries", resourceFilePath("data") + "/binaries"),
+                config("mementos", resourceFilePath("data") + "/mementos"),
+                config("namespaces", resourceFilePath("data/namespaces.json")));
+
+    private static Client client;
+    private static String baseURL;
+    private static String container;
+    private static String JWT_SECRET = "secret";
+
+    private static final NamespaceService nsSvc = new NamespacesJsonContext(resourceFilePath("data/namespaces.json"));
+    private static final IOService ioSvc = new JenaIOService(nsSvc);
+    private static final RDF rdf = new JenaRDF();
+
+    private final Set<Message> messages = new CopyOnWriteArraySet<>();
+    private MessageConsumer consumer;
+    private Connection connection;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        BROKER.addConnector("vm://localhost");
+        BROKER.setPersistent(false);
+        BROKER.start();
+        APP.before();
+        client = new JerseyClientBuilder(APP.getEnvironment()).build("test client");
+        client.property("jersey.config.client.connectTimeout", 5000);
+        client.property("jersey.config.client.readTimeout", 5000);
+        baseURL = "http://localhost:" + APP.getLocalPort() + "/";
+
+        final String jwt = "Bearer " + Jwts.builder().claim("webid", Trellis.AdministratorAgent.getIRIString())
+            .signWith(SignatureAlgorithm.HS512, JWT_SECRET.getBytes(UTF_8)).compact();
+
+        final String containerContent
+            = "PREFIX skos: <http://www.w3.org/2004/02/skos/core#> \n"
+            + "PREFIX dc: <http://purl.org/dc/terms/> \n\n"
+            + "<> skos:prefLabel \"Basic Container\"@eng ; "
+            + "   dc:description \"This is a simple Basic Container for testing.\"@eng .";
+
+        // POST an LDP-BC
+        try (final Response res = target().request()
+                .header(LINK, fromUri(LDP.BasicContainer.getIRIString()).rel("type").build())
+                .header(AUTHORIZATION, jwt).post(entity(containerContent, TEXT_TURTLE))) {
+            assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily());
+            container = res.getLocation().toString();
+        }
+
+    }
+
+    @BeforeEach
+    public void aquireConnection() throws Exception {
+        final ConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost");
+        connection = connectionFactory.createConnection();
+        connection.start();
+        final Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        final Destination destination = session.createQueue("trellis");
+        consumer = session.createConsumer(destination);
+        consumer.setMessageListener(this);
+    }
+
+    @AfterEach
+    public void releaseConnection() throws Exception {
+        consumer.setMessageListener(msg -> { });
+        consumer.close();
+        connection.close();
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        APP.after();
+        BROKER.stop();
+    }
+
+    @Test
+    @DisplayName("Test receiving a JMS creation message")
+    public void testReceiveCreateMessage() throws Exception {
+        final IRI obj = rdf.createIRI(container);
+        await().atMost(5, SECONDS).until(() -> messages.stream()
+                .map(this::convertToGraph)
+                .filter(g -> g.contains(obj, type, null))
+                .anyMatch(g -> g.contains(null, AS.object, obj)
+                        && g.contains(null, AS.actor, Trellis.AdministratorAgent)
+                        && g.contains(null, type, PROV.Activity)
+                        && g.contains(null, type, AS.Create)
+                        && g.contains(obj, type, LDP.BasicContainer)));
+    }
+
+    @Test
+    @DisplayName("Test receiving an update message")
+    public void testReceiveChildMessage() throws Exception {
+        final String resource;
+        final String agent = "https://people.apache.org/~acoburn/#i";
+
+        final String jwt = "Bearer " + Jwts.builder().claim("webid", agent)
+            .signWith(SignatureAlgorithm.HS512, JWT_SECRET.getBytes(UTF_8)).compact();
+
+        // POST an LDP-RS
+        try (final Response res = target(container).request()
+                .header(AUTHORIZATION, jwt).post(entity("", TEXT_TURTLE))) {
+            assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily());
+            resource = res.getLocation().toString();
+        }
+        final IRI obj = rdf.createIRI(resource);
+        final IRI parent = rdf.createIRI(container);
+
+        await().atMost(5, SECONDS).until(() -> messages.stream()
+                .map(this::convertToGraph)
+                .filter(g -> g.contains(obj, type, null))
+                .anyMatch(g -> g.contains(null, AS.object, obj)
+                        && g.contains(null, AS.actor, rdf.createIRI(agent))
+                        && g.contains(null, type, PROV.Activity)
+                        && g.contains(null, type, AS.Create)
+                        && g.contains(obj, type, LDP.RDFSource)));
+        await().atMost(5, SECONDS).until(() -> messages.stream()
+                .map(this::convertToGraph)
+                .filter(g -> g.contains(parent, type, null))
+                .anyMatch(g -> g.contains(null, AS.object, parent)
+                        && g.contains(null, AS.actor, rdf.createIRI(agent))
+                        && g.contains(null, type, PROV.Activity)
+                        && g.contains(null, type, AS.Update)
+                        && g.contains(parent, type, LDP.BasicContainer)));
+    }
+
+    @Test
+    @DisplayName("Test receiving a delete message")
+    public void testReceiveDeleteMessage() throws Exception {
+        final String resource;
+        final String agent1 = "https://madison.example.com/profile#me";
+
+        final String jwt1 = "Bearer " + Jwts.builder().claim("webid", agent1)
+            .signWith(SignatureAlgorithm.HS512, JWT_SECRET.getBytes(UTF_8)).compact();
+
+        // POST an LDP-RS
+        try (final Response res = target(container).request()
+                .header(AUTHORIZATION, jwt1).post(entity("", TEXT_TURTLE))) {
+            assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily());
+            resource = res.getLocation().toString();
+        }
+        final IRI obj = rdf.createIRI(resource);
+        final IRI parent = rdf.createIRI(container);
+
+        await().atMost(5, SECONDS).until(() -> messages.stream()
+                .map(this::convertToGraph)
+                .filter(g -> g.contains(obj, type, null))
+                .anyMatch(g -> g.contains(null, AS.object, obj)
+                        && g.contains(null, AS.actor, rdf.createIRI(agent1))
+                        && g.contains(null, type, PROV.Activity)
+                        && g.contains(null, type, AS.Create)
+                        && g.contains(obj, type, LDP.RDFSource)));
+        await().atMost(5, SECONDS).until(() -> messages.stream()
+                .map(this::convertToGraph)
+                .filter(g -> g.contains(parent, type, null))
+                .anyMatch(g -> g.contains(null, AS.object, parent)
+                        && g.contains(null, AS.actor, rdf.createIRI(agent1))
+                        && g.contains(null, type, PROV.Activity)
+                        && g.contains(null, type, AS.Update)
+                        && g.contains(parent, type, LDP.BasicContainer)));
+
+        final String agent2 = "https://pat.example.com/profile#me";
+        final String jwt2 = "Bearer " + Jwts.builder().claim("webid", agent2)
+            .signWith(SignatureAlgorithm.HS512, JWT_SECRET.getBytes(UTF_8)).compact();
+
+        // DELETE the LDP-RS
+        try (final Response res = target(resource).request().header(AUTHORIZATION, jwt2).delete()) {
+            assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily());
+        }
+
+        await().atMost(5, SECONDS).until(() -> messages.stream()
+                .map(this::convertToGraph)
+                .filter(g -> g.contains(obj, type, null))
+                .anyMatch(g -> g.contains(null, AS.object, obj)
+                        && g.contains(null, AS.actor, rdf.createIRI(agent2))
+                        && g.contains(null, type, PROV.Activity)
+                        && g.contains(null, type, AS.Delete)
+                        && g.contains(obj, type, LDP.Resource)));
+        await().atMost(5, SECONDS).until(() -> messages.stream()
+                .map(this::convertToGraph)
+                .filter(g -> g.contains(parent, type, null))
+                .anyMatch(g -> g.contains(null, AS.object, parent)
+                        && g.contains(null, AS.actor, rdf.createIRI(agent2))
+                        && g.contains(null, type, PROV.Activity)
+                        && g.contains(null, type, AS.Update)
+                        && g.contains(parent, type, LDP.BasicContainer)));
+    }
+
+
+    private Graph convertToGraph(final Message msg) {
+        final Graph g = rdf.createGraph();
+        try {
+            final String body = ((TextMessage) msg).getText();
+            final InputStream is = new ByteArrayInputStream(body.getBytes(UTF_8));
+            ioSvc.read(is, baseURL, JSONLD).forEach(g::add);
+        } catch (final Exception ex) {
+            LOGGER.error("Error processing message: {}", ex.getMessage());
+        }
+        return g;
+    }
+
+    @Override
+    public void onMessage(final Message message) {
+        messages.add(message);
+    }
+
+    private static WebTarget target() {
+        return target(baseURL);
+    }
+
+    private static WebTarget target(final String url) {
+        return client.target(url);
+    }
+}
+

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -102,7 +102,7 @@ public class DeleteHandler extends BaseLdpHandler {
                 try (final TrellisDataset auditDataset = TrellisDataset.createDataset()) {
                     audit.deletion(res.getIdentifier(), session).stream().map(skolemizeQuads(resourceService, baseUrl))
                                     .forEachOrdered(auditDataset::add);
-                    if (!resourceService.add(res.getIdentifier(), auditDataset.asDataset()).get()) {
+                    if (!resourceService.add(res.getIdentifier(), session, auditDataset.asDataset()).get()) {
                         LOGGER.error("Unable to delete resource at {}", res.getIdentifier());
                         LOGGER.error("because unable to write audit quads: \n{}",
                                         auditDataset.asDataset().stream().map(Quad::toString).collect(joining("\n")));

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/HttpSession.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/HttpSession.java
@@ -21,6 +21,8 @@ import static org.trellisldp.api.RDFUtils.getInstance;
 import static org.trellisldp.vocabulary.Trellis.AnonymousAgent;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.rdf.api.IRI;
@@ -35,6 +37,7 @@ public class HttpSession implements Session {
     private final IRI agent;
     private final IRI delegatedBy;
     private final Instant created;
+    private final Map<String, String> properties = new HashMap<>();
 
     /**
      * Create an HTTP-based session.
@@ -82,5 +85,15 @@ public class HttpSession implements Session {
     @Override
     public Instant getCreated() {
         return created;
+    }
+
+    @Override
+    public void setProperty(final String key, final String value) {
+        properties.put(key, value);
+    }
+
+    @Override
+    public Optional<String> getProperty(final String key) {
+        return ofNullable(properties.get(key));
     }
 }

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -198,7 +198,7 @@ public class PatchHandler extends BaseLdpHandler {
                 try (final TrellisDataset auditDataset = TrellisDataset.createDataset()) {
                     audit.update(res.getIdentifier(), session).stream().map(skolemizeQuads(resourceService, baseUrl))
                                     .forEachOrdered(auditDataset::add);
-                    if (!resourceService.add(res.getIdentifier(), auditDataset.asDataset()).get()) {
+                    if (!resourceService.add(res.getIdentifier(), session, auditDataset.asDataset()).get()) {
                         LOGGER.error("Unable to update resource at {}", res.getIdentifier());
                         LOGGER.error("because unable to write audit quads: \n{}",
                                         auditDataset.asDataset().stream().map(Quad::toString).collect(joining("\n")));

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -29,6 +29,7 @@ import static javax.ws.rs.core.Response.status;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.RDFUtils.TRELLIS_DATA_PREFIX;
+import static org.trellisldp.api.RDFUtils.TRELLIS_SESSION_BASE_URL;
 import static org.trellisldp.http.impl.RdfUtils.ldpResourceTypes;
 import static org.trellisldp.http.impl.RdfUtils.skolemizeQuads;
 import static org.trellisldp.vocabulary.Trellis.PreferServerManaged;
@@ -100,6 +101,7 @@ public class PostHandler extends ContentBearingHandler {
         final String identifier = baseUrl + req.getPath() + separator + id;
         final String contentType = req.getContentType();
         final Session session = ofNullable(req.getSession()).orElseGet(HttpSession::new);
+        session.setProperty(TRELLIS_SESSION_BASE_URL, baseUrl);
 
         LOGGER.info("Creating resource as {}", identifier);
 
@@ -121,7 +123,6 @@ public class PostHandler extends ContentBearingHandler {
 
         try (final TrellisDataset dataset = TrellisDataset.createDataset()) {
 
-            dataset.add(rdf.createQuad(null, internalId, DC.isPartOf, rdf.createIRI(baseUrl)));
             dataset.add(rdf.createQuad(PreferServerManaged, internalId, RDF.type, ldpType));
 
             // Add user-supplied data
@@ -152,7 +153,7 @@ public class PostHandler extends ContentBearingHandler {
                 checkConstraint(dataset, PreferUserManaged, ldpType, rdfSyntax.orElse(TURTLE));
             }
 
-            if (resourceService.create(internalId, ldpType, dataset.asDataset()).get()) {
+            if (resourceService.create(internalId, session, ldpType, dataset.asDataset()).get()) {
 
                 // Add Audit quads
                 try (final TrellisDataset auditDataset = TrellisDataset.createDataset()) {

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -159,7 +159,7 @@ public class PostHandler extends ContentBearingHandler {
                 try (final TrellisDataset auditDataset = TrellisDataset.createDataset()) {
                     audit.creation(internalId, session).stream().map(skolemizeQuads(resourceService, baseUrl))
                                     .forEachOrdered(auditDataset::add);
-                    if (!resourceService.add(internalId, auditDataset.asDataset()).get()) {
+                    if (!resourceService.add(internalId, session, auditDataset.asDataset()).get()) {
                         LOGGER.error("Using AuditService {}", audit);
                         LOGGER.error("Unable to act against resource at {}", internalId);
                         LOGGER.error("because unable to write audit quads: \n{}",

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -32,6 +32,7 @@ import static javax.ws.rs.core.Response.status;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.RDFUtils.TRELLIS_DATA_PREFIX;
+import static org.trellisldp.api.RDFUtils.TRELLIS_SESSION_BASE_URL;
 import static org.trellisldp.http.domain.HttpConstants.ACL;
 import static org.trellisldp.http.impl.RdfUtils.buildEtagHash;
 import static org.trellisldp.http.impl.RdfUtils.ldpResourceTypes;
@@ -150,6 +151,8 @@ public class PutHandler extends ContentBearingHandler {
         ofNullable(res).ifPresent(r -> checkResourceCache(identifier, r));
 
         final Session session = ofNullable(req.getSession()).orElseGet(HttpSession::new);
+        session.setProperty(TRELLIS_SESSION_BASE_URL, baseUrl);
+
         final Optional<RDFSyntax> rdfSyntax = ofNullable(req.getContentType()).flatMap(RDFSyntax::byMediaType)
             .filter(SUPPORTED_RDF_TYPES::contains);
 
@@ -187,9 +190,6 @@ public class PutHandler extends ContentBearingHandler {
 
             // Add LDP type
             dataset.add(rdf.createQuad(PreferServerManaged, internalId, RDF.type, ldpType));
-
-            // Add the base URL
-            dataset.add(rdf.createQuad(null, internalId, DC.isPartOf, rdf.createIRI(baseUrl)));
 
             // Add user-supplied data
             if (isBinaryRequest(ldpType, rdfSyntax)) {
@@ -237,7 +237,7 @@ public class PutHandler extends ContentBearingHandler {
                         .forEachOrdered(dataset::add);
                 }
             });
-            final Future<Boolean> success = createOrReplace(res, internalId, ldpType, dataset);
+            final Future<Boolean> success = createOrReplace(res, internalId, session, ldpType, dataset);
             if (success.get()) {
                 // Add audit quads
                 try (final TrellisDataset auditDataset = TrellisDataset.createDataset()) {
@@ -266,11 +266,11 @@ public class PutHandler extends ContentBearingHandler {
             .entity("Unable to persist data. Please consult the logs for more information");
     }
 
-    private Future<Boolean> createOrReplace(final Resource res, final IRI internalId, final IRI ldpType,
-            final TrellisDataset dataset) {
+    private Future<Boolean> createOrReplace(final Resource res, final IRI internalId, final Session session,
+            final IRI ldpType, final TrellisDataset dataset) {
         return nonNull(res)
-            ? resourceService.replace(internalId, ldpType, dataset.asDataset())
-            : resourceService.create(internalId, ldpType, dataset.asDataset());
+            ? resourceService.replace(internalId, session, ldpType, dataset.asDataset())
+            : resourceService.create(internalId, session, ldpType, dataset.asDataset());
     }
 
     private ResponseBuilder buildResponse(final Resource res, final String identifier) {

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -243,7 +243,7 @@ public class PutHandler extends ContentBearingHandler {
                 try (final TrellisDataset auditDataset = TrellisDataset.createDataset()) {
                     auditQuads(res, internalId, session).stream().map(skolemizeQuads(resourceService, baseUrl))
                                     .forEachOrdered(auditDataset::add);
-                    if (!resourceService.add(internalId, auditDataset.asDataset()).get()) {
+                    if (!resourceService.add(internalId, session, auditDataset.asDataset()).get()) {
                         LOGGER.error("Unable to place or replace resource at {}", internalId);
                         LOGGER.error("because unable to write audit quads: \n{}",
                                         auditDataset.asDataset().stream().map(Quad::toString).collect(joining("\n")));

--- a/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -370,7 +370,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
             return term;
         });
 
-        when(mockResourceService.add(any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.delete(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));

--- a/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -370,13 +370,13 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
             return term;
         });
 
-        when(mockResourceService.delete(any(IRI.class), any(IRI.class), any(Dataset.class)))
-            .thenReturn(completedFuture(true));
         when(mockResourceService.add(any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.delete(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
+            .thenReturn(completedFuture(true));
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
@@ -2031,8 +2031,8 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostInterrupted() throws Exception {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH)), eq(LDP.RDFSource),
-                    any(Dataset.class))).thenReturn(mockFuture);
+        when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH)),
+                    any(Session.class), eq(LDP.RDFSource), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(new InterruptedException("Expected InterruptedException")).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request().header("Slug", "child")
@@ -2044,8 +2044,8 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostFutureException() throws Exception {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH)), eq(LDP.RDFSource),
-                    any(Dataset.class))).thenReturn(mockFuture);
+        when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH)),
+                    any(Session.class), eq(LDP.RDFSource), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request().header("Slug", "child")
@@ -2252,8 +2252,8 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testPutInterrupted() throws Exception {
-        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), eq(LDP.Container),
-                    any(Dataset.class))).thenReturn(mockFuture);
+        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)),
+                    any(Session.class), eq(LDP.Container), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(new InterruptedException("Expected InterruptedException")).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request()
@@ -2265,8 +2265,8 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testPutFutureException() throws Exception {
-        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), eq(LDP.Container),
-                    any(Dataset.class))).thenReturn(mockFuture);
+        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)),
+                    any(Session.class), eq(LDP.Container), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request()
@@ -2552,8 +2552,8 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testDeleteInterrupted() throws Exception {
-        when(mockResourceService.delete(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), eq(LDP.Resource),
-                    any(Dataset.class))).thenReturn(mockFuture);
+        when(mockResourceService.delete(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)),
+                    any(Session.class), eq(LDP.Resource), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(new InterruptedException("Expected InterruptedException")).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request().delete();
@@ -2563,8 +2563,8 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testDeleteFutureException() throws Exception {
-        when(mockResourceService.delete(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), eq(LDP.Resource),
-                    any(Dataset.class))).thenReturn(mockFuture);
+        when(mockResourceService.delete(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)),
+                    any(Session.class), eq(LDP.Resource), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request().delete();
@@ -2728,8 +2728,8 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testPatchInterrupted() throws Exception {
-        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), eq(LDP.RDFSource),
-                    any(Dataset.class))).thenReturn(mockFuture);
+        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)),
+                    any(Session.class), eq(LDP.RDFSource), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(new InterruptedException("Expected InterruptedException")).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request()
@@ -2741,8 +2741,8 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testPatchFutureException() throws Exception {
-        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), eq(LDP.RDFSource),
-                    any(Dataset.class))).thenReturn(mockFuture);
+        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)),
+                    any(Session.class), eq(LDP.RDFSource), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request()
@@ -2910,7 +2910,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testMultipartPostError() {
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(false));
         final BinaryService.MultipartUpload upload = new BinaryService.MultipartUpload(BASE_URL, BINARY_PATH,
                 new HttpSession(), mockBinary);
@@ -2925,7 +2925,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testMultipartPostExecutionError() throws Exception {
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
         final BinaryService.MultipartUpload upload = new BinaryService.MultipartUpload(BASE_URL, BINARY_PATH,
@@ -2941,7 +2941,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testMultipartPostInterruptedExecutionError() throws Exception {
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(mockFuture);
         doThrow(InterruptedException.class).when(mockFuture).get();
         final BinaryService.MultipartUpload upload = new BinaryService.MultipartUpload(BASE_URL, BINARY_PATH,

--- a/trellis-http/src/test/java/org/trellisldp/http/CORSResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/CORSResourceTest.java
@@ -254,7 +254,7 @@ public class CORSResourceTest extends JerseyTest {
             });
 
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/trellis-http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
@@ -199,7 +199,7 @@ public class LdpForbiddenResourceTest extends JerseyTest {
 
 
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/trellis-http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
@@ -175,7 +175,7 @@ public class LdpUnauthorizedResourceTest extends JerseyTest {
             });
 
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -112,7 +112,8 @@ public class DeleteHandlerTest {
         when(mockResourceService.skolemize(eq(date))).thenReturn(date);
         when(mockResourceService.delete(eq(iri), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
-        when(mockResourceService.add(eq(iri), any(Dataset.class))).thenReturn(completedFuture(true));
+        when(mockResourceService.add(eq(iri), any(Session.class), any(Dataset.class)))
+            .thenReturn(completedFuture(true));
 
         when(mockLdpRequest.getSession()).thenReturn(mockSession);
         when(mockLdpRequest.getBaseUrl()).thenReturn(baseUrl);
@@ -149,7 +150,8 @@ public class DeleteHandlerTest {
         when(mockLdpRequest.getLink()).thenReturn(fromUri(LDP.BasicContainer.getIRIString()).rel("type").build());
         when(mockLdpRequest.getContentType()).thenReturn(TEXT_TURTLE);
         // will never store audit
-        when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(false));
+        when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
+            .thenReturn(completedFuture(false));
         final AuditService badAuditService = new DefaultAuditService() {};
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, badAuditService, null);
         final Response res = handler.deleteResource(mockResource).build();

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -110,7 +110,8 @@ public class DeleteHandlerTest {
         when(mockResourceService.skolemize(eq(PROV.Activity))).thenReturn(PROV.Activity);
         when(mockResourceService.skolemize(eq(Trellis.AnonymousAgent))).thenReturn(Trellis.AnonymousAgent);
         when(mockResourceService.skolemize(eq(date))).thenReturn(date);
-        when(mockResourceService.delete(eq(iri), any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(true));
+        when(mockResourceService.delete(eq(iri), any(Session.class), any(IRI.class), any(Dataset.class)))
+            .thenReturn(completedFuture(true));
         when(mockResourceService.add(eq(iri), any(Dataset.class))).thenReturn(completedFuture(true));
 
         when(mockLdpRequest.getSession()).thenReturn(mockSession);
@@ -157,7 +158,7 @@ public class DeleteHandlerTest {
 
     @Test
     public void testDeleteError() {
-        when(mockResourceService.delete(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.delete(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(false));
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService, baseUrl);
 

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/HttpSessionTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/HttpSessionTest.java
@@ -14,6 +14,7 @@
 package org.trellisldp.http.impl;
 
 import static java.time.Instant.now;
+import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -44,5 +45,13 @@ public class HttpSessionTest {
         assertNotEquals(session.getIdentifier(), session2.getIdentifier());
         assertFalse(session.getCreated().isBefore(time));
         assertFalse(session.getCreated().isAfter(session2.getCreated()));
+    }
+
+    @Test
+    public void testSessionProperties() {
+        final Session session = new HttpSession();
+        session.setProperty("foo", "bar");
+        assertFalse(session.getProperty("bar").isPresent());
+        assertEquals(of("bar"), session.getProperty("foo"));
     }
 }

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -124,7 +124,8 @@ public class PatchHandlerTest {
         when(mockResource.getModified()).thenReturn(time);
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockResource.getIdentifier()).thenReturn(identifier);
-        when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(true));
+        when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
+            .thenReturn(completedFuture(true));
         when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
@@ -162,7 +163,8 @@ public class PatchHandlerTest {
         when(mockLdpRequest.getLink()).thenReturn(fromUri(LDP.BasicContainer.getIRIString()).rel("type").build());
         when(mockLdpRequest.getContentType()).thenReturn(TEXT_TURTLE);
         // will never store audit
-        when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(false));
+        when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
+            .thenReturn(completedFuture(false));
         final AuditService badAuditService = new DefaultAuditService() {};
         final PatchHandler handler = new PatchHandler(mockLdpRequest, "", badAuditService, mockResourceService,
                         mockIoService, null);

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -78,6 +78,7 @@ import org.trellisldp.api.IOService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
+import org.trellisldp.api.Session;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.http.domain.LdpRequest;
 import org.trellisldp.http.domain.Prefer;
@@ -124,7 +125,7 @@ public class PatchHandlerTest {
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockResource.getIdentifier()).thenReturn(identifier);
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(true));
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
@@ -193,7 +194,7 @@ public class PatchHandlerTest {
 
         verify(mockIoService).update(any(Graph.class), eq(insert), eq(identifier.getIRIString()));
 
-        verify(mockResourceService).replace(eq(identifier), eq(LDP.RDFSource), any(Dataset.class));
+        verify(mockResourceService).replace(eq(identifier), any(Session.class), eq(LDP.RDFSource), any(Dataset.class));
     }
 
     @Test
@@ -265,8 +266,8 @@ public class PatchHandlerTest {
 
     @Test
     public void testError() {
-        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(IRI.class),
-                    any(Dataset.class))).thenReturn(completedFuture(false));
+        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(Session.class),
+                    any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(false));
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockAuditService,

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -72,6 +72,7 @@ import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.api.Session;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.http.domain.Digest;
 import org.trellisldp.http.domain.LdpRequest;
@@ -117,7 +118,7 @@ public class PostHandlerTest {
         initMocks(this);
         when(mockBinaryService.generateIdentifier()).thenReturn("file:" + randomUUID());
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(true));
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
@@ -281,7 +282,7 @@ public class PostHandlerTest {
 
         verify(mockIoService).read(any(InputStream.class), eq(baseUrl + path), eq(TURTLE));
 
-        verify(mockResourceService).create(eq(identifier), eq(LDP.RDFSource), any(Dataset.class));
+        verify(mockResourceService).create(eq(identifier), any(Session.class), eq(LDP.RDFSource), any(Dataset.class));
     }
 
     @Test
@@ -308,7 +309,8 @@ public class PostHandlerTest {
         assertTrue(iriArgument.getValue().getIRIString().startsWith("file:"));
         assertEquals("text/plain", metadataArgument.getValue().get(CONTENT_TYPE));
 
-        verify(mockResourceService).create(eq(identifier), eq(LDP.NonRDFSource), any(Dataset.class));
+        verify(mockResourceService).create(eq(identifier), any(Session.class), eq(LDP.NonRDFSource),
+                any(Dataset.class));
     }
 
     @Test
@@ -336,7 +338,8 @@ public class PostHandlerTest {
         assertTrue(iriArgument.getValue().getIRIString().startsWith("file:"));
         assertEquals("text/plain", metadataArgument.getValue().get(CONTENT_TYPE));
 
-        verify(mockResourceService).create(eq(identifier), eq(LDP.NonRDFSource), any(Dataset.class));
+        verify(mockResourceService).create(eq(identifier), any(Session.class), eq(LDP.NonRDFSource),
+                any(Dataset.class));
     }
 
     @Test
@@ -389,8 +392,8 @@ public class PostHandlerTest {
 
     @Test
     public void testError() throws IOException {
-        when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "newresource")), any(IRI.class),
-                    any(Dataset.class))).thenReturn(completedFuture(false));
+        when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "newresource")), any(Session.class),
+                    any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(false));
         when(mockRequest.getContentType()).thenReturn("text/turtle");
 
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -117,7 +117,8 @@ public class PostHandlerTest {
     public void setUp() {
         initMocks(this);
         when(mockBinaryService.generateIdentifier()).thenReturn("file:" + randomUUID());
-        when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(true));
+        when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
+            .thenReturn(completedFuture(true));
         when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
@@ -164,7 +165,8 @@ public class PostHandlerTest {
         when(mockRequest.getContentType()).thenReturn(TEXT_TURTLE);
         final File entity = new File(getClass().getResource("/simpleTriple.ttl").getFile());
         // will never store audit
-        when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(false));
+        when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
+            .thenReturn(completedFuture(false));
         final AuditService badAuditService = new DefaultAuditService() {};
         final PostHandler handler = new PostHandler(mockRequest, null, entity, mockResourceService,
                         mockIoService, mockBinaryService, null, badAuditService);

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -127,7 +127,8 @@ public class PutHandlerTest {
         when(mockResource.getModified()).thenReturn(time);
         when(mockBinaryService.generateIdentifier()).thenReturn("file:" + randomUUID());
 
-        when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(true));
+        when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
+            .thenReturn(completedFuture(true));
         when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
@@ -174,7 +175,8 @@ public class PutHandlerTest {
         when(mockLdpRequest.getContentType()).thenReturn(TEXT_TURTLE);
         final File entity = new File(getClass().getResource("/simpleTriple.ttl").getFile());
         // will never store audit
-        when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(false));
+        when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
+            .thenReturn(completedFuture(false));
         final AuditService badAuditService = new DefaultAuditService() {};
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, badAuditService,
                         mockIoService, mockBinaryService, null);

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -76,6 +76,7 @@ import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.api.Session;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.http.domain.LdpRequest;
 import org.trellisldp.vocabulary.LDP;
@@ -127,9 +128,9 @@ public class PutHandlerTest {
         when(mockBinaryService.generateIdentifier()).thenReturn("file:" + randomUUID());
 
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(true));
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class)))
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
@@ -370,8 +371,8 @@ public class PutHandlerTest {
     @Test
     public void testError() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
-        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(IRI.class),
-                    any(Dataset.class))).thenReturn(completedFuture(false));
+        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(Session.class),
+                    any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(false));
         when(mockLdpRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockLdpRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
 

--- a/trellis-triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/trellis-triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -261,23 +261,11 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
 
         eventService.ifPresent(svc -> {
             svc.emit(new SimpleEvent(getUrl(identifier, baseUrl),
-                        asList(session.getAgent()), asList(PROV.Activity, getIriFromOperationType(opType)),
+                        asList(session.getAgent()), asList(PROV.Activity, OperationType.asIRI(opType)),
                         targetTypes, inbox));
             getContainer(identifier).ifPresent(parent ->
                     emitEventsForAdjacentResources(svc, parent, session, opType, time));
         });
-    }
-
-    private IRI getIriFromOperationType(final OperationType opType) {
-        switch (opType) {
-            case DELETE:
-              return AS.Delete;
-            case CREATE:
-              return AS.Create;
-            case REPLACE:
-            default:
-              return AS.Update;
-        }
     }
 
     /**
@@ -423,7 +411,19 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     private enum OperationType {
-        DELETE, CREATE, REPLACE
+        DELETE, CREATE, REPLACE;
+
+        static IRI asIRI(final OperationType opType) {
+            switch (opType) {
+                case DELETE:
+                  return AS.Delete;
+                case CREATE:
+                  return AS.Create;
+                case REPLACE:
+                default:
+                  return AS.Update;
+            }
+        }
     }
 
     /**

--- a/trellis-triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/trellis-triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -660,7 +660,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public Future<Boolean> add(final IRI id, final Dataset dataset) {
+    public Future<Boolean> add(final IRI id, final Session session, final Dataset dataset) {
         return supplyAsync(() -> {
             final IRI graphName = rdf.createIRI(id.getIRIString() + "?ext=audit");
             try (final Dataset data = rdf.createDataset()) {

--- a/trellis-triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/trellis-triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -24,12 +24,15 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.builder;
+import static java.util.stream.Stream.empty;
 import static org.apache.commons.lang3.Range.between;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.system.Txn.executeWrite;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.RDFUtils.TRELLIS_DATA_PREFIX;
+import static org.trellisldp.api.RDFUtils.TRELLIS_SESSION_BASE_URL;
 import static org.trellisldp.triplestore.TriplestoreUtils.OBJECT;
 import static org.trellisldp.triplestore.TriplestoreUtils.PREDICATE;
 import static org.trellisldp.triplestore.TriplestoreUtils.SUBJECT;
@@ -48,12 +51,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Future;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.Range;
+import org.apache.commons.rdf.api.BlankNodeOrIRI;
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Literal;
@@ -87,12 +92,14 @@ import org.trellisldp.api.IdentifierService;
 import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.api.Session;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.vocabulary.ACL;
 import org.trellisldp.vocabulary.AS;
 import org.trellisldp.vocabulary.DC;
 import org.trellisldp.vocabulary.FOAF;
 import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.PROV;
 import org.trellisldp.vocabulary.RDF;
 import org.trellisldp.vocabulary.Trellis;
 import org.trellisldp.vocabulary.XSD;
@@ -143,30 +150,33 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public Future<Boolean> create(final IRI identifier, final IRI ixnModel, final Dataset dataset) {
+    public Future<Boolean> create(final IRI identifier, final Session session, final IRI ixnModel,
+            final Dataset dataset) {
         LOGGER.debug("Creating: {}", identifier);
-        return supplyAsync(() -> createOrReplace(identifier, ixnModel, dataset, OperationType.CREATE));
+        return supplyAsync(() -> createOrReplace(identifier, session, ixnModel, dataset, OperationType.CREATE));
     }
 
     @Override
-    public Future<Boolean> delete(final IRI identifier, final IRI ixnModel, final Dataset dataset) {
+    public Future<Boolean> delete(final IRI identifier, final Session session, final IRI ixnModel,
+            final Dataset dataset) {
         LOGGER.debug("Deleting: {}", identifier);
         return supplyAsync(() -> {
             final Instant eventTime = now();
             dataset.add(PreferServerManaged, identifier, DC.type, DeletedResource);
             dataset.add(PreferServerManaged, identifier, RDF.type, LDP.Resource);
-            return storeAndNotify(identifier, dataset, eventTime, OperationType.DELETE);
+            return storeAndNotify(identifier, session, dataset, eventTime, OperationType.DELETE);
         });
     }
 
     @Override
-    public Future<Boolean> replace(final IRI identifier, final IRI ixnModel, final Dataset dataset) {
+    public Future<Boolean> replace(final IRI identifier, final Session session, final IRI ixnModel,
+            final Dataset dataset) {
         LOGGER.debug("Updating: {}", identifier);
-        return supplyAsync(() -> createOrReplace(identifier, ixnModel, dataset, OperationType.REPLACE));
+        return supplyAsync(() -> createOrReplace(identifier, session, ixnModel, dataset, OperationType.REPLACE));
     }
 
-    private Boolean createOrReplace(final IRI identifier, final IRI ixnModel, final Dataset dataset,
-            final OperationType type) {
+    private Boolean createOrReplace(final IRI identifier, final Session session, final IRI ixnModel,
+            final Dataset dataset, final OperationType type) {
         final Instant eventTime = now();
 
         // Set the LDP type
@@ -192,11 +202,11 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
         }
         // Set the parent relationship
         getContainer(identifier).ifPresent(parent -> dataset.add(PreferServerManaged, identifier, DC.isPartOf, parent));
-        return storeAndNotify(identifier, dataset, eventTime, type);
+        return storeAndNotify(identifier, session, dataset, eventTime, type);
     }
 
-    private Boolean storeAndNotify(final IRI identifier, final Dataset dataset, final Instant eventTime,
-                    final OperationType type) {
+    private Boolean storeAndNotify(final IRI identifier, final Session session, final Dataset dataset,
+            final Instant eventTime, final OperationType type) {
         final Literal time = rdf.createLiteral(eventTime.toString(), XSD.dateTime);
         try {
             rdfConnection.update(buildUpdateRequest(identifier, time, dataset, type));
@@ -204,7 +214,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
                 mementoService.ifPresent(svc -> get(identifier).ifPresent(res ->
                             svc.put(identifier, eventTime, res.stream())));
             }
-            emitEvents(identifier, time, dataset);
+            emitEvents(identifier, session, type, time, dataset);
             return true;
         } catch (final Exception ex) {
             LOGGER.error("Could not update data: {}", ex.getMessage());
@@ -231,18 +241,43 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
         return unmodifiableList(versions);
     }
 
+    private static final Predicate<BlankNodeOrIRI> isUserGraph = Trellis.PreferUserManaged::equals;
+    private static final Predicate<BlankNodeOrIRI> isServerGraph = Trellis.PreferServerManaged::equals;
 
-    private void emitEvents(final IRI identifier, final Literal time, final Dataset dataset) {
+    private void emitEvents(final IRI identifier, final Session session, final OperationType opType,
+            final Literal time, final Dataset dataset) {
 
         // Get the base URL
-        final Optional<String> baseUrl = dataset.getGraph().stream(identifier, DC.isPartOf, null)
-            .map(Triple::getObject).map(term -> ((IRI) term).getIRIString()).findAny();
+        final Optional<String> baseUrl = session.getProperty(TRELLIS_SESSION_BASE_URL);
+        final IRI inbox = dataset.getGraph(Trellis.PreferUserManaged)
+            .flatMap(graph -> graph.stream(null, LDP.inbox, null).map(Triple::getObject)
+                    .filter(term -> term instanceof IRI).map(term -> (IRI) term).findFirst())
+            .orElse(null);
+        final List<IRI> targetTypes = dataset.stream()
+            .filter(quad -> quad.getGraphName().filter(isUserGraph.or(isServerGraph)).isPresent())
+            .filter(quad -> quad.getPredicate().equals(RDF.type))
+            .flatMap(quad -> quad.getObject() instanceof IRI ? Stream.of((IRI) quad.getObject()) : empty())
+            .distinct().collect(toList());
 
         eventService.ifPresent(svc -> {
-            svc.emit(new SimpleEvent(getUrl(identifier, baseUrl), dataset));
+            svc.emit(new SimpleEvent(getUrl(identifier, baseUrl),
+                        asList(session.getAgent()), asList(PROV.Activity, getIriFromOperationType(opType)),
+                        targetTypes, inbox));
             getContainer(identifier).ifPresent(parent ->
-                    emitEventsForAdjacentResources(svc, parent, time, baseUrl, dataset));
+                    emitEventsForAdjacentResources(svc, parent, session, opType, time));
         });
+    }
+
+    private IRI getIriFromOperationType(final OperationType opType) {
+        switch (opType) {
+            case DELETE:
+              return AS.Delete;
+            case CREATE:
+              return AS.Create;
+            case REPLACE:
+            default:
+              return AS.Update;
+        }
     }
 
     /**
@@ -261,11 +296,14 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
      *   }
      * }
      * </code></pre></p>
+     *
+     * <p>Note: this query does not retrieve the user-managed rdf:type values
+     * nor does it retrieve any ldp:inbox value.
      */
-    private void emitEventsForAdjacentResources(final EventService svc, final IRI parent,
-            final Literal time, final Optional<String> baseUrl, final Dataset dataset) {
-        final Boolean isDelete = dataset.contains(of(PreferAudit), null, RDF.type, AS.Delete);
-        final Boolean isCreate = dataset.contains(of(PreferAudit), null, RDF.type, AS.Create);
+    private void emitEventsForAdjacentResources(final EventService svc, final IRI parent, final Session session,
+            final OperationType opType, final Literal time) {
+        final Boolean isDelete = opType == OperationType.DELETE;
+        final Boolean isCreate = opType == OperationType.CREATE;
         final Var memberDate = Var.alloc("memberDate");
 
         final Query q = new Query();
@@ -295,14 +333,19 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
                 .map(RDFNode::asNode).map(rdf::asRDFTerm).filter(time::equals).isPresent();
             if (isCreate || isDelete) {
                 if (type.getIRIString().endsWith("Container")) {
-                    svc.emit(new SimpleEvent(getUrl(parent, baseUrl), dataset));
+                    svc.emit(new SimpleEvent(getUrl(parent, session.getProperty(TRELLIS_SESSION_BASE_URL)),
+                                    asList(session.getAgent()), asList(PROV.Activity, AS.Update), asList(type), null));
                 }
                 if (LDP.DirectContainer.equals(type) && memberIsModified) {
-                    member.ifPresent(m -> svc.emit(new SimpleEvent(getUrl(m, baseUrl), dataset)));
+                    member.ifPresent(m ->
+                            svc.emit(new SimpleEvent(getUrl(m, session.getProperty(TRELLIS_SESSION_BASE_URL)),
+                                        asList(session.getAgent()), asList(PROV.Activity, AS.Update),
+                                        asList(type), null)));
                 }
             }
             if (LDP.IndirectContainer.equals(type)) {
-                member.ifPresent(m -> svc.emit(new SimpleEvent(getUrl(m, baseUrl), dataset)));
+                member.ifPresent(m -> svc.emit(new SimpleEvent(getUrl(m, session.getProperty(TRELLIS_SESSION_BASE_URL)),
+                                asList(session.getAgent()), asList(PROV.Activity, AS.Update), asList(type), null)));
             }
         });
     }

--- a/trellis-triplestore/src/test/java/org/trellisldp/triplestore/SimpleSession.java
+++ b/trellis-triplestore/src/test/java/org/trellisldp/triplestore/SimpleSession.java
@@ -14,11 +14,14 @@
 package org.trellisldp.triplestore;
 
 import static java.time.Instant.now;
+import static java.util.Optional.ofNullable;
 import static java.util.UUID.randomUUID;
 import static org.trellisldp.api.RDFUtils.TRELLIS_SESSION_PREFIX;
 import static org.trellisldp.api.RDFUtils.getInstance;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.rdf.api.IRI;
@@ -32,6 +35,7 @@ class SimpleSession implements Session {
     private final Instant created = now();
     private final IRI identifier = getInstance().createIRI(TRELLIS_SESSION_PREFIX + randomUUID());
     private final IRI agent;
+    private final Map<String, String> properties = new HashMap<>();
 
     public SimpleSession(final IRI agent) {
         this.agent = agent;
@@ -55,5 +59,15 @@ class SimpleSession implements Session {
     @Override
     public Instant getCreated() {
         return created;
+    }
+
+    @Override
+    public Optional<String> getProperty(final String key) {
+        return ofNullable(properties.get(key));
+    }
+
+    @Override
+    public void setProperty(final String key, final String value) {
+        properties.put(key, value);
     }
 }

--- a/trellis-triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreEventTest.java
+++ b/trellis-triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreEventTest.java
@@ -14,17 +14,17 @@
 package org.trellisldp.triplestore;
 
 import static java.time.Instant.now;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.trellisldp.vocabulary.RDF.type;
 
 import java.time.Instant;
 import java.util.Collection;
 
-import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.jena.JenaRDF;
@@ -64,17 +64,10 @@ public class TriplestoreEventTest {
     @Test
     public void testSimpleEvent() {
         final IRI resource = rdf.createIRI(identifier);
-        final Dataset dataset = rdf.createDataset();
-        dataset.add(rdf.createQuad(Trellis.PreferUserManaged, resource, LDP.inbox, inbox));
-        dataset.add(rdf.createQuad(Trellis.PreferAudit, rdf.createBlankNode(), PROV.wasAssociatedWith, agent));
-        dataset.add(rdf.createQuad(Trellis.PreferServerManaged, resource, type, LDP.RDFSource));
-        dataset.add(rdf.createQuad(Trellis.PreferUserManaged, resource, type, SKOS.Concept));
-        dataset.add(rdf.createQuad(Trellis.PreferAudit, rdf.createBlankNode(), type, PROV.Activity));
-        dataset.add(rdf.createQuad(Trellis.PreferAudit, rdf.createBlankNode(), type, AS.Create));
-
         final Instant time = now();
 
-        final Event event = new SimpleEvent(identifier, dataset);
+        final Event event = new SimpleEvent(identifier, asList(agent),
+                asList(PROV.Activity, AS.Create), asList(LDP.RDFSource, SKOS.Concept), inbox);
         assertFalse(time.isAfter(event.getCreated()));
         assertTrue(event.getIdentifier().getIRIString().startsWith("urn:uuid:"));
         assertEquals(of(resource), event.getTarget());
@@ -94,9 +87,8 @@ public class TriplestoreEventTest {
     @Test
     public void testEmptyEvent() {
         final IRI resource = rdf.createIRI(identifier);
-        final Dataset dataset = rdf.createDataset();
 
-        final Event event = new SimpleEvent(identifier, dataset);
+        final Event event = new SimpleEvent(identifier, emptyList(), emptyList(), emptyList(), null);
         assertEquals(of(resource), event.getTarget());
         assertFalse(event.getInbox().isPresent());
         assertTrue(event.getAgents().isEmpty());


### PR DESCRIPTION
Resolves #56 and #57

This updates the Trellis API ResourceService methods
by adding session-related data in a distinct type.

This fixes errors in the event stream where event type and agent
data were missing from messages.