### PR TITLE
Convert from maven to maven-publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,11 @@ ext {
             'trellis-webac',
             'trellis-webapp'
     ]
+
+    omitFromMavenPublishing = [
+        'trellis-linux',
+        'trellis-webapp'
+    ]
 }
 
 allprojects { subproj ->
@@ -93,7 +98,6 @@ allprojects { subproj ->
     apply plugin: 'com.github.hierynomus.license'
     apply plugin: 'jacoco'
     apply plugin: 'java'
-    apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
 
@@ -198,79 +202,151 @@ subprojects { subproj ->
 
     publishing {
         publications {
-            maven(MavenPublication) {
+            mavenJava(MavenPublication) {
+                pom.packaging = 'jar'
+
+                pom.withXml {
+                    def root = asNode()
+
+                    // eliminate test-scoped dependencies
+                    root.dependencies.removeAll { dep -> dep.scope == "test" }
+
+                    // add items for maven central
+                    root.children().last() + {
+                        resolveStrategy = Closure.DELEGATE_FIRST
+                        url 'https://www.trellisldp.org'
+                        inceptionYear '2017'
+                        name 'Trellis Linked Data Server'
+                        description 'The core components for a Trellis linked data server'
+
+                        organization {
+                            name project.vendor
+                            url project.homepage
+                        }
+
+                        developers {
+                            developer {
+                                id 'acoburn'
+                                name 'Aaron Coburn'
+                                email 'acoburn (at) apache (dot) org'
+                                roles {
+                                    role 'developer'
+                                }
+                                timezone '-5'
+                            }
+                        }
+
+                        scm {
+                            connection 'scm:git:git://github.com/trellis-ldp/trellis.git'
+                            developerConnection 'scm:git:git@github.com/trellis-ldp/trellis.git'
+                            url 'https://github.com/trellis-ldp/trellis'
+                            tag 'HEAD'
+                        }
+
+                        licenses {
+                            license {
+                                name 'Apache License, Version 2.0'
+                                url 'http://www.apache.org/licenses/LICENSE-2.0'
+                                comments 'Copyright (c) 2017-2018 Trellis LDP'
+                            }
+                        }
+                    }
+
+                    def pomFile = file("${project.buildDir}/generated-pom.xml")
+                    writeTo(pomFile)
+                    def pomAscFile = signing.sign(pomFile).signatureFiles[0]
+                    if (pomAscFile.file) {
+                        artifact(pomAscFile) {
+                            classifier = null
+                            extension = 'pom.asc'
+                        }
+                    }
+                }
+
                 from components.java
+
+                artifact(sourceJar) {
+                    classifier = 'sources'
+                }
+
+                artifact(javadocJar) {
+                    classifier = 'javadoc'
+                }
+
+                project.tasks.signArchives.signatureFiles.each {
+                    if (it.file) {
+                        def matcher = it =~ /-(sources|javadoc|features|configuration)\.(jar|xml|cfg)\.asc$/
+                        if (matcher.find()) {
+                            artifact(it) {
+                                classifier = matcher.group(1)
+                                extension = matcher.group(2) + ".asc"
+                            }
+                        } else if (it.getPath().endsWith('.jar.asc')) {
+                            artifact(it) {
+                                classifier = null
+                                extension = "jar.asc"
+                            }
+                        } else if (it.getPath().endsWith(".war.asc")) {
+                            artifact(it) {
+                                classifier = null
+                                extension = "war.asc"
+                            }
+                        }
+                    }
+                }
             }
         }
+        repositories {
+            maven {
+                def sonatypeUsername = project.hasProperty('ossrhUsername') ? ossrhUsername : ""
+                def sonatypePassword = project.hasProperty('ossrhPassword') ? ossrhPassword : ""
+                if (version.endsWith("SNAPSHOT")) {
+                    url "https://oss.sonatype.org/content/repositories/snapshots/"
+                } else {
+                    url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                }
+                credentials {
+                    username sonatypeUsername
+                    password sonatypePassword
+                }
+            }
+        }
+    }
+
+    model {
+        tasks.generatePomFileForMavenJavaPublication {
+            destination = file("$buildDir/generated-pom.xml")
+        }
+        tasks.publishMavenJavaPublicationToMavenLocal {
+            dependsOn project.tasks.signArchives
+        }
+        tasks.publishMavenJavaPublicationToMavenRepository {
+            dependsOn project.tasks.signArchives
+        }
+    }
+
+    tasks.withType(PublishToMavenRepository) {
+        onlyIf {
+            ! omitFromMavenPublishing.contains(subproj.name)
+        }
+    }
+    tasks.withType(PublishToMavenLocal) {
+        onlyIf {
+            ! omitFromMavenPublishing.contains(subproj.name)
+        }
+    }
+    task install(dependsOn: [assemble, publishToMavenLocal])
+    task upload(dependsOn: [assemble, publish])
+
+    signing {
+        required { !version.endsWith("SNAPSHOT") && gradle.taskGraph.hasTask("publish") }
+        sign configurations.archives
     }
 
     processResources {
         outputs.upToDateWhen { false }
         filesMatching(['**/features.xml', '**/banner.txt']) {
             expand project.properties
-        }
-    }
-
-    signing {
-        required { !version.endsWith("SNAPSHOT") && gradle.taskGraph.hasTask("uploadArchives") }
-        sign configurations.archives
-    }
-
-    uploadArchives {
-        repositories.mavenDeployer {
-            def sonatypeUsername = project.hasProperty('ossrhUsername') ? ossrhUsername : ""
-            def sonatypePassword = project.hasProperty('ossrhPassword') ? ossrhPassword : ""
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: sonatypeUsername, password: sonatypePassword)
-            }
-
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: sonatypeUsername, password: sonatypePassword)
-            }
-
-            pom.project {
-                packaging 'jar'
-                url 'https://www.trellisldp.org'
-                inceptionYear '2017'
-                name 'Trellis Linked Data Server'
-                description 'The core components for a Trellis linked data server'
-
-                organization {
-                    name project.vendor
-                    url project.homepage
-                }
-
-                developers {
-                    developer {
-                        id 'acoburn'
-                        name 'Aaron Coburn'
-                        email 'acoburn (at) apache (dot) org'
-                        organization = 'Trellis LDP'
-                        organizationUrl 'https://www.trellisldp.org'
-                        roles {
-                            role 'developer'
-                        }
-                        timezone '-5'
-                    }
-                }
-
-                scm {
-                    connection 'scm:git:git://github.com/trellis-ldp/trellis.git'
-                    developerConnection 'scm:git:git@github.com/trellis-ldp/trellis.git'
-                    url 'https://github.com/trellis-ldp/trellis'
-                    tag 'HEAD'
-                }
-
-                licenses {
-                    license {
-                        name 'Apache License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0'
-                        comments 'Copyright (c) 2017-2018 Trellis LDP'
-                    }
-                }
-            }
         }
     }
 

--- a/components/file/build.gradle
+++ b/components/file/build.gradle
@@ -44,10 +44,12 @@ jar {
     }
 }
 
-artifacts {
-    archives (file('build/cfg/main/org.trellisldp.file.cfg')) {
-        classifier 'configuration'
-        type 'cfg'
+publishing.publications {
+    maven(MavenPublication) {
+        artifact ('build/cfg/main/org.trellisldp.file.cfg') {
+            classifier 'configuration'
+            extension 'cfg'
+        }
     }
 }
 

--- a/components/io-jena/build.gradle
+++ b/components/io-jena/build.gradle
@@ -38,10 +38,11 @@ jar {
     }
 }
 
-artifacts {
-    archives (file('build/cfg/main/org.trellisldp.io.cfg')) {
-        classifier 'configuration'
-        type 'cfg'
+publishing.publications {
+    maven(MavenPublication) {
+        artifact('build/cfg/main/org.trellisldp.io.cfg') {
+            classifier 'configuration'
+            extension 'cfg'
+        }
     }
 }
-

--- a/components/namespaces/build.gradle
+++ b/components/namespaces/build.gradle
@@ -33,14 +33,15 @@ jar {
     }
 }
 
-artifacts {
-    archives (file('build/cfg/main/org.trellisldp.namespaces.cfg')) {
-        classifier 'configuration'
-        type 'cfg'
-    }
-    archives (file('build/resources/main/defaultNamespaces.json')) {
-        classifier 'configuration'
-        type 'json'
+publishing.publications {
+    maven(MavenPublication) {
+        artifact (file('build/cfg/main/org.trellisldp.namespaces.cfg')) {
+            classifier 'configuration'
+            extension 'cfg'
+        }
+        artifact (file('build/resources/main/defaultNamespaces.json')) {
+            classifier 'configuration'
+            extension 'json'
+        }
     }
 }
-

--- a/notifications/jms/build.gradle
+++ b/notifications/jms/build.gradle
@@ -44,10 +44,12 @@ jar {
     }
 }
 
-artifacts {
-    archives (file('build/cfg/main/org.trellisldp.jms.cfg')) {
-        classifier 'configuration'
-        type 'cfg'
+publishing.publications {
+    maven(MavenPublication) {
+        artifact ('build/cfg/main/org.trellisldp.jms.cfg') {
+            classifier 'configuration'
+            extension 'cfg'
+        }
     }
 }
 

--- a/platform/karaf/build.gradle
+++ b/platform/karaf/build.gradle
@@ -6,9 +6,11 @@ processResources {
     expand project.properties
 }
 
-artifacts {
-    archives (file('build/resources/main/features.xml')) {
-        classifier 'features'
-        type 'xml'
+publishing.publications {
+    maven(MavenPublication) {
+        artifact ('build/resources/main/features.xml') {
+            classifier 'features'
+            extension 'xml'
+        }
     }
 }

--- a/platform/linux/build.gradle
+++ b/platform/linux/build.gradle
@@ -68,20 +68,18 @@ signing {
     sign distZip
 }
 
-install {
-    enabled = false
-}
-
-uploadArchives {
-    // There is no need to store these artifacts on maven central
-    enabled = false
-}
-
 task copyDistTask(type: Copy) {
     from '../LICENSE'
     from 'README.md'
     into 'src/dist'
 }
 
-assembleDist.dependsOn copyDistTask
+assembleDist {
+    dependsOn copyDistTask
+    dependsOn buildRpm
+    dependsOn buildDeb
+    dependsOn signArchives
+    dependsOn signBuildRpm
+    dependsOn signBuildDeb
+}
 

--- a/platform/osgi/build.gradle
+++ b/platform/osgi/build.gradle
@@ -124,10 +124,12 @@ jar {
     }
 }
 
-artifacts {
-    archives (file('build/cfg/main/org.trellisldp.osgi.cfg')) {
-        classifier 'configuration'
-        type 'cfg'
+publishing.publications {
+    maven(MavenPublication) {
+        artifact ('build/cfg/main/org.trellisldp.osgi.cfg') {
+            classifier 'configuration'
+            extension 'cfg'
+        }
     }
 }
 

--- a/platform/webapp/build.gradle
+++ b/platform/webapp/build.gradle
@@ -35,11 +35,6 @@ dependencies {
     testRuntimeClasspath("ch.qos.logback:logback-classic:$logbackVersion")
 }
 
-uploadArchives {
-    // There is no need to store these artifacts on maven central
-    enabled = false
-}
-
 test {
     systemProperty 'trellis.file.memento.basepath', "$buildDir/data/mementos"
     systemProperty 'trellis.file.binary.basepath', "$buildDir/data/binaries"


### PR DESCRIPTION
Resolves #149 

With Gradle 4.8 (we currently use 4.7 for this project), the `maven` plugin becomes deprecated in favor of the `maven-publish` plugin. This PR converts to using the new plugin. The changes primarily relate to signing, POM generation along with a few other items. Because I'm so used to issuing `gradle install` and `gradle upload`, this also aliases the relevant tasks to those commands.