### PR TITLE
Making environment and config protected for use by subclasses

### DIFF
--- a/trellis-app/src/main/java/org/trellisldp/app/TrellisApplication.java
+++ b/trellis-app/src/main/java/org/trellisldp/app/TrellisApplication.java
@@ -64,9 +64,9 @@ import org.trellisldp.webac.WebACService;
  */
 public class TrellisApplication extends Application<TrellisConfiguration> {
 
-    private Environment environment;
+    protected Environment environment;
 
-    private TrellisConfiguration config;
+    protected TrellisConfiguration config;
 
     private EventService notificationService;
 


### PR DESCRIPTION
The whole point of my last PR was to make it easier to subclass `TrellisApplication`, but I forgot to make config available to subclasses!