### PR TITLE
Enable jacoco for JDK 10 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ matrix:
       install: . ./buildtools/src/install/install-jdk-10.sh
 
 after_success:
-    - sh ./buildtools/src/install/report.sh
+    - ./gradlew jacocoRootReport coveralls sonarqube

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ allprojects {
     apply plugin: 'jacoco'
 
     ext {
-        jacocoVersion = '0.8.0'
+        jacocoVersion = '0.8.1'
         checkstyleVersion = '8.8'
     }
 
@@ -117,11 +117,6 @@ subprojects {
 
     test {
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-
-        jacoco {
-            // TODO - re-enable Jacoco for JDK 10 once support catches up
-            enabled = ! JavaVersion.current().isJava10Compatible()
-        }
     }
 
     checkstyle {

--- a/buildtools/src/install/report.sh
+++ b/buildtools/src/install/report.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-if [ "$JDK_RELEASE" != "JDK 10" ]; then
-    ./gradlew jacocoRootReport coveralls sonarqube
-fi


### PR DESCRIPTION
JaCoCo 0.8.1 has been released with support for jdk10 builds, so now the jacoco plugin can be enabled for jdk10 builds.