### PR TITLE
Add ResourceService::supportedInteractionModels method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,12 +85,13 @@ subprojects {
         jaxbVersion = '2.3.0'
 
         /* Transitive dependencies (for Karaf provisioning) */
-        guavaVersion = '20.0' // via mustache 0.9.5
+        transitiveGuavaVersion = '20.0' // via mustache 0.9.5
 
         /* Testing */
         apiguardianVersion = '1.0.0'
         awaitilityVersion = '3.1.0'
         commonsTextVersion = '1.3'
+        guavaVersion = '24.1-jre'
         jerseyVersion = '2.25.1'
         jsonVersion = '1.1.2'
         junitVersion = '5.1.0'

--- a/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/trellis-api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
@@ -234,6 +235,13 @@ public interface ResourceService extends MutableDataService<Resource>, Immutable
             .flatMap(resource -> resource.stream(graphNames).map(q ->
                 getInstance().createQuad(resource.getIdentifier(), q.getSubject(), q.getPredicate(), q.getObject())));
     }
+
+    /**
+     * Return a collection of interaction models supported by this Resource Service.
+     *
+     * @return a set of supported interaction models
+     */
+    Set<IRI> supportedInteractionModels();
 
     /**
      * An identifier generator.

--- a/trellis-api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/trellis-api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -15,6 +15,7 @@
 package org.trellisldp.api;
 
 import static java.time.Instant.now;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.synchronizedMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -149,6 +151,10 @@ public class JoiningResourceServiceTest {
             return "new-identifier";
         }
 
+        @Override
+        public Set<IRI> supportedInteractionModels() {
+            return emptySet();
+        }
     }
 
     private final ResourceService testable = new TestableJoiningResourceService(testImmutableService,

--- a/trellis-http/build.gradle
+++ b/trellis-http/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
+    testImplementation group: 'com.google.guava', name: 'guava', version: guavaVersion
     testImplementation group: 'org.apache.commons', name: 'commons-text', version: commonsTextVersion
     testImplementation group: 'org.apache.commons', name: 'commons-rdf-simple', version: commonsRdfVersion
     testImplementation group: 'org.apache.tamaya', name: 'tamaya-core', version: tamayaVersion

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -143,10 +143,10 @@ public class BaseLdpHandler {
     protected void checkInteractionModel(final IRI interactionModel) {
         if (!resourceService.supportedInteractionModels().contains(interactionModel)) {
             LOGGER.error("Interaction model not supported: ", interactionModel);
-            throw new BadRequestException("Invalid interaction model provided: " + interactionModel,
+            throw new BadRequestException("Unsupported interaction model provided: " + interactionModel,
                     status(BAD_REQUEST)
-                        .link(Trellis.InvalidInteractionModel.getIRIString(), LDP.constrainedBy.getIRIString())
-                        .entity("Invalid interaction model provided").type(TEXT_PLAIN_TYPE).build());
+                        .link(Trellis.UnsupportedInteractionModel.getIRIString(), LDP.constrainedBy.getIRIString())
+                        .entity("Unsupported interaction model provided").type(TEXT_PLAIN_TYPE).build());
         }
     }
 

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -17,11 +17,14 @@ import static java.util.Arrays.asList;
 import static java.util.Date.from;
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.status;
 import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
 import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
+import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.RDFUtils.getInstance;
 
 import java.time.Instant;
@@ -29,24 +32,31 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
+import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.api.RDFSyntax;
+import org.slf4j.Logger;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.http.domain.LdpRequest;
+import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.Trellis;
 
 /**
  * @author acoburn
  */
 public class BaseLdpHandler {
+
+    private static final Logger LOGGER = getLogger(BaseLdpHandler.class);
 
     protected static final RDF rdf = getInstance();
 
@@ -122,4 +132,22 @@ public class BaseLdpHandler {
             throw new WebApplicationException(builder.build());
         }
     }
+
+    /**
+     * Check that the given interaction model is supported by the
+     * underlying persistence layer.
+     *
+     * @param interactionModel the interaction model
+     * @throws BadRequestException if the interaction model is not supported
+     */
+    protected void checkInteractionModel(final IRI interactionModel) {
+        if (!resourceService.supportedInteractionModels().contains(interactionModel)) {
+            LOGGER.error("Interaction model not supported: ", interactionModel);
+            throw new BadRequestException("Invalid interaction model provided: " + interactionModel,
+                    status(BAD_REQUEST)
+                        .link(Trellis.InvalidInteractionModel.getIRIString(), LDP.constrainedBy.getIRIString())
+                        .entity("Invalid interaction model provided").type(TEXT_PLAIN_TYPE).build());
+        }
+    }
+
 }

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -84,6 +84,9 @@ public class DeleteHandler extends BaseLdpHandler {
         final EntityTag etag = new EntityTag(buildEtagHash(identifier, res.getModified()));
         checkCache(req.getRequest(), res.getModified(), etag);
 
+        // Check that the persistence layer supports LDP-R
+        checkInteractionModel(LDP.Resource);
+
         LOGGER.debug("Deleting {}", identifier);
 
         try (final TrellisDataset dataset = TrellisDataset.createDataset()) {

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -145,6 +145,9 @@ public class PatchHandler extends BaseLdpHandler {
         final EntityTag etag = new EntityTag(buildEtagHash(identifier, res.getModified()));
         checkCache(req.getRequest(), res.getModified(), etag);
 
+        // Check that the persistence layer supports LDP-RS
+        checkInteractionModel(LDP.RDFSource);
+
         LOGGER.debug("Updating {} via PATCH", identifier);
 
         final IRI graphName = ACL.equals(req.getExt()) ? PreferAccessControl : PreferUserManaged;

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -116,6 +116,9 @@ public class PostHandler extends ContentBearingHandler {
             .filter(l -> l.startsWith(LDP.URI)).map(rdf::createIRI)
             .filter(l -> !LDP.Resource.equals(l)).orElse(defaultType);
 
+        // Verify that the persistence layer supports the specified IXN model
+        checkInteractionModel(ldpType);
+
         if (ldpType.equals(LDP.NonRDFSource) && rdfSyntax.isPresent()) {
             throw new BadRequestException("Cannot save a NonRDFSource with RDF syntax");
         }

--- a/trellis-http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/trellis-http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -176,6 +176,9 @@ public class PutHandler extends ContentBearingHandler {
             .filter(l -> l.startsWith(LDP.URI)).map(rdf::createIRI).filter(l -> !LDP.Resource.equals(l))
             .orElse(defaultType);
 
+        // Verify that the persistence layer supports the given interaction model
+        checkInteractionModel(ldpType);
+
         LOGGER.debug("Using LDP Type: {}", ldpType);
         // It is not possible to change the LDP type to a type that is not a subclass
         checkInteractionModelChange(res, ldpType, isBinaryDescription);

--- a/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -13,6 +13,7 @@
  */
 package org.trellisldp.http;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.MAX;
 import static java.time.Instant.ofEpochSecond;
@@ -190,26 +191,12 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     private static final IRI childIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH);
     private static final IRI deletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + DELETED_PATH);
     private static final IRI userDeletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + USER_DELETED_PATH);
-    private static final Set<IRI> allInteractionModels = new HashSet<>();
+    private static final Set<IRI> allInteractionModels = newHashSet(LDP.Resource, LDP.RDFSource, LDP.NonRDFSource,
+            LDP.Container, LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer);
 
     protected static final String BASE_URL = "http://example.org/";
 
-    protected static final Set<IRI> allModes = new HashSet<>();
-
-    static {
-        allModes.add(ACL.Append);
-        allModes.add(ACL.Control);
-        allModes.add(ACL.Read);
-        allModes.add(ACL.Write);
-
-        allInteractionModels.add(LDP.Resource);
-        allInteractionModels.add(LDP.RDFSource);
-        allInteractionModels.add(LDP.NonRDFSource);
-        allInteractionModels.add(LDP.Container);
-        allInteractionModels.add(LDP.BasicContainer);
-        allInteractionModels.add(LDP.DirectContainer);
-        allInteractionModels.add(LDP.IndirectContainer);
-    }
+    protected static final Set<IRI> allModes = newHashSet(ACL.Append, ACL.Control, ACL.Read, ACL.Write);
 
     @Mock
     protected ResourceService mockResourceService;

--- a/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -190,6 +190,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     private static final IRI childIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH);
     private static final IRI deletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + DELETED_PATH);
     private static final IRI userDeletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + USER_DELETED_PATH);
+    private static final Set<IRI> allInteractionModels = new HashSet<>();
 
     protected static final String BASE_URL = "http://example.org/";
 
@@ -200,6 +201,14 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
         allModes.add(ACL.Control);
         allModes.add(ACL.Read);
         allModes.add(ACL.Write);
+
+        allInteractionModels.add(LDP.Resource);
+        allInteractionModels.add(LDP.RDFSource);
+        allInteractionModels.add(LDP.NonRDFSource);
+        allInteractionModels.add(LDP.Container);
+        allInteractionModels.add(LDP.BasicContainer);
+        allInteractionModels.add(LDP.DirectContainer);
+        allInteractionModels.add(LDP.IndirectContainer);
     }
 
     @Mock
@@ -255,6 +264,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
         whenResource(mockResourceService.get(eq(root))).thenReturn(of(mockResource));
         when(mockResourceService.get(eq(childIdentifier))).thenReturn(empty());
         when(mockResourceService.get(eq(childIdentifier), any(Instant.class))).thenReturn(empty());
+        when(mockResourceService.supportedInteractionModels()).thenReturn(allInteractionModels);
         whenResource(mockResourceService.get(eq(binaryIdentifier))).thenReturn(of(mockBinaryResource));
         whenResource(mockResourceService.get(eq(binaryIdentifier), any(Instant.class)))
             .thenReturn(of(mockBinaryVersionedResource));

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -197,7 +197,7 @@ public class DeleteHandlerTest {
         final BadRequestException ex = assertThrows(BadRequestException.class, () ->
                 handler.deleteResource(mockResource));
         assertTrue(ex.getResponse().getLinks().stream().anyMatch(link ->
-                link.getUri().toString().equals(Trellis.InvalidInteractionModel.getIRIString()) &&
+                link.getUri().toString().equals(Trellis.UnsupportedInteractionModel.getIRIString()) &&
                 link.getRel().equals(LDP.constrainedBy.getIRIString())));
         assertEquals(TEXT_PLAIN_TYPE, ex.getResponse().getMediaType());
     }

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -295,7 +295,7 @@ public class PatchHandlerTest {
         final BadRequestException ex = assertThrows(BadRequestException.class, () ->
                 patchHandler.updateResource(mockResource));
         assertTrue(ex.getResponse().getLinks().stream().anyMatch(link ->
-                link.getUri().toString().equals(Trellis.InvalidInteractionModel.getIRIString()) &&
+                link.getUri().toString().equals(Trellis.UnsupportedInteractionModel.getIRIString()) &&
                 link.getRel().equals(LDP.constrainedBy.getIRIString())));
         assertEquals(TEXT_PLAIN_TYPE, ex.getResponse().getMediaType());
     }

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -14,11 +14,14 @@
 package org.trellisldp.http.impl;
 
 import static java.time.Instant.ofEpochSecond;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Stream.of;
 import static javax.ws.rs.core.Link.fromUri;
 import static javax.ws.rs.core.MediaType.TEXT_HTML_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
@@ -128,6 +131,7 @@ public class PatchHandlerTest {
         when(mockResource.getModified()).thenReturn(time);
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockResource.getIdentifier()).thenReturn(identifier);
+        when(mockResourceService.supportedInteractionModels()).thenReturn(singleton(LDP.RDFSource));
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
@@ -279,6 +283,21 @@ public class PatchHandlerTest {
                         mockResourceService, mockIoService, null);
 
         assertThrows(BadRequestException.class, () -> patchHandler.updateResource(mockResource));
+    }
+
+    @Test
+    public void testNoLdpRsSupport() {
+        when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
+
+        final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockAuditService,
+                        mockResourceService, mockIoService, null);
+
+        final BadRequestException ex = assertThrows(BadRequestException.class, () ->
+                patchHandler.updateResource(mockResource));
+        assertTrue(ex.getResponse().getLinks().stream().anyMatch(link ->
+                link.getUri().toString().equals(Trellis.InvalidInteractionModel.getIRIString()) &&
+                link.getRel().equals(LDP.constrainedBy.getIRIString())));
+        assertEquals(TEXT_PLAIN_TYPE, ex.getResponse().getMediaType());
     }
 
     @Test

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -15,6 +15,7 @@ package org.trellisldp.http.impl;
 
 import static java.net.URI.create;
 import static java.time.Instant.ofEpochSecond;
+import static java.util.Collections.emptySet;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
@@ -43,7 +44,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -78,6 +81,7 @@ import org.trellisldp.http.domain.Digest;
 import org.trellisldp.http.domain.LdpRequest;
 import org.trellisldp.vocabulary.DC;
 import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.Trellis;
 
 /**
  * @author acoburn
@@ -88,6 +92,18 @@ public class PostHandlerTest {
     private static final Instant time = ofEpochSecond(1496262729);
     private static final String baseUrl = "http://example.org/repo/";
     private static final RDF rdf = getInstance();
+    private static final Set<IRI> allInteractionModels = new HashSet<>();
+
+    static {
+        allInteractionModels.add(LDP.Resource);
+        allInteractionModels.add(LDP.RDFSource);
+        allInteractionModels.add(LDP.NonRDFSource);
+        allInteractionModels.add(LDP.Container);
+        allInteractionModels.add(LDP.BasicContainer);
+        allInteractionModels.add(LDP.DirectContainer);
+        allInteractionModels.add(LDP.IndirectContainer);
+    }
+
     private File entity;
 
     @Mock
@@ -120,6 +136,7 @@ public class PostHandlerTest {
     public void setUp() {
         initMocks(this);
         when(mockBinaryService.generateIdentifier()).thenReturn("file:" + randomUUID());
+        when(mockResourceService.supportedInteractionModels()).thenReturn(allInteractionModels);
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
@@ -259,6 +276,21 @@ public class PostHandlerTest {
         assertFalse(res.getLinks().stream().anyMatch(hasType(LDP.Container)));
         assertFalse(res.getLinks().stream().anyMatch(hasType(LDP.NonRDFSource)));
         assertEquals(create(baseUrl + "newresource"), res.getLocation());
+    }
+
+    @Test
+    public void testUnsupportedType() {
+        when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
+        when(mockRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel("type").build());
+
+        final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
+        final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
+                        mockIoService, mockBinaryService, null, mockAuditService);
+
+        final BadRequestException ex = assertThrows(BadRequestException.class, postHandler::createResource);
+        assertTrue(ex.getResponse().getLinks().stream().anyMatch(link ->
+                link.getUri().toString().equals(Trellis.InvalidInteractionModel.getIRIString()) &&
+                link.getRel().equals(LDP.constrainedBy.getIRIString())));
     }
 
     @Test

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -13,6 +13,7 @@
  */
 package org.trellisldp.http.impl;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static java.net.URI.create;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Collections.emptySet;
@@ -44,7 +45,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
@@ -92,17 +92,8 @@ public class PostHandlerTest {
     private static final Instant time = ofEpochSecond(1496262729);
     private static final String baseUrl = "http://example.org/repo/";
     private static final RDF rdf = getInstance();
-    private static final Set<IRI> allInteractionModels = new HashSet<>();
-
-    static {
-        allInteractionModels.add(LDP.Resource);
-        allInteractionModels.add(LDP.RDFSource);
-        allInteractionModels.add(LDP.NonRDFSource);
-        allInteractionModels.add(LDP.Container);
-        allInteractionModels.add(LDP.BasicContainer);
-        allInteractionModels.add(LDP.DirectContainer);
-        allInteractionModels.add(LDP.IndirectContainer);
-    }
+    private static final Set<IRI> allInteractionModels = newHashSet(LDP.Resource, LDP.RDFSource,
+            LDP.NonRDFSource, LDP.Container, LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer);
 
     private File entity;
 

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -280,7 +280,7 @@ public class PostHandlerTest {
 
         final BadRequestException ex = assertThrows(BadRequestException.class, postHandler::createResource);
         assertTrue(ex.getResponse().getLinks().stream().anyMatch(link ->
-                link.getUri().toString().equals(Trellis.InvalidInteractionModel.getIRIString()) &&
+                link.getUri().toString().equals(Trellis.UnsupportedInteractionModel.getIRIString()) &&
                 link.getRel().equals(LDP.constrainedBy.getIRIString())));
     }
 

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -13,6 +13,7 @@
  */
 package org.trellisldp.http.impl;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Collections.emptySet;
 import static java.util.Date.from;
@@ -48,7 +49,6 @@ import static org.trellisldp.http.domain.RdfMediaType.TEXT_TURTLE;
 import java.io.File;
 import java.io.InputStream;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.Predicate;
@@ -98,17 +98,8 @@ public class PutHandlerTest {
     private static final String baseUrl = "http://localhost:8080/repo/";
     private static final RDF rdf = getInstance();
     private static final IRI identifier = rdf.createIRI("trellis:data/resource");
-    private static final Set<IRI> allInteractionModels = new HashSet<>();
-
-    static {
-        allInteractionModels.add(LDP.Resource);
-        allInteractionModels.add(LDP.RDFSource);
-        allInteractionModels.add(LDP.NonRDFSource);
-        allInteractionModels.add(LDP.Container);
-        allInteractionModels.add(LDP.BasicContainer);
-        allInteractionModels.add(LDP.DirectContainer);
-        allInteractionModels.add(LDP.IndirectContainer);
-    }
+    private static final Set<IRI> allInteractionModels = newHashSet(LDP.Resource, LDP.RDFSource, LDP.NonRDFSource,
+            LDP.Container, LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer);
 
     private final Binary testBinary = new Binary(rdf.createIRI("file:binary.txt"), binaryTime, "text/plain", null);
 

--- a/trellis-http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/trellis-http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -394,7 +394,7 @@ public class PutHandlerTest {
         final BadRequestException ex = assertThrows(BadRequestException.class, () ->
                 putHandler.setResource(mockResource));
         assertTrue(ex.getResponse().getLinks().stream().anyMatch(link ->
-                link.getUri().toString().equals(Trellis.InvalidInteractionModel.getIRIString()) &&
+                link.getUri().toString().equals(Trellis.UnsupportedInteractionModel.getIRIString()) &&
                 link.getRel().equals(LDP.constrainedBy.getIRIString())));
     }
 

--- a/trellis-karaf/src/main/resources/features.xml
+++ b/trellis-karaf/src/main/resources/features.xml
@@ -109,7 +109,7 @@
     <feature>trellis-api</feature>
     <feature>trellis-vocabulary</feature>
 
-    <bundle dependency="true">mvn:com.google.guava/guava/${guavaVersion}</bundle>
+    <bundle dependency="true">mvn:com.google.guava/guava/${transitiveGuavaVersion}</bundle>
     <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.mustache-compiler/${mustacheVersion}</bundle>
     <bundle dependency="true">mvn:org.apache.tamaya/tamaya-api/${tamayaVersion}</bundle>
 

--- a/trellis-triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/trellis-triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -19,12 +19,14 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.sort;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.builder;
 import static java.util.stream.Stream.empty;
 import static org.apache.commons.lang3.Range.between;
@@ -50,6 +52,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -121,6 +124,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     private final RDFConnection rdfConnection;
     private final Optional<EventService> eventService;
     private final Optional<MementoService> mementoService;
+    private final Set<IRI> supportedIxnModels;
 
     /**
      * Create a triplestore-backed resource service.
@@ -138,6 +142,8 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
         this.supplier = identifierService.getSupplier();
         this.eventService = ofNullable(eventService);
         this.mementoService = ofNullable(mementoService);
+        this.supportedIxnModels = unmodifiableSet(asList(LDP.Resource, LDP.RDFSource, LDP.NonRDFSource, LDP.Container,
+                LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer).stream().collect(toSet()));
         init();
     }
 
@@ -682,6 +688,11 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
                 throw new RuntimeTrellisException(ex);
             }
         });
+    }
+
+    @Override
+    public Set<IRI> supportedInteractionModels() {
+        return supportedIxnModels;
     }
 
     /**

--- a/trellis-vocabulary/src/main/java/org/trellisldp/vocabulary/Trellis.java
+++ b/trellis-vocabulary/src/main/java/org/trellisldp/vocabulary/Trellis.java
@@ -40,6 +40,7 @@ public final class Trellis {
     /* Named Individuals */
     public static final IRI AdministratorAgent = createIRI(URI + "AdministratorAgent");
     public static final IRI AnonymousAgent = createIRI(URI + "AnonymousAgent");
+    public static final IRI InvalidInteractionModel = createIRI(URI + "InvalidInteractionModel");
     public static final IRI InvalidType = createIRI(URI + "InvalidType");
     public static final IRI InvalidRange = createIRI(URI + "InvalidRange");
     public static final IRI InvalidCardinality = createIRI(URI + "InvalidCardinality");

--- a/trellis-vocabulary/src/main/java/org/trellisldp/vocabulary/Trellis.java
+++ b/trellis-vocabulary/src/main/java/org/trellisldp/vocabulary/Trellis.java
@@ -40,7 +40,6 @@ public final class Trellis {
     /* Named Individuals */
     public static final IRI AdministratorAgent = createIRI(URI + "AdministratorAgent");
     public static final IRI AnonymousAgent = createIRI(URI + "AnonymousAgent");
-    public static final IRI InvalidInteractionModel = createIRI(URI + "InvalidInteractionModel");
     public static final IRI InvalidType = createIRI(URI + "InvalidType");
     public static final IRI InvalidRange = createIRI(URI + "InvalidRange");
     public static final IRI InvalidCardinality = createIRI(URI + "InvalidCardinality");
@@ -49,6 +48,7 @@ public final class Trellis {
     public static final IRI PreferAudit = createIRI(URI + "PreferAudit");
     public static final IRI PreferServerManaged = createIRI(URI + "PreferServerManaged");
     public static final IRI PreferUserManaged = createIRI(URI + "PreferUserManaged");
+    public static final IRI UnsupportedInteractionModel = createIRI(URI + "UnsupportedInteractionModel");
 
     private Trellis() {
         // prevent instantiation


### PR DESCRIPTION
Resolves #92 

Once we have agreement on this approach, I can apply it to #88, allowing the test suite to adjust to varying levels of LDP container support.

I decided _not_ to include a default implementation in the interface -- if we want implementations to be clear about what is supported, then I thought it makes more sense to simply require an implementing class to _implement_ the method.

I am also making use of a new named individual in the Trellis ontology `trellis:InvalidInteractionModel`, which is used with the `ldp:constrainedBy` link header in the case of an error condition.