### PR TITLE
Update JDK 10 download URL

### DIFF
--- a/buildtools/src/install/install-jdk-10.sh
+++ b/buildtools/src/install/install-jdk-10.sh
@@ -5,14 +5,10 @@
 set -e
 
 JDK_FEATURE=10
-TMP=$(curl -L jdk.java.net/${JDK_FEATURE})              # extract most recent "JDK_BUILD" number from web page source
-TMP="${TMP#*Most recent build: jdk-${JDK_FEATURE}+}"    # remove everything before the number
-TMP="${TMP%%<*}"                                        # remove everything after the number
-JDK_BUILD="$(echo -e "${TMP}" | tr -d '[:space:]')"     # remove all whitespace
-JDK_ARCHIVE=openjdk-${JDK_FEATURE}+${JDK_BUILD}_linux-x64_bin.tar.gz
+JDK_ARCHIVE=openjdk-${JDK_FEATURE}_linux-x64_bin.tar.gz
 
 cd ~
-wget https://download.java.net/java/jdk${JDK_FEATURE}/archive/${JDK_BUILD}/GPL/${JDK_ARCHIVE}
+wget https://download.java.net/java/GA/jdk{$JDK_FEATURE}/{$JDK_FEATURE}/binaries/${JDK_ARCHIVE}
 tar -xzf ${JDK_ARCHIVE}
 export JAVA_HOME=~/jdk-${JDK_FEATURE}
 export PATH=${JAVA_HOME}/bin:$PATH

--- a/buildtools/src/install/install-jdk-10.sh
+++ b/buildtools/src/install/install-jdk-10.sh
@@ -8,7 +8,7 @@ JDK_FEATURE=10
 JDK_ARCHIVE=openjdk-${JDK_FEATURE}_linux-x64_bin.tar.gz
 
 cd ~
-wget https://download.java.net/java/GA/jdk{$JDK_FEATURE}/{$JDK_FEATURE}/binaries/${JDK_ARCHIVE}
+wget https://download.java.net/java/GA/jdk${JDK_FEATURE}/${JDK_FEATURE}/binaries/${JDK_ARCHIVE}
 tar -xzf ${JDK_ARCHIVE}
 export JAVA_HOME=~/jdk-${JDK_FEATURE}
 export PATH=${JAVA_HOME}/bin:$PATH


### PR DESCRIPTION
JDK 10 is now GA and the download URL has changed.

Eventually travis will make this even easier....