### PR TITLE
Factoring apart component builds for easier overriding

### DIFF
--- a/trellis-app/src/main/java/org/trellisldp/app/TrellisApplication.java
+++ b/trellis-app/src/main/java/org/trellisldp/app/TrellisApplication.java
@@ -74,7 +74,7 @@ public class TrellisApplication extends Application<TrellisConfiguration> {
 
     private MementoService mementoService;
 
-    private TriplestoreResourceService resourceService;
+    private ResourceService resourceService;
 
     private NamespaceService namespaceService;
 
@@ -157,7 +157,7 @@ public class TrellisApplication extends Application<TrellisConfiguration> {
 
     protected AuditService buildAuditService() {
         return resourceService != null && resourceService instanceof AuditService
-                        ? resourceService
+                        ? (AuditService) resourceService
                         : new DefaultAuditService();
     }
 

--- a/trellis-app/src/main/java/org/trellisldp/app/TrellisApplication.java
+++ b/trellis-app/src/main/java/org/trellisldp/app/TrellisApplication.java
@@ -22,12 +22,12 @@ import static org.trellisldp.app.TrellisUtils.getNotificationService;
 import static org.trellisldp.app.TrellisUtils.getRDFConnection;
 import static org.trellisldp.app.TrellisUtils.getWebacConfiguration;
 
-import javax.jms.JMSException;
-
 import io.dropwizard.Application;
 import io.dropwizard.auth.chained.ChainedAuthFilter;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+
+import javax.jms.JMSException;
 
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.trellisldp.agent.SimpleAgent;

--- a/trellis-app/src/main/java/org/trellisldp/app/TrellisApplication.java
+++ b/trellis-app/src/main/java/org/trellisldp/app/TrellisApplication.java
@@ -168,25 +168,25 @@ public class TrellisApplication extends Application<TrellisConfiguration> {
         return new TrellisCache<>(cache);
     }
 
-    protected JenaIOService buildIoService(final NamespaceService namespaceService,
+    protected IOService buildIoService(final NamespaceService namespaceService,
                     final CacheService<String, String> profileCache) {
         return new JenaIOService(namespaceService, profileCache, TrellisUtils.getAssetConfiguration(config));
     }
 
-    protected FileBinaryService buildBinaryService(final IdentifierService idService) {
+    protected BinaryService buildBinaryService(final IdentifierService idService) {
         return new FileBinaryService(idService, config.getBinaries(), config.getBinaryHierarchyLevels(),
                         config.getBinaryHierarchyLength());
     }
 
-    protected NamespacesJsonContext buildNamespaceService() {
+    protected NamespaceService buildNamespaceService() {
         return new NamespacesJsonContext(config.getNamespaces());
     }
 
-    protected FileMementoService buildMementoService() {
+    protected MementoService buildMementoService() {
         return new FileMementoService(config.getMementos());
     }
 
-    protected UUIDGenerator buildIdService() {
+    protected IdentifierService buildIdService() {
         return new UUIDGenerator();
     }
 


### PR DESCRIPTION
This commit introduces `protected` methods for most of the parts of a running Trellis instance, in order to make subclassing `TrellisApplication` less filled with cut-and-paste.