### PR TITLE
enable tests on NoopNamespaceService

### DIFF
--- a/trellis-api/src/test/java/org/trellisldp/api/NoopNamespaceServiceTest.java
+++ b/trellis-api/src/test/java/org/trellisldp/api/NoopNamespaceServiceTest.java
@@ -18,7 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
 
+@RunWith(JUnitPlatform.class)
 public class NoopNamespaceServiceTest {
 
     @Test


### PR DESCRIPTION
The tests for `NoopNamespaceService` are not currently enabled. This change enables them.