### PR TITLE
Simplify Binary metadata handling in HTTP layer

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
@@ -38,6 +38,7 @@ import org.apache.commons.rdf.api.RDF;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.trellisldp.api.Binary;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
@@ -90,7 +91,8 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, dataset).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, null,
+                    dataset).get());
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
         res.ifPresent(r -> r.stream(Trellis.PreferUserManaged)
@@ -112,14 +114,15 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, dataset).get());
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, null,
+                    dataset).get());
 
         dataset.clear();
         dataset.add(Trellis.PreferUserManaged, identifier, SKOS.prefLabel, rdf.createLiteral("preferred label"));
         dataset.add(Trellis.PreferUserManaged, identifier, SKOS.altLabel, rdf.createLiteral("alternate label"));
         dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
-        assertTrue(getResourceService().replace(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER,
+        assertTrue(getResourceService().replace(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, null,
                     dataset).get());
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -146,7 +149,7 @@ public interface ResourceServiceTests {
 
         assertFalse(getResourceService().get(identifier).isPresent());
 
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER,
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, null,
                     dataset).get());
         assertTrue(getResourceService().get(identifier).filter(res -> !res.isDeleted()).isPresent());
 
@@ -166,7 +169,7 @@ public interface ResourceServiceTests {
         final Dataset dataset0 = rdf.createDataset();
         dataset0.add(Trellis.PreferUserManaged, identifier, DC.title, rdf.createLiteral("Immutable Resource Test"));
 
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER,
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, null,
                     dataset0).get());
 
         final IRI audit1 = rdf.createIRI(TRELLIS_BNODE_PREFIX + getResourceService().generateIdentifier());
@@ -226,7 +229,7 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferUserManaged, identifier, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER,
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, ROOT_CONTAINER, null,
                     dataset).get());
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -266,14 +269,10 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferUserManaged, identifier, DC.subject, rdf.createIRI(SUBJECT1));
         final Instant binaryTime = now();
         final IRI binaryLocation = rdf.createIRI("binary:location/" + getResourceService().generateIdentifier());
-        dataset.add(Trellis.PreferServerManaged, identifier, DC.hasPart, binaryLocation);
-        dataset.add(Trellis.PreferServerManaged, binaryLocation, DC.modified,
-                    rdf.createLiteral(binaryTime.toString(), XSD.dateTime));
-        dataset.add(Trellis.PreferServerManaged, binaryLocation, DC.format, rdf.createLiteral("text/plain"));
-        dataset.add(Trellis.PreferServerManaged, binaryLocation, DC.extent, rdf.createLiteral("150", XSD.long_));
+        final Binary binary = new Binary(binaryLocation, binaryTime, "text/plain", 150L);
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.NonRDFSource, ROOT_CONTAINER,
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.NonRDFSource, ROOT_CONTAINER, binary,
                     dataset).get());
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -320,7 +319,7 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, DC.subject, rdf.createIRI(SUBJECT0));
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.Container, ROOT_CONTAINER,
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.Container, ROOT_CONTAINER, null,
                     dataset0).get());
 
         final IRI child1 = rdf.createIRI(base + "/child01");
@@ -329,7 +328,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferUserManaged, child1, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(child1).isPresent());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, dataset1).get());
+        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, null, dataset1).get());
 
         final IRI child2 = rdf.createIRI(base + "/child02");
         final Dataset dataset2 = rdf.createDataset();
@@ -337,7 +336,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferUserManaged, child2, DC.subject, rdf.createIRI(SUBJECT2));
 
         assertFalse(getResourceService().get(child2).isPresent());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, dataset2).get());
+        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, null, dataset2).get());
 
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -383,7 +382,7 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, DC.subject, rdf.createIRI(SUBJECT0));
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.BasicContainer, ROOT_CONTAINER,
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.BasicContainer, ROOT_CONTAINER, null,
                     dataset0).get());
 
         final IRI child1 = rdf.createIRI(base + "/child11");
@@ -392,7 +391,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferUserManaged, child1, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(child1).isPresent());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, dataset1).get());
+        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, null, dataset1).get());
 
         final IRI child2 = rdf.createIRI(base + "/child12");
         final Dataset dataset2 = rdf.createDataset();
@@ -400,7 +399,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferUserManaged, child2, DC.subject, rdf.createIRI(SUBJECT2));
 
         assertFalse(getResourceService().get(child2).isPresent());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, dataset2).get());
+        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, null, dataset2).get());
 
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -452,7 +451,7 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, LDP.isMemberOfRelation, DC.isPartOf);
 
         assertFalse(getResourceService().get(identifier).isPresent());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.DirectContainer, ROOT_CONTAINER,
+        assertTrue(getResourceService().create(identifier, getSession(), LDP.DirectContainer, ROOT_CONTAINER, null,
                     dataset0).get());
 
         final IRI child1 = rdf.createIRI(base + "/child1");
@@ -461,7 +460,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferUserManaged, child1, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(child1).isPresent());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, dataset1).get());
+        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, null, dataset1).get());
 
         final IRI child2 = rdf.createIRI(base + "/child2");
         final Dataset dataset2 = rdf.createDataset();
@@ -469,7 +468,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferUserManaged, child2, DC.subject, rdf.createIRI(SUBJECT2));
 
         assertFalse(getResourceService().get(child2).isPresent());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, dataset2).get());
+        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, null, dataset2).get());
 
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());
@@ -523,7 +522,7 @@ public interface ResourceServiceTests {
 
         assertFalse(getResourceService().get(identifier).isPresent());
         assertTrue(getResourceService().create(identifier, getSession(), LDP.IndirectContainer, ROOT_CONTAINER,
-                    dataset0).get());
+                    null, dataset0).get());
 
         final IRI child1 = rdf.createIRI(base + "/child1");
         final Dataset dataset1 = rdf.createDataset();
@@ -531,7 +530,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferUserManaged, child1, DC.subject, rdf.createIRI(SUBJECT1));
 
         assertFalse(getResourceService().get(child1).isPresent());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, dataset1).get());
+        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, identifier, null, dataset1).get());
 
         final IRI child2 = rdf.createIRI(base + "/child2");
         final Dataset dataset2 = rdf.createDataset();
@@ -539,7 +538,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferUserManaged, child2, DC.subject, rdf.createIRI(SUBJECT2));
 
         assertFalse(getResourceService().get(child2).isPresent());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, dataset2).get());
+        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, identifier, null, dataset2).get());
 
         final Optional<? extends Resource> res = getResourceService().get(identifier);
         assertTrue(res.isPresent());

--- a/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -67,14 +67,14 @@ public abstract class JoiningResourceService implements ResourceService {
 
     @Override
     public Future<Boolean> create(final IRI id, final Session session, final IRI ixnModel, final IRI container,
-            final Dataset dataset) {
-        return mutableData.create(id, session, ixnModel, container, dataset);
+            final Binary binary, final Dataset dataset) {
+        return mutableData.create(id, session, ixnModel, container, binary, dataset);
     }
 
     @Override
     public Future<Boolean> replace(final IRI id, final Session session, final IRI ixnModel, final IRI container,
-            final Dataset dataset) {
-        return mutableData.replace(id, session, ixnModel, container, dataset);
+            final Binary binary, final Dataset dataset) {
+        return mutableData.replace(id, session, ixnModel, container, binary, dataset);
     }
 
     @Override

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -34,10 +34,12 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param session the session context for this operation
      * @param ixnModel the LDP interaction model for this resource
      * @param container an LDP container for this resource, {@code null} for none
+     * @param binary metadata for a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
      * @param dataset the dataset to be persisted
      * @return whether the resource was added
      */
-    Future<Boolean> create(IRI identifier, Session session, IRI ixnModel, IRI container, Dataset dataset);
+    Future<Boolean> create(IRI identifier, Session session, IRI ixnModel, IRI container, Binary binary,
+            Dataset dataset);
 
     /**
      * Replace a resource in the server.
@@ -46,11 +48,12 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param session the session context for this operation
      * @param ixnModel the LDP interaction model for this resource
      * @param container an LDP container for this resource, {@code null} for none
+     * @param binary metadata for a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
      * @param dataset the dataset to be persisted
      * @return whether the resource was replaced
      */
-    Future<Boolean> replace(IRI identifier, Session session, IRI ixnModel, IRI container, Dataset dataset);
-
+    Future<Boolean> replace(IRI identifier, Session session, IRI ixnModel, IRI container, Binary binary,
+            Dataset dataset);
 
     /**
      * Delete a resource from the server.

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -34,7 +34,7 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param session the session context for this operation
      * @param ixnModel the LDP interaction model for this resource
      * @param container an LDP container for this resource, {@code null} for none
-     * @param binary metadata for a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
+     * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
      * @param dataset the dataset to be persisted
      * @return whether the resource was added
      */
@@ -48,7 +48,7 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param session the session context for this operation
      * @param ixnModel the LDP interaction model for this resource
      * @param container an LDP container for this resource, {@code null} for none
-     * @param binary metadata for a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
+     * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
      * @param dataset the dataset to be persisted
      * @return whether the resource was replaced
      */

--- a/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -100,14 +100,14 @@ public class JoiningResourceServiceTest {
 
         @Override
         public Future<Boolean> create(final IRI id, final Session session, final IRI ixnModel, final IRI container,
-                        final Dataset dataset) {
+                        final Binary binary, final Dataset dataset) {
             resources.put(id, new TestResource(id, dataset));
             return isntBadId(id);
         }
 
         @Override
         public Future<Boolean> replace(final IRI id, final Session session, final IRI ixnModel, final IRI container,
-                        final Dataset dataset) {
+                        final Binary binary, final Dataset dataset) {
             resources.replace(id, new TestResource(id, dataset));
             return isntBadId(id);
         }
@@ -212,7 +212,7 @@ public class JoiningResourceServiceTest {
     public void testRoundtripping() throws InterruptedException, ExecutionException {
         final Quad testQuad = createQuad(testResourceId1, testResourceId1, testResourceId1, badId);
         final Resource testResource = new TestResource(testResourceId1, testQuad);
-        assertTrue(testable.create(testResourceId1, mockSession, testResource.getInteractionModel(), null,
+        assertTrue(testable.create(testResourceId1, mockSession, testResource.getInteractionModel(), null, null,
                         testResource.dataset()).get(), "Couldn't create a resource!");
         Resource retrieved = testable.get(testResourceId1).orElseThrow(AssertionError::new);
         assertEquals(testResource.getIdentifier(), retrieved.getIdentifier(), "Resource was retrieved with wrong ID!");
@@ -221,7 +221,7 @@ public class JoiningResourceServiceTest {
 
         final Quad testQuad2 = createQuad(testResourceId1, badId, testResourceId1, badId);
         final Resource testResource2 = new TestResource(testResourceId1, testQuad2);
-        assertTrue(testable.replace(testResourceId1, mockSession, testResource2.getInteractionModel(), null,
+        assertTrue(testable.replace(testResourceId1, mockSession, testResource2.getInteractionModel(), null, null,
                         testResource2.dataset()).get(), "Couldn't replace resource!");
         retrieved = testable.get(testResourceId1).orElseThrow(AssertionError::new);
         assertEquals(testResource2.getIdentifier(), retrieved.getIdentifier(), "Resource was retrieved with wrong ID!");
@@ -240,7 +240,7 @@ public class JoiningResourceServiceTest {
 
         // store some data in mutable and immutable sides under the same resource ID
         final Resource testMutableResource = new TestResource(testResourceId2, testMutableQuad);
-        assertTrue(testable.create(testResourceId2, mockSession, testMutableResource.getInteractionModel(), null,
+        assertTrue(testable.create(testResourceId2, mockSession, testMutableResource.getInteractionModel(), null, null,
                         testMutableResource.dataset()).get(), "Couldn't create a mutable resource!");
         final Resource testImmutableResource = new TestResource(testResourceId2, testImmutableQuad);
         assertTrue(testable.add(testResourceId2, mockSession, testImmutableResource.dataset()).get(),
@@ -261,8 +261,8 @@ public class JoiningResourceServiceTest {
     public void testBadPersist() throws InterruptedException, ExecutionException {
         final Quad testQuad = createQuad(badId, testResourceId1, testResourceId1, badId);
         final Resource testResource = new TestResource(badId, testQuad);
-        assertFalse(testable
-                        .create(badId, mockSession, testResource.getInteractionModel(), null, testResource.dataset())
+        assertFalse(testable.create(badId, mockSession, testResource.getInteractionModel(), null, null,
+                            testResource.dataset())
                         .get(), "Could create a resource when underlying services should reject it!");
     }
 
@@ -316,6 +316,7 @@ public class JoiningResourceServiceTest {
         dataset.add(quad);
 
         final Resource res = new JoiningResourceService.PersistableResource(identifier, LDP.Container, dataset);
+        assertEquals(identifier, res.getIdentifier());
         assertEquals(LDP.Container, res.getInteractionModel());
         assertFalse(res.getModified().isBefore(time));
         assertFalse(res.getModified().isAfter(now()));

--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -113,8 +113,9 @@ public class DeleteHandler extends BaseLdpHandler {
 
                 // update the resource
                 final IRI container = resourceService.getContainer(resId).orElse(null);
-                final Boolean success = resourceService
-                                .replace(resId, session, LDP.Resource, container, dataset.asDataset()).get();
+                final Boolean success = resourceService.replace(resId, session, LDP.Resource, container,
+                        res.getBinary().orElse(null), dataset.asDataset()).get();
+
                 if (success) {
 
                     // Add the audit quads

--- a/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -368,9 +368,9 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
             .thenReturn(completedFuture(true));
         when(mockResourceService.delete(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
-        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(),
+        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(), any(),
                         any(Dataset.class))).thenReturn(completedFuture(true));
-        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(),
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(), any(),
                         any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
@@ -2026,7 +2026,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     public void testPostInterrupted() throws Exception {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH)), any(Session.class),
-                        eq(LDP.RDFSource), any(), any(Dataset.class))).thenReturn(mockFuture);
+                        eq(LDP.RDFSource), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(new InterruptedException("Expected InterruptedException")).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request().header("Slug", "child")
@@ -2039,7 +2039,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     public void testPostFutureException() throws Exception {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH)), any(Session.class),
-                        eq(LDP.RDFSource), any(), any(Dataset.class))).thenReturn(mockFuture);
+                        eq(LDP.RDFSource), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request().header("Slug", "child")
@@ -2247,7 +2247,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPutInterrupted() throws Exception {
         when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), any(Session.class),
-                        eq(LDP.Container), any(), any(Dataset.class))).thenReturn(mockFuture);
+                        eq(LDP.Container), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(new InterruptedException("Expected InterruptedException")).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request()
@@ -2260,7 +2260,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPutFutureException() throws Exception {
         when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), any(Session.class),
-                        eq(LDP.Container), any(), any(Dataset.class))).thenReturn(mockFuture);
+                        eq(LDP.Container), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request()
@@ -2819,7 +2819,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPatchInterrupted() throws Exception {
         when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), any(Session.class),
-                        eq(LDP.RDFSource), any(), any(Dataset.class))).thenReturn(mockFuture);
+                        eq(LDP.RDFSource), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(new InterruptedException("Expected InterruptedException")).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request()
@@ -2832,7 +2832,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPatchFutureException() throws Exception {
         when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH)), any(Session.class),
-                        eq(LDP.RDFSource), any(), any(Dataset.class))).thenReturn(mockFuture);
+                        eq(LDP.RDFSource), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
 
         final Response res = target(RESOURCE_PATH).request()
@@ -3000,7 +3000,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testMultipartPostError() {
-        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(),
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(), any(),
                         any(Dataset.class))).thenReturn(completedFuture(false));
         final BinaryService.MultipartUpload upload = new BinaryService.MultipartUpload(BASE_URL, BINARY_PATH,
                 new HttpSession(), mockBinary);
@@ -3015,7 +3015,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testMultipartPostExecutionError() throws Exception {
-        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(),
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(), any(),
                         any(Dataset.class))).thenReturn(mockFuture);
         doThrow(ExecutionException.class).when(mockFuture).get();
         final BinaryService.MultipartUpload upload = new BinaryService.MultipartUpload(BASE_URL, BINARY_PATH,
@@ -3031,7 +3031,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testMultipartPostInterruptedExecutionError() throws Exception {
-        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(),
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(), any(),
                         any(Dataset.class))).thenReturn(mockFuture);
         doThrow(InterruptedException.class).when(mockFuture).get();
         final BinaryService.MultipartUpload upload = new BinaryService.MultipartUpload(BASE_URL, BINARY_PATH,

--- a/core/http/src/test/java/org/trellisldp/http/CORSResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CORSResourceTest.java
@@ -251,7 +251,7 @@ public class CORSResourceTest extends JerseyTest {
             });
 
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
-        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(IRI.class),
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(IRI.class), any(),
                         any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/core/http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
@@ -196,7 +196,7 @@ public class LdpForbiddenResourceTest extends JerseyTest {
 
 
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
-        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(IRI.class),
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(IRI.class), any(),
                         any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/core/http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
@@ -173,7 +173,7 @@ public class LdpUnauthorizedResourceTest extends JerseyTest {
             });
 
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
-        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(IRI.class),
+        when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(IRI.class), any(),
                         any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -203,7 +203,7 @@ public class DeleteHandlerTest {
 
     @Test
     public void testDeleteACLError() {
-        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(),
+        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(), any(),
                         any(Dataset.class))).thenReturn(completedFuture(false));
         when(mockLdpRequest.getExt()).thenReturn(ACL);
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
@@ -214,7 +214,7 @@ public class DeleteHandlerTest {
 
     @Test
     public void testDeleteACLAuditError() {
-        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(),
+        when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(), any(),
                         any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
             .thenReturn(completedFuture(false));

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -140,7 +140,7 @@ public class PatchHandlerTest {
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(),
-                        any(Dataset.class))).thenReturn(completedFuture(true));
+                        any(), any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(BlankNode.class))).thenAnswer(inv ->
@@ -210,7 +210,7 @@ public class PatchHandlerTest {
         verify(mockIoService).update(any(Graph.class), eq(insert), eq(identifier.getIRIString()));
 
         verify(mockResourceService).replace(eq(identifier), any(Session.class), eq(LDP.RDFSource), any(),
-                        any(Dataset.class));
+                        any(), any(Dataset.class));
     }
 
     @Test
@@ -283,7 +283,7 @@ public class PatchHandlerTest {
     @Test
     public void testError() {
         when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(Session.class),
-                    any(IRI.class), any(), any(Dataset.class))).thenReturn(completedFuture(false));
+                    any(IRI.class), any(), any(), any(Dataset.class))).thenReturn(completedFuture(false));
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
@@ -311,7 +311,7 @@ public class PatchHandlerTest {
     public void testException() throws Exception {
         when(mockFuture.get()).thenThrow(new InterruptedException("Expected"));
         when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(Session.class),
-                    any(IRI.class), any(), any(Dataset.class))).thenReturn(mockFuture);
+                    any(IRI.class), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -136,7 +136,7 @@ public class PostHandlerTest {
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(),
-                        any(Dataset.class))).thenReturn(completedFuture(true));
+                        any(), any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(BlankNode.class))).thenAnswer(inv ->
@@ -316,7 +316,7 @@ public class PostHandlerTest {
         verify(mockIoService).read(any(InputStream.class), eq(baseUrl + path), eq(TURTLE));
 
         verify(mockResourceService).create(eq(identifier), any(Session.class), eq(LDP.RDFSource), any(),
-                        any(Dataset.class));
+                        any(), any(Dataset.class));
     }
 
     @Test
@@ -344,7 +344,7 @@ public class PostHandlerTest {
         assertEquals("text/plain", metadataArgument.getValue().get(CONTENT_TYPE));
 
         verify(mockResourceService).create(eq(identifier), any(Session.class), eq(LDP.NonRDFSource), any(),
-                        any(Dataset.class));
+                        any(), any(Dataset.class));
     }
 
     @Test
@@ -373,7 +373,7 @@ public class PostHandlerTest {
         assertEquals("text/plain", metadataArgument.getValue().get(CONTENT_TYPE));
 
         verify(mockResourceService).create(eq(identifier), any(Session.class), eq(LDP.NonRDFSource), any(),
-                        any(Dataset.class));
+                        any(), any(Dataset.class));
     }
 
     @Test
@@ -427,7 +427,7 @@ public class PostHandlerTest {
     @Test
     public void testError() throws IOException {
         when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "newresource")), any(Session.class),
-                    any(IRI.class), any(), any(Dataset.class))).thenReturn(completedFuture(false));
+                    any(IRI.class), any(), any(), any(Dataset.class))).thenReturn(completedFuture(false));
         when(mockRequest.getContentType()).thenReturn("text/turtle");
 
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
@@ -441,7 +441,7 @@ public class PostHandlerTest {
     public void testException() throws Exception {
         when(mockFuture.get()).thenThrow(new InterruptedException("Expected"));
         when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "newresource")), any(Session.class),
-                    any(IRI.class), any(), any(Dataset.class))).thenReturn(mockFuture);
+                    any(IRI.class), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         when(mockRequest.getContentType()).thenReturn("text/turtle");
 
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -147,9 +147,9 @@ public class PutHandlerTest {
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
         when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(),
-                        any(Dataset.class))).thenReturn(completedFuture(true));
+                        any(), any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(),
-                        any(Dataset.class))).thenReturn(completedFuture(true));
+                        any(), any(Dataset.class))).thenReturn(completedFuture(true));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(BlankNode.class))).thenAnswer(inv ->
@@ -407,7 +407,7 @@ public class PutHandlerTest {
     public void testError() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(Session.class),
-                    any(IRI.class), any(), any(Dataset.class))).thenReturn(completedFuture(false));
+                    any(IRI.class), any(), any(), any(Dataset.class))).thenReturn(completedFuture(false));
         when(mockLdpRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockLdpRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
 
@@ -423,7 +423,7 @@ public class PutHandlerTest {
         when(mockFuture.get()).thenThrow(new InterruptedException("Expected"));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(Session.class),
-                    any(IRI.class), any(), any(Dataset.class))).thenReturn(mockFuture);
+                    any(IRI.class), any(), any(), any(Dataset.class))).thenReturn(mockFuture);
         when(mockLdpRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockLdpRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
 


### PR DESCRIPTION
Resolves #126 

The changes in the test code are pretty uninteresting. Of note are the changes in `core/api` and `core/http`.