### PR TITLE
Fix ResourceService tests

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
@@ -62,6 +62,8 @@ public interface ResourceServiceTests {
 
     String SUBJECT2 = "http://example.com/subject/2";
 
+    IRI ROOT_CONTAINER = getInstance().createIRI(TRELLIS_DATA_PREFIX);
+
     /**
      * Get the resource service implementation.
      * @return the resource service implementation
@@ -88,7 +90,7 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, null, dataset).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, dataset).get());
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
         res.ifPresent(r -> r.stream(Trellis.PreferUserManaged)
@@ -110,14 +112,15 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, null, dataset).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, dataset).get());
 
         dataset.clear();
         dataset.add(Trellis.PreferUserManaged, identifier, SKOS.prefLabel, rdf.createLiteral("preferred label"));
         dataset.add(Trellis.PreferUserManaged, identifier, SKOS.altLabel, rdf.createLiteral("alternate label"));
         dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
-        assertTrue(getResourceService().replace(identifier, getSession(), LDP.RDFSource, null, dataset).get());
+        assertTrue(getResourceService().replace(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER,
+                    dataset).get());
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
         res.ifPresent(r -> {
@@ -143,7 +146,8 @@ public interface ResourceServiceTests {
 
         assertFalse(getResourceService().get(identifier).isPresent());
 
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, null, dataset).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER,
+                    dataset).get());
         assertTrue(getResourceService().get(identifier).filter(res -> !res.isDeleted()).isPresent());
 
         assertTrue(getResourceService().delete(identifier, getSession(), LDP.Resource, rdf.createDataset()).get());
@@ -162,7 +166,8 @@ public interface ResourceServiceTests {
         final Dataset dataset0 = rdf.createDataset();
         dataset0.add(Trellis.PreferUserManaged, identifier, DC.title, rdf.createLiteral("Immutable Resource Test"));
 
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, null, dataset0).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER,
+                    dataset0).get());
 
         final IRI audit1 = rdf.createIRI(TRELLIS_BNODE_PREFIX + getResourceService().generateIdentifier());
         final Dataset dataset1 = rdf.createDataset();
@@ -221,7 +226,8 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferUserManaged, identifier, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, null, dataset).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER,
+                    dataset).get());
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
         res.ifPresent(r -> {
@@ -267,7 +273,8 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferServerManaged, binaryLocation, DC.extent, rdf.createLiteral("150", XSD.long_));
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.NonRDFSource, null, dataset).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.NonRDFSource, ROOT_CONTAINER,
+                    dataset).get());
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
         res.ifPresent(r -> {
@@ -313,7 +320,8 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, DC.subject, rdf.createIRI(SUBJECT0));
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.Container, null, dataset0).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.Container, ROOT_CONTAINER,
+                    dataset0).get());
 
         final IRI child1 = rdf.createIRI(base + "/child01");
         final Dataset dataset1 = rdf.createDataset();
@@ -321,7 +329,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferUserManaged, child1, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(child1).isPresent());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, null, dataset1).get());
+        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, dataset1).get());
 
         final IRI child2 = rdf.createIRI(base + "/child02");
         final Dataset dataset2 = rdf.createDataset();
@@ -329,7 +337,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferUserManaged, child2, DC.subject, rdf.createIRI(SUBJECT2));
 
         assertFalse(getResourceService().get(child2).isPresent());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, null, dataset2).get());
+        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, dataset2).get());
 
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -375,7 +383,8 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, DC.subject, rdf.createIRI(SUBJECT0));
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.BasicContainer, null, dataset0).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.BasicContainer, ROOT_CONTAINER,
+                    dataset0).get());
 
         final IRI child1 = rdf.createIRI(base + "/child11");
         final Dataset dataset1 = rdf.createDataset();
@@ -383,7 +392,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferUserManaged, child1, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(child1).isPresent());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, null, dataset1).get());
+        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, dataset1).get());
 
         final IRI child2 = rdf.createIRI(base + "/child12");
         final Dataset dataset2 = rdf.createDataset();
@@ -391,7 +400,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferUserManaged, child2, DC.subject, rdf.createIRI(SUBJECT2));
 
         assertFalse(getResourceService().get(child2).isPresent());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, null, dataset2).get());
+        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, dataset2).get());
 
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -443,7 +452,8 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, LDP.isMemberOfRelation, DC.isPartOf);
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.DirectContainer, null, dataset0).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.DirectContainer, ROOT_CONTAINER,
+                    dataset0).get());
 
         final IRI child1 = rdf.createIRI(base + "/child1");
         final Dataset dataset1 = rdf.createDataset();
@@ -451,7 +461,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferUserManaged, child1, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(child1).isPresent());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, null, dataset1).get());
+        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, dataset1).get());
 
         final IRI child2 = rdf.createIRI(base + "/child2");
         final Dataset dataset2 = rdf.createDataset();
@@ -459,7 +469,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferUserManaged, child2, DC.subject, rdf.createIRI(SUBJECT2));
 
         assertFalse(getResourceService().get(child2).isPresent());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, null, dataset2).get());
+        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, dataset2).get());
 
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -512,7 +522,8 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, LDP.insertedContentRelation, FOAF.primaryTopic);
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.IndirectContainer, null, dataset0).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.IndirectContainer, ROOT_CONTAINER,
+                    dataset0).get());
 
         final IRI child1 = rdf.createIRI(base + "/child1");
         final Dataset dataset1 = rdf.createDataset();
@@ -520,7 +531,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferUserManaged, child1, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(child1).isPresent());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, null, dataset1).get());
+        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, dataset1).get());
 
         final IRI child2 = rdf.createIRI(base + "/child2");
         final Dataset dataset2 = rdf.createDataset();
@@ -528,7 +539,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferUserManaged, child2, DC.subject, rdf.createIRI(SUBJECT2));
 
         assertFalse(getResourceService().get(child2).isPresent());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, null, dataset2).get());
+        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, dataset2).get());
 
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());


### PR DESCRIPTION
This fixes the common tests in `org.trellisldp.test.ResourceService`. It doesn't touch the `TriplestoreResourceService` tests.