### PR TITLE
adds Camel Producer notification module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ ext {
     /* Dependencies */
     activationApiVersion = '1.2.0'
     activeMqVersion = '5.15.4'
+    camelVersion = '2.21.1'
     commonsCodecVersion = '1.11'
     commonsCollectionsVersion = '4.1'
     commonsIoVersion = '2.6'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Jun 17 20:01:03 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/notifications/camel-producer/build.gradle
+++ b/notifications/camel-producer/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'java-library'
+apply plugin: 'osgi'
+
+description = 'Trellis Notifications (Kafka)'
+
+ext {
+    moduleName = 'org.trellisldp.kafka'
+}
+
+dependencies {
+    api("org.apache.camel:camel-core:$camelVersion")
+    api("org.apache.camel:camel-kafka:$camelVersion")
+    api("org.glassfish.hk2.external:javax.inject:$javaxInjectVersion")
+    api project(':trellis-api')
+
+    implementation("org.apache.tamaya:tamaya-api:$tamayaVersion")
+    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+
+    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
+    testImplementation("javax.activation:javax.activation-api:$activationApiVersion")
+    testImplementation("javax.annotation:javax.annotation-api:$javaxAnnotationsVersion")
+    testImplementation("javax.xml.bind:jaxb-api:$jaxbVersion")
+    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
+    testImplementation("org.apache.kafka:kafka-clients:$kafkaVersion")
+    testImplementation("org.apache.tamaya:tamaya-core:$tamayaVersion")
+    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation project(':trellis-event-serialization')
+    testImplementation project(':trellis-vocabulary')
+}
+
+jar {
+    manifest {
+        description project.description
+        docURL project.docURL
+        vendor project.vendor
+        license project.license
+
+        instruction 'Automatic-Module-Name', moduleName
+        instruction 'Import-Package', '*'
+        instruction 'Export-Package', "${moduleName};version=${projectOsgiVersion}"
+        instruction 'Require-Capability', '''\
+            osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)",
+            osgi.serviceloader;
+                filter:="(osgi.serviceloader=org.trellisldp.api.ActivityStreamService)";
+                resolution:=mandatory; cardinality:=mandatory
+            '''
+    }
+}

--- a/notifications/camel-producer/src/main/java/org/trellisldp/camel/producer/CamelProducer.java
+++ b/notifications/camel-producer/src/main/java/org/trellisldp/camel/producer/CamelProducer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.camel.producer;
+
+import static java.util.Objects.requireNonNull;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.ServiceLoader;
+
+import org.apache.camel.ProducerTemplate;
+import org.apache.commons.rdf.api.IRI;
+import org.slf4j.Logger;
+import org.trellisldp.api.ActivityStreamService;
+import org.trellisldp.api.Event;
+import org.trellisldp.api.EventService;
+
+/**
+ * A Camel message producer.
+ */
+public class CamelProducer implements EventService {
+
+    private volatile ProducerTemplate template;
+
+    private String endpointUri;
+
+    private static final Logger LOGGER = getLogger(CamelProducer.class);
+
+    // TODO - JDK9 ServiceLoader::findFirst
+    private static ActivityStreamService service = ServiceLoader.load(ActivityStreamService.class).iterator().next();
+
+    /**
+     * Create a new CamelProducer.
+     *
+     * @param template the template
+     * @param endpointUri the endpointUri
+     */
+    public CamelProducer(final ProducerTemplate template, final String endpointUri) {
+        requireNonNull(template, "Camel producer may not be null!");
+
+        this.template = template;
+        this.endpointUri = endpointUri;
+    }
+
+    @Override
+    public void emit(final Event event) {
+        requireNonNull(event, "Cannot emit a null event!");
+
+        service.serialize(event).ifPresent(message -> {
+            template.sendBodyAndHeader(
+                    endpointUri, message, "id", event.getTarget().map(IRI::getIRIString).orElse(null));
+        });
+    }
+}
+

--- a/notifications/camel-producer/src/main/java/org/trellisldp/camel/producer/package-info.java
+++ b/notifications/camel-producer/src/main/java/org/trellisldp/camel/producer/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ *
+ */
+package org.trellisldp.camel.producer;

--- a/notifications/camel-producer/src/test/java/org/trellisldp/camel/producer/CamelKafkaProducerTest.java
+++ b/notifications/camel-producer/src/test/java/org/trellisldp/camel/producer/CamelKafkaProducerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.camel.producer;
+
+import static java.time.Instant.now;
+import static java.util.Collections.singleton;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Hashtable;
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.JndiRegistry;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.camel.processor.idempotent.kafka.KafkaIdempotentRepository;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.trellisldp.api.Event;
+import org.trellisldp.api.EventService;
+import org.trellisldp.vocabulary.AS;
+import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.Trellis;
+
+public class CamelKafkaProducerTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CamelKafkaProducerTest.class);
+
+    private KafkaIdempotentRepository kafkaIdempotentRepository;
+
+    private volatile ProducerTemplate template;
+
+    private static ThreadLocal<ModelCamelContext> threadCamelContext = new ThreadLocal<>();
+
+    private volatile ModelCamelContext context;
+
+    private static final RDF rdf = new SimpleRDF();
+
+    private final Instant time = now();
+
+    @Mock
+    private Event mockEvent;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+        when(mockEvent.getTarget()).thenReturn(of(rdf.createIRI("trellis:repository/resource")));
+        when(mockEvent.getAgents()).thenReturn(singleton(Trellis.AdministratorAgent));
+        when(mockEvent.getIdentifier()).thenReturn(rdf.createIRI("urn:test"));
+        when(mockEvent.getCreated()).thenReturn(time);
+        when(mockEvent.getTypes()).thenReturn(singleton(AS.Update));
+        when(mockEvent.getTargetTypes()).thenReturn(singleton(LDP.RDFSource));
+        when(mockEvent.getInbox()).thenReturn(empty());
+    }
+
+    @Test
+    public void testCamelKafkaProducer() throws Exception {
+        context = (ModelCamelContext) createCamelContext();
+        threadCamelContext.set(context);
+        template = context.createProducerTemplate();
+        context.addRoutes(createRouteBuilder());
+        context.start();
+        template.start();
+        final EventService svc = new CamelProducer(template, "direct:in");
+        svc.emit(mockEvent);
+    }
+
+
+    private JndiRegistry createRegistry() throws Exception {
+        final JndiRegistry jndi = new JndiRegistry(createJndiContext());
+
+        kafkaIdempotentRepository = new KafkaIdempotentRepository("test-topic", "localhost:9094");
+        jndi.bind("kafkaIdempotentRepository", kafkaIdempotentRepository);
+
+        return jndi;
+    }
+
+    private Context createJndiContext() throws Exception {
+        final Properties properties = new Properties();
+
+        final InputStream in = getClass().getClassLoader().getResourceAsStream("jndi.properties");
+        if (in != null) {
+            LOGGER.debug("Using jndi.properties from classpath root");
+            properties.load(in);
+        } else {
+            properties.put("java.naming.factory.initial", "org.apache.camel.util.jndi.CamelInitialContextFactory");
+        }
+        return new InitialContext(new Hashtable<>(properties));
+    }
+
+    private CamelContext createCamelContext() throws Exception {
+        return new DefaultCamelContext(createRegistry());
+    }
+
+    private RoutesBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:in").to("mock:before").idempotentConsumer(header("id")).messageIdRepositoryRef(
+                        "kafkaIdempotentRepository").to("mock:out").end();
+            }
+        };
+    }
+}

--- a/notifications/camel-producer/src/test/resources/docker-compose.yml
+++ b/notifications/camel-producer/src/test/resources/docker-compose.yml
@@ -1,0 +1,61 @@
+version: "3"
+
+services:
+  zoo1:
+    image: zookeeper:3.5
+    container_name: zoo1
+    restart: always
+    hostname: zoo1
+    ports:
+       - "2181:2181"
+       - "8500:8090"
+    environment:
+        ZOO_MY_ID: 1
+        ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2182 server.3=zoo3:2888:3888;2183
+
+  zoo2:
+    image: zookeeper:3.5
+    restart: always
+    hostname: zoo2
+    ports:
+       - "2182:2181"
+    environment:
+        ZOO_MY_ID: 2
+        ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2182 server.3=zoo3:2888:3888;2183
+
+  zoo3:
+    image: zookeeper:3.5
+    restart: always
+    hostname: zoo3
+    ports:
+       - "2183:2181"
+    environment:
+        ZOO_MY_ID: 3
+        ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2182 server.3=zoo3:2888:3888;2183
+
+  kafka:
+    image: trellisldp/kafka:1.1.0
+    ports:
+        - "9094:9094"
+        - "1099:1099"
+    environment:
+      HOSTNAME_COMMAND: "ifconfig|grep inet|head -1|sed 's/\\:/ /'|awk '{print $$3}'"
+      KAFKA_ZOOKEEPER_CONNECT: zoo1:2181
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://_{HOSTNAME_COMMAND}:9094
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+     # KAFKA_JMX_OPTS: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.rmi.port=1099"
+     # JMX_PORT: 1099
+      KAFKA_MESSAGE_MAX_BYTES: 5000000
+    volumes:
+      - kafka-data-volume:/kafka
+
+volumes:
+  kafka-data-volume:
+    driver_opts:
+      type: none
+      device: /mnt/kafka-data
+      o: bind
+
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ include ':trellis-vocabulary'
 include ':trellis-amqp'
 include ':trellis-jms'
 include ':trellis-kafka'
+include ':trellis-camel-producer'
 
 include ':trellis-agent'
 include ':trellis-audit'
@@ -34,6 +35,7 @@ project(':trellis-vocabulary').projectDir = "$rootDir/core/vocabulary" as File
 project(':trellis-amqp').projectDir = "$rootDir/notifications/amqp" as File
 project(':trellis-jms').projectDir = "$rootDir/notifications/jms" as File
 project(':trellis-kafka').projectDir = "$rootDir/notifications/kafka" as File
+project(':trellis-camel-producer').projectDir = "$rootDir/notifications/camel-producer" as File
 
 project(':trellis-agent').projectDir = "$rootDir/components/agent" as File
 project(':trellis-app').projectDir = "$rootDir/components/app" as File


### PR DESCRIPTION
note: the test requires a running Kafka instance, so CI will fail.  Included in resources is a docker-compose for this, but it is not integrated into the test.  This could also be done with an embedded broker and zookeeper.
Other tests can be added for different idempotent repository contexts.

closes #145 
