### PR TITLE
Follow File URI specification

### DIFF
--- a/components/file/build.gradle
+++ b/components/file/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation("commons-codec:commons-codec:$commonsCodecVersion")
     implementation("commons-io:commons-io:$commonsIoVersion")
     implementation("org.apache.commons:commons-collections4:$commonsCollectionsVersion")
+    implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
     implementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion")
     implementation("org.apache.jena:jena-osgi:$jenaVersion")
     implementation("org.apache.tamaya:tamaya-api:$tamayaVersion")

--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -29,6 +29,7 @@ import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_256;
 import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_384;
 import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_512;
 import static org.apache.commons.collections4.IteratorUtils.asEnumeration;
+import static org.apache.commons.lang3.StringUtils.stripStart;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.File;
@@ -113,7 +114,7 @@ public class FileBinaryService implements BinaryService {
             final Integer hierarchy, final Integer length) {
         requireNonNull(basePath, BINARY_BASE_PATH + " configuration may not be null!");
         this.basePath = basePath;
-        this.idSupplier = idService.getSupplier("file:", hierarchy, length);
+        this.idSupplier = idService.getSupplier("file:///", hierarchy, length);
     }
 
     private FileBinaryService(final IdentifierService idService, final Configuration config) {
@@ -194,7 +195,7 @@ public class FileBinaryService implements BinaryService {
 
     private Optional<File> getFileFromIdentifier(final IRI identifier) {
         return ofNullable(identifier).map(IRI::getIRIString).map(URI::create).map(URI::getSchemeSpecificPart)
-            .map(x -> new File(basePath, x));
+            .map(x -> stripStart(x, "/")).map(x -> new File(basePath, x));
     }
 
     private Function<MessageDigest, Optional<String>> digest(final InputStream stream) {

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -63,7 +63,7 @@ public class FileBinaryServiceTest {
     private static final String directory = new File(FileBinaryService.class.getResource("/" + testDoc).getPath())
         .getParent();
 
-    private static final IRI file = rdf.createIRI("file:" + testDoc);
+    private static final IRI file = rdf.createIRI("file:///" + testDoc);
     private final IdentifierService idService = new UUIDGenerator();
 
     @Mock
@@ -83,13 +83,13 @@ public class FileBinaryServiceTest {
     public void testFileExists() {
         final BinaryService resolver = new FileBinaryService(idService);
         assertTrue(resolver.exists(file));
-        assertFalse(resolver.exists(rdf.createIRI("file:fake.txt")));
+        assertFalse(resolver.exists(rdf.createIRI("file:///fake.txt")));
     }
 
     @Test
     public void testFilePurge() {
         final BinaryService resolver = new FileBinaryService(idService);
-        final IRI fileIRI = rdf.createIRI("file:" + randomFilename());
+        final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         final InputStream inputStream = new ByteArrayInputStream("Some data".getBytes(UTF_8));
         resolver.setContent(fileIRI, inputStream);
         assertTrue(resolver.exists(fileIRI));
@@ -100,7 +100,7 @@ public class FileBinaryServiceTest {
     @Test
     public void testIdSupplier() {
         final BinaryService resolver = new FileBinaryService(idService);
-        assertTrue(resolver.generateIdentifier().startsWith("file:"));
+        assertTrue(resolver.generateIdentifier().startsWith("file:///"));
         assertNotEquals(resolver.generateIdentifier(), resolver.generateIdentifier());
     }
 
@@ -142,7 +142,7 @@ public class FileBinaryServiceTest {
     public void testSetFileContent() {
         final String contents = "A new file";
         final BinaryService resolver = new FileBinaryService(idService);
-        final IRI fileIRI = rdf.createIRI("file:" + randomFilename());
+        final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         final InputStream inputStream = new ByteArrayInputStream(contents.getBytes(UTF_8));
         resolver.setContent(fileIRI, inputStream);
         assertTrue(resolver.getContent(fileIRI).isPresent());
@@ -152,7 +152,7 @@ public class FileBinaryServiceTest {
     @Test
     public void testGetFileContentError() throws IOException {
         final BinaryService resolver = new FileBinaryService(idService);
-        final IRI fileIRI = rdf.createIRI("file:" + randomFilename());
+        final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         assertThrows(UncheckedIOException.class, () -> resolver.getContent(fileIRI));
     }
 
@@ -162,7 +162,7 @@ public class FileBinaryServiceTest {
                 throw new IOException("Expected error");
         });
         final BinaryService resolver = new FileBinaryService(idService);
-        final IRI fileIRI = rdf.createIRI("file:" + randomFilename());
+        final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         assertThrows(UncheckedIOException.class, () -> resolver.setContent(fileIRI, throwingMockInputStream));
     }
 

--- a/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
@@ -80,7 +80,7 @@ public class FileResourceTest {
             assertEquals(parse("2017-02-16T11:17:00Z"), binary.getModified());
             assertEquals(of(10L), binary.getSize());
             assertEquals(of("text/plain"), binary.getMimeType());
-            assertEquals(rdf.createIRI("file:path/to/binary"), binary.getIdentifier());
+            assertEquals(rdf.createIRI("file:///path/to/binary"), binary.getIdentifier());
         });
         assertFalse(res.hasAcl());
         assertFalse(res.isMemento());

--- a/components/file/src/test/resources/binary.nq
+++ b/components/file/src/test/resources/binary.nq
@@ -1,9 +1,9 @@
 <trellis:data/binary> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#NonRDFSource> <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
 <trellis:data/binary> <http://purl.org/dc/terms/modified> "2017-02-16T11:17:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
-<file:path/to/binary> <http://purl.org/dc/terms/modified> "2017-02-16T11:17:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
-<trellis:data/binary> <http://purl.org/dc/terms/hasPart> <file:path/to/binary> <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
-<file:path/to/binary> <http://purl.org/dc/terms/extent> "10"^^<http://www.w3.org/2001/XMLSchema#long> <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
-<file:path/to/binary> <http://purl.org/dc/terms/format> "text/plain" <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
+<file:///path/to/binary> <http://purl.org/dc/terms/modified> "2017-02-16T11:17:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
+<trellis:data/binary> <http://purl.org/dc/terms/hasPart> <file:///path/to/binary> <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
+<file:///path/to/binary> <http://purl.org/dc/terms/extent> "10"^^<http://www.w3.org/2001/XMLSchema#long> <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
+<file:///path/to/binary> <http://purl.org/dc/terms/format> "text/plain" <http://www.trellisldp.org/ns/trellis#PreferServerManaged> .
 <trellis:data/binary> <http://www.w3.org/2000/01/rdf-schema#label> "A label"@eng <http://www.trellisldp.org/ns/trellis#PreferUserManaged> .
 <trellis:data/binary> <http://purl.org/dc/terms/subject> <http://example.org/subject> <http://www.trellisldp.org/ns/trellis#PreferUserManaged> .
 

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
@@ -201,7 +201,7 @@ public class TriplestoreResourceTest {
         final String binaryTime = "2018-01-10T14:02:00Z";
         final String size = "2560";
         final String mimeType = "image/jpeg";
-        final IRI binaryIdentifier = rdf.createIRI("file:binary");
+        final IRI binaryIdentifier = rdf.createIRI("file:///binary");
 
         final JenaDataset dataset = rdf.createDataset();
         dataset.add(identifier, identifier, RDF.type, SKOS.Concept);

--- a/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -183,7 +183,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     private static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH);
     private static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
     private static final IRI binaryIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + BINARY_PATH);
-    private static final IRI binaryInternalIdentifier = rdf.createIRI("file:some/file");
+    private static final IRI binaryInternalIdentifier = rdf.createIRI("file:///some/file");
     private static final IRI nonexistentIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + NON_EXISTENT_PATH);
     private static final IRI childIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH);
     private static final IRI deletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + DELETED_PATH);

--- a/core/http/src/test/java/org/trellisldp/http/CORSResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CORSResourceTest.java
@@ -120,7 +120,7 @@ public class CORSResourceTest extends JerseyTest {
     private static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH);
     private static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX + REPO1);
     private static final IRI binaryIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + BINARY_PATH);
-    private static final IRI binaryInternalIdentifier = rdf.createIRI("file:some/file");
+    private static final IRI binaryInternalIdentifier = rdf.createIRI("file:///some/file");
     private static final IRI nonexistentIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + NON_EXISTENT_PATH);
     private static final IRI childIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH);
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -109,7 +109,7 @@ public class GetHandlerTest {
     private static final String baseUrl = "http://localhost:8080/repo/";
     private static final RDF rdf = getInstance();
 
-    private Binary testBinary = new Binary(rdf.createIRI("file:testResource.txt"), binaryTime, "text/plain", 100L);
+    private Binary testBinary = new Binary(rdf.createIRI("file:///testResource.txt"), binaryTime, "text/plain", 100L);
 
     @Mock
     private ResourceService mockResourceService;

--- a/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
@@ -67,7 +67,7 @@ public class OptionsHandlerTest {
     private static final String baseUrl = "http://localhost:8080/repo";
     private static final RDF rdf = getInstance();
 
-    private Binary testBinary = new Binary(rdf.createIRI("file:testResource.txt"), binaryTime, "text/plain", 100L);
+    private Binary testBinary = new Binary(rdf.createIRI("file:///testResource.txt"), binaryTime, "text/plain", 100L);
 
     @Mock
     private ResourceService mockResourceService;

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -131,7 +131,7 @@ public class PostHandlerTest {
     @BeforeEach
     public void setUp() {
         initMocks(this);
-        when(mockBinaryService.generateIdentifier()).thenReturn("file:" + randomUUID());
+        when(mockBinaryService.generateIdentifier()).thenReturn("file:///" + randomUUID());
         when(mockResourceService.supportedInteractionModels()).thenReturn(allInteractionModels);
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
             .thenReturn(completedFuture(true));
@@ -340,7 +340,7 @@ public class PostHandlerTest {
 
         verify(mockBinaryService).setContent(iriArgument.capture(), any(InputStream.class),
                 metadataArgument.capture());
-        assertTrue(iriArgument.getValue().getIRIString().startsWith("file:"));
+        assertTrue(iriArgument.getValue().getIRIString().startsWith("file:///"));
         assertEquals("text/plain", metadataArgument.getValue().get(CONTENT_TYPE));
 
         verify(mockResourceService).create(eq(identifier), any(Session.class), eq(LDP.NonRDFSource), any(),
@@ -369,7 +369,7 @@ public class PostHandlerTest {
 
         verify(mockBinaryService).setContent(iriArgument.capture(), any(InputStream.class),
                 metadataArgument.capture());
-        assertTrue(iriArgument.getValue().getIRIString().startsWith("file:"));
+        assertTrue(iriArgument.getValue().getIRIString().startsWith("file:///"));
         assertEquals("text/plain", metadataArgument.getValue().get(CONTENT_TYPE));
 
         verify(mockResourceService).create(eq(identifier), any(Session.class), eq(LDP.NonRDFSource), any(),

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -101,7 +101,7 @@ public class PutHandlerTest {
     private static final Set<IRI> allInteractionModels = newHashSet(LDP.Resource, LDP.RDFSource, LDP.NonRDFSource,
             LDP.Container, LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer);
 
-    private final Binary testBinary = new Binary(rdf.createIRI("file:binary.txt"), binaryTime, "text/plain", null);
+    private final Binary testBinary = new Binary(rdf.createIRI("file:///binary.txt"), binaryTime, "text/plain", null);
 
     private final AgentService agentService = new SimpleAgentService();
 
@@ -141,7 +141,7 @@ public class PutHandlerTest {
         when(mockResource.getIdentifier()).thenReturn(identifier);
         when(mockResource.getBinary()).thenReturn(empty());
         when(mockResource.getModified()).thenReturn(time);
-        when(mockBinaryService.generateIdentifier()).thenReturn("file:" + randomUUID());
+        when(mockBinaryService.generateIdentifier()).thenReturn("file:///" + randomUUID());
 
         when(mockResourceService.supportedInteractionModels()).thenReturn(allInteractionModels);
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))


### PR DESCRIPTION
Resolves #128

Internal file URIs for binary locations have been using
a `file:foo/bar` format, but this is invalid according to RFC 8089,
the "file" URI scheme: https://tools.ietf.org/html/rfc8089

With this change, those internal IRIs are represented as
`file:///foo/bar`.