### PR TITLE
Separate MementoService and ResourceService

### DIFF
--- a/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/TrellisApplication.java
+++ b/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/TrellisApplication.java
@@ -112,7 +112,7 @@ public class TrellisApplication extends AbstractTrellisApplication<AppConfigurat
 
         // Health checks
         environment.healthChecks().register("rdfconnection", new RDFConnectionHealthCheck(rdfConnection));
-        return new TriplestoreResourceService(rdfConnection, idService, mementoService, notificationService);
+        return new TriplestoreResourceService(rdfConnection, idService, notificationService);
     }
 
     private IOService buildIoService(final AppConfiguration config) {

--- a/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/TrellisApplication.java
+++ b/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/TrellisApplication.java
@@ -55,6 +55,8 @@ public class TrellisApplication extends AbstractTrellisApplication<AppConfigurat
 
     private IOService ioService;
 
+    private MementoService mementoService;
+
     /**
      * The main entry point.
      *
@@ -81,6 +83,11 @@ public class TrellisApplication extends AbstractTrellisApplication<AppConfigurat
     }
 
     @Override
+    protected Optional<MementoService> getMementoService() {
+        return of(mementoService);
+    }
+
+    @Override
     protected Optional<AuditService> getAuditService() {
         return of(resourceService);
     }
@@ -91,6 +98,7 @@ public class TrellisApplication extends AbstractTrellisApplication<AppConfigurat
 
         final IdentifierService idService = new UUIDGenerator();
 
+        this.mementoService = new FileMementoService(config.getMementos());
         this.resourceService = buildResourceService(idService, config, environment);
         this.binaryService = buildBinaryService(idService, config);
         this.ioService = buildIoService(config);
@@ -98,7 +106,6 @@ public class TrellisApplication extends AbstractTrellisApplication<AppConfigurat
 
     private TriplestoreResourceService buildResourceService(final IdentifierService idService,
             final AppConfiguration config, final Environment environment) {
-        final MementoService mementoService = new FileMementoService(config.getMementos());
         final RDFConnection rdfConnection = AppUtils.getRDFConnection(config);
         final EventService notificationService = AppUtils.getNotificationService(config.getNotifications(),
                 environment);

--- a/components/app/src/main/java/org/trellisldp/app/AbstractTrellisApplication.java
+++ b/components/app/src/main/java/org/trellisldp/app/AbstractTrellisApplication.java
@@ -35,7 +35,9 @@ import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.NoopAuditService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.app.config.BasicAuthConfiguration;
 import org.trellisldp.app.config.JwtAuthConfiguration;
@@ -83,6 +85,15 @@ public abstract class AbstractTrellisApplication<T extends TrellisConfiguration>
     protected abstract BinaryService getBinaryService();
 
     /**
+     * Get an optional {@link MementoService}. There should be at most one
+     * {@code MementoService} in a deployed Trellis instance. If there is one, this
+     * method should return the same {@code MementosService} every time it is called.
+     *
+     * @return an {@code MementoService}, if one exists
+     */
+    protected abstract Optional<MementoService> getMementoService();
+
+    /**
      * Get an optional {@link AuditService}. There should be at most one
      * {@code AuditService} in a deployed Trellis instance. If there is one, this
      * method should return the same {@code AuditService} every time it is called.
@@ -128,7 +139,8 @@ public abstract class AbstractTrellisApplication<T extends TrellisConfiguration>
 
         // Resource matchers
         environment.jersey().register(new LdpResource(getResourceService(), getIOService(), getBinaryService(),
-                    agentService, getAuditService().orElseGet(NoopAuditService::new), config.getBaseUrl()));
+                    agentService, getMementoService().orElseGet(NoopMementoService::new),
+                    getAuditService().orElseGet(NoopAuditService::new), config.getBaseUrl()));
 
         // Authentication
         final AgentAuthorizationFilter agentFilter = new AgentAuthorizationFilter(agentService);

--- a/components/app/src/test/java/org/trellisldp/app/SimpleTrellisApp.java
+++ b/components/app/src/test/java/org/trellisldp/app/SimpleTrellisApp.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.NoopEventService;
 import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.NoopNamespaceService;
@@ -62,6 +63,11 @@ public class SimpleTrellisApp extends AbstractTrellisApplication<TrellisConfigur
 
     @Override
     protected Optional<AuditService> getAuditService() {
+        return empty();
+    }
+
+    @Override
+    protected Optional<MementoService> getMementoService() {
         return empty();
     }
 

--- a/components/app/src/test/java/org/trellisldp/app/SimpleTrellisApp.java
+++ b/components/app/src/test/java/org/trellisldp/app/SimpleTrellisApp.java
@@ -28,7 +28,6 @@ import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.MementoService;
 import org.trellisldp.api.NoopEventService;
-import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.NoopNamespaceService;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.app.config.TrellisConfiguration;
@@ -77,6 +76,6 @@ public class SimpleTrellisApp extends AbstractTrellisApplication<TrellisConfigur
         ioService = new JenaIOService(new NoopNamespaceService(), null, null, emptySet(), emptySet());
         binaryService = new FileBinaryService(new UUIDGenerator(), resourceFilePath("data") + "/binaries", 2, 2);
         resourceService = new TriplestoreResourceService(connect(createTxnMem()), new UUIDGenerator(),
-                new NoopMementoService(), new NoopEventService());
+                new NoopEventService());
     }
 }

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -642,11 +642,6 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public Optional<Resource> get(final IRI identifier, final Instant time) {
-        return mementoService.isPresent() ? mementoService.flatMap(svc -> svc.get(identifier, time)) : get(identifier);
-    }
-
-    @Override
     public Optional<Resource> get(final IRI identifier) {
         return TriplestoreResource.findResource(rdfConnection, identifier);
     }

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -61,7 +61,6 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
@@ -234,11 +233,6 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
             throw new RuntimeTrellisException(ex);
         }
         return true;
-    }
-
-    @Override
-    public List<Range<Instant>> getMementos(final IRI identifier) {
-        return mementoService.map(svc -> svc.list(identifier)).orElse(emptyList());
     }
 
     private void emitEvents(final IRI identifier, final Session session, final OperationType opType,

--- a/components/triplestore/src/main/resources/OSGI-INF/blueprint/trellis-triplestore.xml
+++ b/components/triplestore/src/main/resources/OSGI-INF/blueprint/trellis-triplestore.xml
@@ -17,12 +17,10 @@
     <!--<reference id="eventService" interface="org.trellisldp.api.EventService"/>-->
 
     <reference id="idService" interface="org.trellisldp.api.IdentifierService"/>
-    <reference id="mementoService" interface="org.trellisldp.api.MementoService"/>
 
     <bean id="resourceService" class="org.trellisldp.triplestore.TriplestoreResourceService">
       <argument ref="rdfConnection"/>
       <argument ref="idService"/>
-      <argument ref="mementoService"/>
       <argument ref="eventService"/>
     </bean>
 

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/ResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/ResourceServiceTest.java
@@ -19,9 +19,9 @@ import static org.apache.jena.rdfconnection.RDFConnectionFactory.connect;
 import org.apache.commons.rdf.jena.JenaDataset;
 import org.apache.commons.rdf.jena.JenaRDF;
 import org.apache.jena.rdfconnection.RDFConnection;
+import org.trellisldp.api.EventService;
 import org.trellisldp.api.IdentifierService;
 import org.trellisldp.api.NoopEventService;
-import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
 import org.trellisldp.id.UUIDGenerator;
@@ -34,11 +34,11 @@ public class ResourceServiceTest extends AbstractResourceServiceTests {
 
     private static final JenaRDF rdf = new JenaRDF();
     private static final IdentifierService idService = new UUIDGenerator();
+    private static final EventService eventService = new NoopEventService();
 
     private final JenaDataset dataset = rdf.createDataset();
     private final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-    private final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                new NoopMementoService(), new NoopEventService());
+    private final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, eventService);
     private final Session session = new SimpleSession(rdf.createIRI("user:test"));
 
     @Override

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -52,7 +52,6 @@ import org.mockito.Mock;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IdentifierService;
-import org.trellisldp.api.MementoService;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
 import org.trellisldp.id.UUIDGenerator;
@@ -92,9 +91,6 @@ public class TriplestoreResourceServiceTest {
     @Mock
     private RDFConnection mockRdfConnection;
 
-    @Mock
-    private MementoService mockMementoService;
-
     @BeforeEach
     public void setUp() {
         initMocks(this);
@@ -108,8 +104,7 @@ public class TriplestoreResourceServiceTest {
     public void testIdentifierService() {
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
         assertNotEquals(svc.generateIdentifier(), svc.generateIdentifier());
         assertNotEquals(svc.generateIdentifier(), svc.generateIdentifier());
     }
@@ -118,8 +113,7 @@ public class TriplestoreResourceServiceTest {
     public void testResourceNotFound() {
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
         assertFalse(svc.get(rdf.createIRI(TRELLIS_DATA_PREFIX + "missing")).isPresent());
     }
 
@@ -134,8 +128,7 @@ public class TriplestoreResourceServiceTest {
         dataset.add(Trellis.PreferServerManaged, three, RDF.type, LDP.RDFSource);
 
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
         assertEquals(4L, svc.scan().count());
         assertTrue(svc.scan().anyMatch(t -> t.getSubject().equals(root) && t.getObject().equals(LDP.BasicContainer)));
         assertTrue(svc.scan().anyMatch(t -> t.getSubject().equals(one) && t.getObject().equals(LDP.Container)));
@@ -148,8 +141,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         assertTrue(svc.get(root).isPresent());
         svc.get(root).ifPresent(res -> {
@@ -172,8 +164,7 @@ public class TriplestoreResourceServiceTest {
         dataset.add(Trellis.PreferServerManaged, root, DC.modified, rdf.createLiteral(early.toString(), XSD.dateTime));
 
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         assertTrue(svc.get(root).isPresent());
         svc.get(root).ifPresent(res -> {
@@ -194,8 +185,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         assertTrue(svc.get(root).isPresent());
         svc.get(root).ifPresent(res -> {
@@ -240,8 +230,7 @@ public class TriplestoreResourceServiceTest {
 
     @Test
     public void testRDFConnectionError() throws Exception {
-        final ResourceService svc = new TriplestoreResourceService(mockRdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(mockRdfConnection, idService, mockEventService);
         doThrow(new RuntimeException("Expected exception")).when(mockRdfConnection).update(any(UpdateRequest.class));
         doThrow(new RuntimeException("Expected exception")).when(mockRdfConnection)
             .loadDataset(any(org.apache.jena.query.Dataset.class));
@@ -255,8 +244,7 @@ public class TriplestoreResourceServiceTest {
     @Test
     public void testGetContainer() {
         final RDFConnection rdfConnection = connect(wrap(rdf.createDataset().asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI child = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource/child");
@@ -272,8 +260,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final BlankNode acl = rdf.createBlankNode();
@@ -312,8 +299,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final Dataset dataset = rdf.createDataset();
@@ -349,8 +335,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI binaryIdentifier = rdf.createIRI("foo:binary");
@@ -432,8 +417,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final Dataset dataset = rdf.createDataset();
@@ -554,8 +538,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final Dataset dataset1 = rdf.createDataset();
@@ -599,8 +582,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final Dataset dataset = rdf.createDataset();
@@ -722,8 +704,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final Dataset dataset = rdf.createDataset();
@@ -846,8 +827,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final Dataset dataset = rdf.createDataset();
@@ -937,8 +917,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI members = rdf.createIRI(TRELLIS_DATA_PREFIX + "members");
@@ -1075,8 +1054,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI members = rdf.createIRI(TRELLIS_DATA_PREFIX + "members");
@@ -1310,8 +1288,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI members = rdf.createIRI(TRELLIS_DATA_PREFIX + "members");
@@ -1542,8 +1519,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI members = rdf.createIRI(TRELLIS_DATA_PREFIX + "members");
@@ -1682,8 +1658,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI members = rdf.createIRI(TRELLIS_DATA_PREFIX + "members");
@@ -1822,8 +1797,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI members = rdf.createIRI(TRELLIS_DATA_PREFIX + "members");
@@ -1968,8 +1942,7 @@ public class TriplestoreResourceServiceTest {
         final Instant early = now();
         final JenaDataset d = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(d.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
+        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
 
         final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final IRI members = rdf.createIRI(TRELLIS_DATA_PREFIX + "members");

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -115,25 +115,12 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testNoMementoService() {
-        final JenaDataset dataset = rdf.createDataset();
-        final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                null, mockEventService);
-        final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
-        final Instant time = now();
-        svc.get(identifier, time).ifPresent(res -> assertFalse(res.isMemento()));
-        assertEquals(svc.get(identifier), svc.get(identifier, time));
-    }
-
-    @Test
     public void testResourceNotFound() {
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
         final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
                 mockMementoService, mockEventService);
         assertFalse(svc.get(rdf.createIRI(TRELLIS_DATA_PREFIX + "missing")).isPresent());
-        assertFalse(svc.get(rdf.createIRI(TRELLIS_DATA_PREFIX + "missing"), now()).isPresent());
     }
 
     @Test

--- a/core/api/src/main/java/org/trellisldp/api/MementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MementoService.java
@@ -36,6 +36,14 @@ public interface MementoService {
     void put(IRI identifier, Instant time, Stream<? extends Quad> data);
 
     /**
+     * Create a new Memento for a resource.
+     * @param resource the resource
+     */
+    default void put(Resource resource) {
+        put(resource.getIdentifier(), resource.getModified(), resource.stream());
+    }
+
+    /**
      * Fetch a Memento resource for the given time.
      * @param identifier the resource identifier
      * @param time the requested time

--- a/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
@@ -36,6 +36,11 @@ public class NoopMementoService implements MementoService {
     }
 
     @Override
+    public void put(final Resource resource) {
+        // no-op
+    }
+
+    @Override
     public Optional<Resource> get(final IRI identifier, final Instant time) {
         return empty();
     }

--- a/core/api/src/main/java/org/trellisldp/api/Resource.java
+++ b/core/api/src/main/java/org/trellisldp/api/Resource.java
@@ -145,13 +145,13 @@ public interface Resource {
     /**
      * Test whether this resource is a Memento resource. {@code Resource}s retrieved
      * from {@link ResourceService#get(IRI)} should return {@code false} here, and
-     * {@code Resource}s retrieved from {@link ResourceService#get(IRI, Instant)}
+     * {@code Resource}s retrieved from {@link MementoService#get(IRI, Instant)}
      * should return {@code true}.
      *
      * @return {@code true} if this is a Memento resource; {@code false} otherwise
-     * 
+     *
      * @see ResourceService#get(IRI)
-     * @see ResourceService#get(IRI, Instant)
+     * @see MementoService#get(IRI, Instant)
      */
     default Boolean isMemento() {
         return false;

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -20,12 +20,10 @@ import static org.trellisldp.api.RDFUtils.getInstance;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.BlankNode;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
@@ -54,16 +52,6 @@ public interface ResourceService extends MutableDataService<Resource>, Immutable
         return of(path).filter(p -> !p.isEmpty()).map(x -> x.lastIndexOf('/')).map(idx -> idx < 0 ? 0 : idx)
                     .map(idx -> TRELLIS_DATA_PREFIX + path.substring(0, idx)).map(getInstance()::createIRI);
     }
-
-    /**
-     * Retrieve a list of Mementos for this resource.
-     *
-     * @param identifier the resource identifier
-     * @return a {@link List} of {@link Range}s of {@link Instant}s.
-     * Each element of the list can be used to build a link header for a single Memento
-     * (i.e. for the {@code from} and {@code until} parameters)
-     */
-    List<Range<Instant>> getMementos(IRI identifier);
 
     /**
      * Scan the resources.

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -18,7 +18,6 @@ import static org.trellisldp.api.RDFUtils.TRELLIS_BNODE_PREFIX;
 import static org.trellisldp.api.RDFUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.api.RDFUtils.getInstance;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;

--- a/core/api/src/main/java/org/trellisldp/api/RetrievalService.java
+++ b/core/api/src/main/java/org/trellisldp/api/RetrievalService.java
@@ -14,7 +14,6 @@
 
 package org.trellisldp.api;
 
-import java.time.Instant;
 import java.util.Optional;
 
 import org.apache.commons.rdf.api.IRI;
@@ -22,7 +21,7 @@ import org.apache.commons.rdf.api.IRI;
 /**
  * A service that can retrieve resources of some type, featuring optional
  * retrieval by time.
- * 
+ *
  * @author ajs6f
  * @param <T> the type of resource available from this service
  */
@@ -35,15 +34,4 @@ public interface RetrievalService<T> {
      * @return the resource
      */
     Optional<? extends T> get(IRI identifier);
-
-    /**
-     * Get a resource by the given identifier and time.
-     *
-     * @param identifier the resource identifier
-     * @param time the time
-     * @return the resource
-     */
-    default Optional<? extends T> get(IRI identifier, Instant time) {
-        return get(identifier);
-    }
 }

--- a/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -26,9 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -37,7 +35,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
@@ -130,11 +127,6 @@ public class JoiningResourceServiceTest {
         public TestableJoiningResourceService(final ImmutableDataService<Resource> immutableData,
                         final MutableDataService<Resource> mutableData) {
             super(mutableData, immutableData);
-        }
-
-        @Override
-        public List<Range<Instant>> getMementos(final IRI identifier) {
-            return Collections.emptyList();
         }
 
         @Override

--- a/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.api;
 
-import static java.time.Instant.now;
 import static java.util.Arrays.asList;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toList;
@@ -27,7 +26,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.vocabulary.RDF.type;
 
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -83,7 +81,6 @@ public class ResourceServiceTest {
         doCallRealMethod().when(mockResourceService).toExternal(any(), any());
 
         when(mockRetrievalService.get(eq(existing))).thenAnswer(inv -> of(mockResource));
-        doCallRealMethod().when(mockRetrievalService).get(any(IRI.class), any(Instant.class));
 
         when(mockResourceService.scan()).thenAnswer(inv ->
             asList(rdf.createTriple(existing, type, LDP.Container)).stream());
@@ -93,21 +90,15 @@ public class ResourceServiceTest {
     public void testRetrievalService2() {
         final RetrievalService<Resource> svc = new MyRetrievalService();
         final Optional<? extends Resource> res = svc.get(existing);
-        final Optional<? extends Resource> res2 = svc.get(existing, now());
         assertTrue(res.isPresent());
         assertEquals(mockResource, res.get());
-        assertTrue(res2.isPresent());
-        assertEquals(mockResource, res2.get());
     }
 
     @Test
     public void testRetrievalService() {
         final Optional<? extends Resource> res = mockRetrievalService.get(existing);
-        final Optional<? extends Resource> res2 = mockRetrievalService.get(existing, now());
         assertTrue(res.isPresent());
         assertEquals(mockResource, res.get());
-        assertTrue(res2.isPresent());
-        assertEquals(mockResource, res2.get());
     }
 
     @Test

--- a/core/http/src/main/java/org/trellisldp/http/LdpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/LdpResource.java
@@ -70,6 +70,8 @@ import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.http.domain.AcceptDatetime;
@@ -118,6 +120,8 @@ public class LdpResource implements ContainerRequestFilter {
 
     protected final AgentService agentService;
 
+    protected final MementoService mementoService;
+
     protected final String baseUrl;
 
     /**
@@ -130,7 +134,9 @@ public class LdpResource implements ContainerRequestFilter {
      */
     public LdpResource(final ResourceService resourceService, final IOService ioService,
             final BinaryService binaryService, final AgentService agentService) {
-        this(resourceService, ioService, binaryService, agentService, loadFirst(AuditService.class).orElse(none()));
+        this(resourceService, ioService, binaryService, agentService,
+                loadFirst(MementoService.class).orElseGet(NoopMementoService::new),
+                loadFirst(AuditService.class).orElse(none()));
     }
 
     /**
@@ -140,12 +146,14 @@ public class LdpResource implements ContainerRequestFilter {
      * @param ioService the i/o service
      * @param binaryService the datastream service
      * @param agentService the user agent service
+     * @param mementoService the memento service
      * @param auditService an audit service
      */
     @Inject
     public LdpResource(final ResourceService resourceService, final IOService ioService,
-            final BinaryService binaryService, final AgentService agentService, final AuditService auditService) {
-        this(resourceService, ioService, binaryService, agentService, auditService,
+            final BinaryService binaryService, final AgentService agentService,
+            final MementoService mementoService, final AuditService auditService) {
+        this(resourceService, ioService, binaryService, agentService, mementoService, auditService,
                 ConfigurationProvider.getConfiguration().get(CONFIGURATION_BASE_URL));
     }
 
@@ -157,17 +165,19 @@ public class LdpResource implements ContainerRequestFilter {
      * @param binaryService the datastream service
      * @param agentService the user agent service
      * @param auditService an audit service
+     * @param mementoService the memento service
      * @param baseUrl a base URL
      */
     public LdpResource(final ResourceService resourceService, final IOService ioService,
-            final BinaryService binaryService, final AgentService agentService, final AuditService auditService,
-            final String baseUrl) {
+            final BinaryService binaryService, final AgentService agentService, final MementoService mementoService,
+            final AuditService auditService, final String baseUrl) {
         this.baseUrl = baseUrl;
         this.resourceService = resourceService;
         this.ioService = ioService;
         this.binaryService = binaryService;
         this.agentService = agentService;
         this.auditService = auditService;
+        this.mementoService = mementoService;
     }
 
 
@@ -269,7 +279,8 @@ public class LdpResource implements ContainerRequestFilter {
     private Response fetchResource(final LdpRequest req) {
         final String urlBase = getBaseUrl(req);
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + req.getPath());
-        final GetHandler getHandler = new GetHandler(req, resourceService, ioService, binaryService, urlBase);
+        final GetHandler getHandler = new GetHandler(req, resourceService, ioService, binaryService, mementoService,
+                urlBase);
 
         // Fetch a versioned resource
         if (nonNull(req.getVersion())) {
@@ -281,14 +292,14 @@ public class LdpResource implements ContainerRequestFilter {
         } else if (TIMEMAP.equals(req.getExt())) {
             LOGGER.debug("Getting timemap resource: {}", req.getPath());
             return resourceService.get(identifier)
-                .map(res -> new MementoResource(resourceService).getTimeMapBuilder(req, ioService, urlBase))
+                .map(res -> new MementoResource(mementoService).getTimeMapBuilder(req, ioService, urlBase))
                 .orElseGet(() -> status(NOT_FOUND)).build();
 
         // Fetch a timegate
         } else if (nonNull(req.getDatetime())) {
             LOGGER.debug("Getting timegate resource: {}", req.getDatetime().getInstant());
             return resourceService.get(identifier, req.getDatetime().getInstant())
-                .map(res -> new MementoResource(resourceService).getTimeGateBuilder(req, urlBase))
+                .map(res -> new MementoResource(mementoService).getTimeGateBuilder(req, urlBase))
                 .orElseGet(() -> status(NOT_FOUND)).build();
         }
 
@@ -310,7 +321,8 @@ public class LdpResource implements ContainerRequestFilter {
 
         final String urlBase = getBaseUrl(req);
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + req.getPath());
-        final OptionsHandler optionsHandler = new OptionsHandler(req, resourceService, ioService, urlBase);
+        final OptionsHandler optionsHandler = new OptionsHandler(req, resourceService, ioService, mementoService,
+                urlBase);
 
         if (nonNull(req.getVersion())) {
             return resourceService.get(identifier, req.getVersion().getInstant()).map(optionsHandler::ldpOptions)
@@ -336,7 +348,7 @@ public class LdpResource implements ContainerRequestFilter {
         final String urlBase = getBaseUrl(req);
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + req.getPath());
         final PatchHandler patchHandler = new PatchHandler(req, body, resourceService, auditService, ioService,
-                        agentService, urlBase);
+                        agentService, mementoService, urlBase);
 
         return resourceService.get(identifier).map(patchHandler::updateResource)
             .orElseGet(() -> status(NOT_FOUND)).build();
@@ -355,7 +367,7 @@ public class LdpResource implements ContainerRequestFilter {
         final String urlBase = getBaseUrl(req);
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + req.getPath());
         final DeleteHandler deleteHandler = new DeleteHandler(req, resourceService, auditService,
-                        agentService, urlBase);
+                        agentService, mementoService, urlBase);
 
         return resourceService.get(identifier).map(deleteHandler::deleteResource)
             .orElseGet(() -> status(NOT_FOUND)).build();
@@ -378,7 +390,7 @@ public class LdpResource implements ContainerRequestFilter {
             .orElseGet(resourceService::generateIdentifier);
 
         final PostHandler postHandler = new PostHandler(req, identifier, body, resourceService, auditService,
-                        ioService, binaryService, agentService, urlBase);
+                        ioService, binaryService, agentService, mementoService, urlBase);
         final String separator = path.isEmpty() ? "" : "/";
 
         // First check if this is a container
@@ -410,7 +422,7 @@ public class LdpResource implements ContainerRequestFilter {
         final String urlBase = getBaseUrl(req);
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + req.getPath());
         final PutHandler putHandler = new PutHandler(req, body, resourceService, auditService, ioService, binaryService,
-                        agentService, urlBase);
+                        agentService, mementoService, urlBase);
 
         return resourceService.get(identifier).filter(res -> !res.isDeleted())
             .map(putHandler::setResource).orElseGet(putHandler::createResource).build();

--- a/core/http/src/main/java/org/trellisldp/http/LdpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/LdpResource.java
@@ -285,7 +285,7 @@ public class LdpResource implements ContainerRequestFilter {
         // Fetch a versioned resource
         if (nonNull(req.getVersion())) {
             LOGGER.debug("Getting versioned resource: {}", req.getVersion());
-            return resourceService.get(identifier, req.getVersion().getInstant())
+            return mementoService.get(identifier, req.getVersion().getInstant())
                 .map(getHandler::getRepresentation).orElseGet(() -> status(NOT_FOUND)).build();
 
         // Fetch a timemap
@@ -298,7 +298,7 @@ public class LdpResource implements ContainerRequestFilter {
         // Fetch a timegate
         } else if (nonNull(req.getDatetime())) {
             LOGGER.debug("Getting timegate resource: {}", req.getDatetime().getInstant());
-            return resourceService.get(identifier, req.getDatetime().getInstant())
+            return mementoService.get(identifier, req.getDatetime().getInstant())
                 .map(res -> new MementoResource(mementoService).getTimeGateBuilder(req, urlBase))
                 .orElseGet(() -> status(NOT_FOUND)).build();
         }
@@ -325,7 +325,7 @@ public class LdpResource implements ContainerRequestFilter {
                 urlBase);
 
         if (nonNull(req.getVersion())) {
-            return resourceService.get(identifier, req.getVersion().getInstant()).map(optionsHandler::ldpOptions)
+            return mementoService.get(identifier, req.getVersion().getInstant()).map(optionsHandler::ldpOptions)
                 .orElseGet(() -> status(NOT_FOUND)).build();
         }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -40,6 +40,7 @@ import org.apache.commons.rdf.api.RDF;
 import org.slf4j.Logger;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.ConstraintService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.http.domain.LdpRequest;
@@ -66,20 +67,23 @@ public class BaseLdpHandler {
     private final String baseUrl;
     protected final LdpRequest req;
     protected final ResourceService resourceService;
+    protected final MementoService mementoService;
 
     /**
      * A base class for response handling.
      *
      * @param req the LDP request
      * @param resourceService the resource service
+     * @param mementoService the memento service
      * @param auditService an audit service
      * @param baseUrl the base URL
      */
-    public BaseLdpHandler(final LdpRequest req, final ResourceService resourceService, final AuditService auditService,
-                    final String baseUrl) {
+    public BaseLdpHandler(final LdpRequest req, final ResourceService resourceService,
+            final MementoService mementoService, final AuditService auditService, final String baseUrl) {
         this.baseUrl = baseUrl;
         this.req = req;
         this.resourceService = resourceService;
+        this.mementoService = mementoService;
         this.audit = auditService;
     }
 
@@ -93,7 +97,7 @@ public class BaseLdpHandler {
     protected void checkDeleted(final Resource res, final String identifier) {
         if (res.isDeleted()) {
             throw new WebApplicationException(status(GONE)
-                    .links(MementoResource.getMementoLinks(identifier, resourceService.getMementos(res.getIdentifier()))
+                    .links(MementoResource.getMementoLinks(identifier, mementoService.list(res.getIdentifier()))
                     .toArray(Link[]::new)).build());
         }
     }

--- a/core/http/src/main/java/org/trellisldp/http/impl/ContentBearingHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/ContentBearingHandler.java
@@ -45,6 +45,7 @@ import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.ConstraintViolation;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.http.domain.Digest;
@@ -75,12 +76,13 @@ class ContentBearingHandler extends BaseLdpHandler {
      * @param resourceService the resource service
      * @param auditService an audit service
      * @param ioService the serialization service
+     * @param mementoService the memento service
      * @param binaryService the binary service
      */
     protected ContentBearingHandler(final LdpRequest req, final File entity, final ResourceService resourceService,
                     final AuditService auditService, final IOService ioService, final BinaryService binaryService,
-                    final AgentService agentService, final String baseUrl) {
-        super(req, resourceService, auditService, baseUrl);
+                    final AgentService agentService, final MementoService mementoService, final String baseUrl) {
+        super(req, resourceService, mementoService, auditService, baseUrl);
         this.binaryService = binaryService;
         this.ioService = ioService;
         this.agentService = agentService;

--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -39,6 +39,7 @@ import org.apache.commons.rdf.api.Triple;
 import org.slf4j.Logger;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
@@ -63,11 +64,12 @@ public class DeleteHandler extends BaseLdpHandler {
      * @param resourceService the resource service
      * @param auditService an audit service
      * @param agentService the agent service
+     * @param mementoService the memento service
      * @param baseUrl the base URL
      */
     public DeleteHandler(final LdpRequest req, final ResourceService resourceService, final AuditService auditService,
-                    final AgentService agentService, final String baseUrl) {
-        super(req, resourceService, auditService, baseUrl);
+                    final AgentService agentService, final MementoService mementoService, final String baseUrl) {
+        super(req, resourceService, mementoService, auditService, baseUrl);
         this.agentService = agentService;
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -91,6 +91,7 @@ import org.slf4j.Logger;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.http.domain.LdpRequest;
@@ -120,11 +121,12 @@ public class GetHandler extends BaseLdpHandler {
      * @param resourceService the resource service
      * @param ioService the serialization service
      * @param binaryService the binary service
+     * @param mementoService the memento service
      * @param baseUrl the base URL
      */
     public GetHandler(final LdpRequest req, final ResourceService resourceService, final IOService ioService,
-            final BinaryService binaryService, final String baseUrl) {
-        super(req, resourceService, null, baseUrl);
+            final BinaryService binaryService, final MementoService mementoService, final String baseUrl) {
+        super(req, resourceService, mementoService, null, baseUrl);
         this.ioService = ioService;
         this.binaryService = binaryService;
     }
@@ -171,7 +173,7 @@ public class GetHandler extends BaseLdpHandler {
         // Only show memento links for the user-managed graph (not ACL)
         if (!ACL.equals(req.getExt())) {
             builder.link(identifier, "original timegate")
-                .links(MementoResource.getMementoLinks(identifier, resourceService.getMementos(res.getIdentifier()))
+                .links(MementoResource.getMementoLinks(identifier, mementoService.list(res.getIdentifier()))
                         .toArray(Link[]::new));
         }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
@@ -66,7 +66,7 @@ import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.api.RDFSyntax;
 import org.apache.commons.rdf.api.Triple;
 import org.trellisldp.api.IOService;
-import org.trellisldp.api.ResourceService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.http.domain.LdpRequest;
 import org.trellisldp.vocabulary.Memento;
 import org.trellisldp.vocabulary.Time;
@@ -127,15 +127,15 @@ public final class MementoResource {
         return buffer.stream();
     };
 
-    private final ResourceService resourceService;
+    private final MementoService mementoService;
 
     /**
      * Wrap a resource in some Memento-specific response builders.
      *
-     * @param resourceService the resource service
+     * @param mementoService the memento service
      */
-    public MementoResource(final ResourceService resourceService) {
-        this.resourceService = resourceService;
+    public MementoResource(final MementoService mementoService) {
+        this.mementoService = mementoService;
     }
 
     /**
@@ -152,7 +152,7 @@ public final class MementoResource {
         final List<MediaType> acceptableTypes = req.getHeaders().getAcceptableMediaTypes();
         final String identifier = getBaseUrl(baseUrl, req) + req.getPath();
         final IRI internalIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + req.getPath());
-        final List<Link> links = getMementoLinks(identifier, resourceService.getMementos(internalIdentifier))
+        final List<Link> links = getMementoLinks(identifier, mementoService.list(internalIdentifier))
             .collect(toList());
 
         final Response.ResponseBuilder builder = Response.ok().link(identifier, ORIGINAL + " " + TIMEGATE);
@@ -212,7 +212,7 @@ public final class MementoResource {
         return Response.status(FOUND)
             .location(fromUri(identifier + "?version=" + req.getDatetime().getInstant().toEpochMilli()).build())
             .link(identifier, ORIGINAL + " " + TIMEGATE)
-            .links(getMementoLinks(identifier, resourceService.getMementos(internalIdentifier)).toArray(Link[]::new))
+            .links(getMementoLinks(identifier, mementoService.list(internalIdentifier)).toArray(Link[]::new))
             .header(VARY, ACCEPT_DATETIME);
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/OptionsHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/OptionsHandler.java
@@ -43,6 +43,7 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFSyntax;
 import org.slf4j.Logger;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.http.domain.LdpRequest;
@@ -64,11 +65,12 @@ public class OptionsHandler extends BaseLdpHandler {
      * @param req the LDP request
      * @param resourceService the resource service
      * @param ioService the I/O service
+     * @param mementoService the memento service
      * @param baseUrl the base URL
      */
     public OptionsHandler(final LdpRequest req, final ResourceService resourceService, final IOService ioService,
-            final String baseUrl) {
-        super(req, resourceService, null, baseUrl);
+            final MementoService mementoService, final String baseUrl) {
+        super(req, resourceService, mementoService, null, baseUrl);
         this.ioService = ioService;
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -216,6 +216,9 @@ public class PatchHandler extends BaseLdpHandler {
                         }
                 }
 
+                // Update the memento
+                resourceService.get(res.getIdentifier()).ifPresent(mementoService::put);
+
                 final ResponseBuilder builder = ok();
 
                 getLinkTypes(res.getInteractionModel()).forEach(type -> builder.link(type, "type"));

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -65,6 +65,7 @@ import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.ConstraintViolation;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
@@ -96,12 +97,13 @@ public class PatchHandler extends BaseLdpHandler {
      * @param resourceService the resource service
      * @param ioService the serialization service
      * @param agentService the agent service
+     * @param mementoService the memento service
      * @param baseUrl the base URL
      */
     public PatchHandler(final LdpRequest req, final String updateBody, final ResourceService resourceService,
             final AuditService auditService, final IOService ioService, final AgentService agentService,
-            final String baseUrl) {
-        super(req, resourceService, auditService, baseUrl);
+            final MementoService mementoService, final String baseUrl) {
+        super(req, resourceService, mementoService, auditService, baseUrl);
         this.ioService = ioService;
         this.agentService = agentService;
         this.updateBody = updateBody;

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -172,6 +172,9 @@ public class PostHandler extends ContentBearingHandler {
                         }
                 }
 
+                // Add memento data
+                resourceService.get(internalId).ifPresent(mementoService::put);
+
                 final ResponseBuilder builder = status(CREATED).location(create(identifier));
 
                 // Add LDP types

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -54,6 +54,7 @@ import org.trellisldp.api.AuditService;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
 import org.trellisldp.http.domain.LdpRequest;
@@ -81,12 +82,14 @@ public class PostHandler extends ContentBearingHandler {
      * @param binaryService the datastream service
      * @param auditService and audit service
      * @param agentService the agent service
+     * @param mementoService the memento service
      * @param baseUrl the base URL
      */
     public PostHandler(final LdpRequest req, final String id, final File entity, final ResourceService resourceService,
                     final AuditService auditService, final IOService ioService, final BinaryService binaryService,
-                    final AgentService agentService, final String baseUrl) {
-        super(req, entity, resourceService, auditService, ioService, binaryService, agentService, baseUrl);
+                    final AgentService agentService, final MementoService mementoService, final String baseUrl) {
+        super(req, entity, resourceService, auditService, ioService, binaryService, agentService, mementoService,
+                baseUrl);
         this.id = id;
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -240,6 +240,9 @@ public class PutHandler extends ContentBearingHandler {
                     }
                 }
 
+                // Create a memento
+                resourceService.get(internalId).ifPresent(mementoService::put);
+
                 final ResponseBuilder builder = buildResponse(res, identifier);
                 getLdpLinkTypes(ldpType, isBinaryDescription).map(IRI::getIRIString)
                     .forEach(type -> builder.link(type, "type"));

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -66,6 +66,7 @@ import org.trellisldp.api.AuditService;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
@@ -91,12 +92,14 @@ public class PutHandler extends ContentBearingHandler {
      * @param ioService the serialization service
      * @param binaryService the binary service
      * @param agentService the agent service
+     * @param mementoService the memento service
      * @param baseUrl the base URL
      */
     public PutHandler(final LdpRequest req, final File entity, final ResourceService resourceService,
                     final AuditService auditService, final IOService ioService, final BinaryService binaryService,
-                    final AgentService agentService, final String baseUrl) {
-        super(req, entity, resourceService, auditService, ioService, binaryService, agentService, baseUrl);
+                    final AgentService agentService, final MementoService mementoService, final String baseUrl) {
+        super(req, entity, resourceService, auditService, ioService, binaryService, agentService, mementoService,
+                baseUrl);
     }
 
     private void checkResourceCache(final String identifier, final Resource res) {

--- a/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -129,6 +129,7 @@ import org.trellisldp.api.AuditService;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
@@ -196,6 +197,9 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     protected static final String HUB = "http://hub.example.org/";
 
     protected static final Set<IRI> allModes = newHashSet(ACL.Append, ACL.Control, ACL.Read, ACL.Write);
+
+    @Mock
+    protected MementoService mockMementoService;
 
     @Mock
     protected ResourceService mockResourceService;
@@ -272,7 +276,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
         when(mockAgentService.asAgent(anyString())).thenReturn(agent);
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(allModes);
 
-        when(mockResourceService.getMementos(eq(identifier)))
+        when(mockMementoService.list(eq(identifier)))
                 .thenReturn(asList(between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
                     between(ofEpochSecond(timestamp - 1000), time),
                     between(time, ofEpochSecond(timestamp + 1000))));
@@ -283,7 +287,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
         when(mockVersionedResource.getIdentifier()).thenReturn(identifier);
         when(mockVersionedResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
-        when(mockResourceService.getMementos(eq(binaryIdentifier))).thenReturn(asList(
+        when(mockMementoService.list(eq(binaryIdentifier))).thenReturn(asList(
                 between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
                 between(ofEpochSecond(timestamp - 1000), time),
                 between(time, ofEpochSecond(timestamp + 1000))));
@@ -322,7 +326,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
         when(mockResource.getIdentifier()).thenReturn(identifier);
         when(mockResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
-        when(mockResourceService.getMementos(eq(deletedIdentifier))).thenReturn(emptyList());
+        when(mockMementoService.list(eq(deletedIdentifier))).thenReturn(emptyList());
         when(mockDeletedResource.isDeleted()).thenReturn(true);
         when(mockDeletedResource.getInteractionModel()).thenReturn(LDP.Resource);
         when(mockDeletedResource.getModified()).thenReturn(time);
@@ -331,7 +335,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
         when(mockDeletedResource.getIdentifier()).thenReturn(identifier);
         when(mockDeletedResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
-        when(mockResourceService.getMementos(eq(userDeletedIdentifier))).thenReturn(emptyList());
+        when(mockMementoService.list(eq(userDeletedIdentifier))).thenReturn(emptyList());
         when(mockUserDeletedResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockUserDeletedResource.getModified()).thenReturn(time);
         when(mockUserDeletedResource.getBinary()).thenReturn(empty());
@@ -1219,7 +1223,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testGetTimeMapLink() throws IOException {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.getMementos(eq(identifier))).thenReturn(asList(
+        when(mockMementoService.list(eq(identifier))).thenReturn(asList(
                 between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
                 between(ofEpochSecond(timestamp - 1000), time),
                 between(time, ofEpochSecond(timestamp + 1000))));
@@ -1278,7 +1282,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testGetTimeMapJsonCompact() throws IOException {
-        when(mockResourceService.getMementos(eq(identifier))).thenReturn(asList(
+        when(mockMementoService.list(eq(identifier))).thenReturn(asList(
                 between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
                 between(ofEpochSecond(timestamp - 1000), time),
                 between(time, ofEpochSecond(timestamp + 1000))));
@@ -1359,7 +1363,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testGetTimeMapJson() throws IOException {
-        when(mockResourceService.getMementos(eq(identifier))).thenReturn(asList(
+        when(mockMementoService.list(eq(identifier))).thenReturn(asList(
                 between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
                 between(ofEpochSecond(timestamp - 1000), time),
                 between(time, ofEpochSecond(timestamp + 1000))));
@@ -1931,7 +1935,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testOptionsTimemap() {
-        when(mockResourceService.getMementos(identifier)).thenReturn(asList(
+        when(mockMementoService.list(identifier)).thenReturn(asList(
                 between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
                 between(ofEpochSecond(timestamp - 1000), time),
                 between(time, ofEpochSecond(timestamp + 1000))));

--- a/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -250,27 +250,27 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @BeforeEach
     public void setUpMocks() {
-        whenResource(mockResourceService.get(any(IRI.class), any(Instant.class)))
+        whenResource(mockMementoService.get(any(IRI.class), any(Instant.class)))
             .thenReturn(of(mockVersionedResource));
         whenResource(mockResourceService.get(eq(identifier))).thenReturn(of(mockResource));
         whenResource(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "repository/resource"))))
             .thenReturn(of(mockResource));
         whenResource(mockResourceService.get(eq(root))).thenReturn(of(mockResource));
         when(mockResourceService.get(eq(childIdentifier))).thenReturn(empty());
-        when(mockResourceService.get(eq(childIdentifier), any(Instant.class))).thenReturn(empty());
+        when(mockMementoService.get(eq(childIdentifier), any(Instant.class))).thenReturn(empty());
         when(mockResourceService.supportedInteractionModels()).thenReturn(allInteractionModels);
         whenResource(mockResourceService.get(eq(binaryIdentifier))).thenReturn(of(mockBinaryResource));
-        whenResource(mockResourceService.get(eq(binaryIdentifier), any(Instant.class)))
+        whenResource(mockMementoService.get(eq(binaryIdentifier), any(Instant.class)))
             .thenReturn(of(mockBinaryVersionedResource));
         when(mockResourceService.get(eq(nonexistentIdentifier))).thenReturn(empty());
-        when(mockResourceService.get(eq(nonexistentIdentifier), any(Instant.class))).thenReturn(empty());
+        when(mockMementoService.get(eq(nonexistentIdentifier), any(Instant.class))).thenReturn(empty());
         whenResource(mockResourceService.get(eq(deletedIdentifier))).thenReturn(of(mockDeletedResource));
-        whenResource(mockResourceService.get(eq(deletedIdentifier), any(Instant.class)))
+        whenResource(mockMementoService.get(eq(deletedIdentifier), any(Instant.class)))
             .thenReturn(of(mockDeletedResource));
         when(mockResourceService.generateIdentifier()).thenReturn(RANDOM_VALUE);
 
         whenResource(mockResourceService.get(eq(userDeletedIdentifier))).thenReturn(of(mockUserDeletedResource));
-        whenResource(mockResourceService.get(eq(userDeletedIdentifier), any(Instant.class)))
+        whenResource(mockMementoService.get(eq(userDeletedIdentifier), any(Instant.class)))
             .thenReturn(of(mockUserDeletedResource));
 
         when(mockAgentService.asAgent(anyString())).thenReturn(agent);
@@ -1981,7 +1981,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPost() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE)),
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE)),
                     eq(MAX))).thenReturn(empty());
 
         final Response res = target(RESOURCE_PATH).request()
@@ -1997,7 +1997,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostRoot() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RANDOM_VALUE)), eq(MAX)))
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RANDOM_VALUE)), eq(MAX)))
             .thenReturn(empty());
 
         final Response res = target("").request()
@@ -2205,7 +2205,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostBinary() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
                     any(Instant.class))).thenReturn(empty());
         final Response res = target(RESOURCE_PATH).request().header("Slug", "newresource")
             .post(entity("some data.", TEXT_PLAIN_TYPE));
@@ -2219,7 +2219,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostBinaryWithInvalidDigest() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
                     any(Instant.class))).thenReturn(empty());
         final Response res = target(RESOURCE_PATH).request().header("Slug", "newresource")
             .header("Digest", "md5=blahblah").post(entity("some data.", TEXT_PLAIN_TYPE));
@@ -2238,7 +2238,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostBinaryWithInvalidDigestType() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
                     any(Instant.class))).thenReturn(empty());
         final Response res = target(RESOURCE_PATH).request().header("Slug", "newresource")
             .header("Digest", "uh=huh").post(entity("some data.", TEXT_PLAIN_TYPE));
@@ -2249,7 +2249,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostBinaryWithMd5Digest() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
                     any(Instant.class))).thenReturn(empty());
         final Response res = target(RESOURCE_PATH).request().header("Digest", "md5=BJozgIQwPzzVzSxvjQsWkA==")
             .header("Slug", "newresource").post(entity("some data.", TEXT_PLAIN_TYPE));
@@ -2263,7 +2263,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostBinaryWithSha1Digest() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
                     any(Instant.class))).thenReturn(empty());
         final Response res = target(RESOURCE_PATH).request().header("Digest", "sha=3VWEuvPnAM6riDQJUu4TG7A4Ots=")
             .header("Slug", "newresource").post(entity("some data.", TEXT_PLAIN_TYPE));
@@ -2277,7 +2277,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     @Test
     public void testPostBinaryWithSha256Digest() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
                     any(Instant.class))).thenReturn(empty());
         final Response res = target(RESOURCE_PATH).request()
             .header("Digest", "sha-256=voCCIRTNXosNlEgQ/7IuX5dFNvFQx5MfG/jy1AKiLMU=")
@@ -2423,7 +2423,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testPutNew() {
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test")), eq(MAX)))
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test")), eq(MAX)))
             .thenReturn(empty());
 
         final Response res = target(RESOURCE_PATH + "/test").request()
@@ -2672,7 +2672,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testDeleteNonExistant() {
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test")), eq(MAX)))
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test")), eq(MAX)))
             .thenReturn(empty());
 
         final Response res = target(RESOURCE_PATH + "/test").request().delete();
@@ -2856,7 +2856,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
 
     @Test
     public void testPatchNew() {
-        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test")), eq(MAX)))
+        when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test")), eq(MAX)))
             .thenReturn(empty());
 
         final Response res = target(RESOURCE_PATH + "/test").request()

--- a/core/http/src/test/java/org/trellisldp/http/CORSResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CORSResourceTest.java
@@ -23,7 +23,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
-import static org.apache.commons.lang3.Range.between;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -135,7 +134,7 @@ public class CORSResourceTest extends JerseyTest {
     protected AgentService mockAgentService;
 
     @Mock
-    private Resource mockResource, mockVersionedResource, mockBinaryResource, mockBinaryVersionedResource;
+    private Resource mockResource, mockBinaryResource;
 
     @Override
     public Application configure() {
@@ -168,15 +167,11 @@ public class CORSResourceTest extends JerseyTest {
 
     @BeforeEach
     public void setUpMocks() {
-        whenResource(mockResourceService.get(any(IRI.class), any(Instant.class)))
-            .thenReturn(of(mockVersionedResource));
         whenResource(mockResourceService.get(eq(identifier))).thenReturn(of(mockResource));
         whenResource(mockResourceService.get(eq(root))).thenReturn(of(mockResource));
         when(mockResourceService.get(eq(childIdentifier))).thenReturn(empty());
         when(mockResourceService.get(eq(childIdentifier), any(Instant.class))).thenReturn(empty());
         whenResource(mockResourceService.get(eq(binaryIdentifier))).thenReturn(of(mockBinaryResource));
-        whenResource(mockResourceService.get(eq(binaryIdentifier), any(Instant.class)))
-            .thenReturn(of(mockBinaryVersionedResource));
         when(mockResourceService.get(eq(nonexistentIdentifier))).thenReturn(empty());
         when(mockResourceService.get(eq(nonexistentIdentifier), any(Instant.class))).thenReturn(empty());
         when(mockResourceService.generateIdentifier()).thenReturn(RANDOM_VALUE);
@@ -184,17 +179,6 @@ public class CORSResourceTest extends JerseyTest {
         when(mockAgentService.asAgent(anyString())).thenReturn(agent);
 
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(allModes);
-
-        when(mockResourceService.getMementos(eq(identifier))).thenReturn(asList(
-                between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
-                between(ofEpochSecond(timestamp - 1000), time),
-                between(time, ofEpochSecond(timestamp + 1000))));
-        when(mockVersionedResource.getInteractionModel()).thenReturn(LDP.RDFSource);
-        when(mockVersionedResource.getModified()).thenReturn(time);
-        when(mockVersionedResource.getBinary()).thenReturn(empty());
-        when(mockVersionedResource.isMemento()).thenReturn(true);
-        when(mockVersionedResource.getIdentifier()).thenReturn(identifier);
-        when(mockVersionedResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockResource.getModified()).thenReturn(time);

--- a/core/http/src/test/java/org/trellisldp/http/CORSResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CORSResourceTest.java
@@ -170,10 +170,8 @@ public class CORSResourceTest extends JerseyTest {
         whenResource(mockResourceService.get(eq(identifier))).thenReturn(of(mockResource));
         whenResource(mockResourceService.get(eq(root))).thenReturn(of(mockResource));
         when(mockResourceService.get(eq(childIdentifier))).thenReturn(empty());
-        when(mockResourceService.get(eq(childIdentifier), any(Instant.class))).thenReturn(empty());
         whenResource(mockResourceService.get(eq(binaryIdentifier))).thenReturn(of(mockBinaryResource));
         when(mockResourceService.get(eq(nonexistentIdentifier))).thenReturn(empty());
-        when(mockResourceService.get(eq(nonexistentIdentifier), any(Instant.class))).thenReturn(empty());
         when(mockResourceService.generateIdentifier()).thenReturn(RANDOM_VALUE);
 
         when(mockAgentService.asAgent(anyString())).thenReturn(agent);

--- a/core/http/src/test/java/org/trellisldp/http/LdpAdminResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpAdminResourceTest.java
@@ -38,7 +38,7 @@ public class LdpAdminResourceTest extends AbstractLdpResourceTest {
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new LdpResource(mockResourceService, ioService, mockBinaryService,
-                    mockAgentService, mockAuditService));
+                    mockAgentService, mockMementoService, mockAuditService));
         config.register(new TestAuthenticationFilter("testUser", ""));
         config.register(new WebAcFilter(mockAccessControlService));
         config.register(agentFilter);

--- a/core/http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
@@ -103,9 +103,6 @@ public class LdpForbiddenResourceTest extends JerseyTest {
     private Resource mockResource;
 
     @Mock
-    private Resource mockVersionedResource;
-
-    @Mock
     private AgentService mockAgentService;
 
     @Mock
@@ -145,19 +142,10 @@ public class LdpForbiddenResourceTest extends JerseyTest {
 
     @BeforeEach
     public void setUpMocks() {
-        Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class), any(Instant.class)))
-                        .thenReturn(of(mockVersionedResource));
         Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class)))
                         .thenReturn(of(mockResource));
 
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
-
-        when(mockVersionedResource.getInteractionModel()).thenReturn(LDP.RDFSource);
-        when(mockVersionedResource.getModified()).thenReturn(time);
-        when(mockVersionedResource.getBinary()).thenReturn(empty());
-        when(mockVersionedResource.isMemento()).thenReturn(true);
-        when(mockVersionedResource.getIdentifier()).thenReturn(identifier);
-        when(mockVersionedResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockAgentService.asAgent("testUser")).thenReturn(agent);
 

--- a/core/http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
@@ -14,7 +14,6 @@
 package org.trellisldp.http;
 
 import static java.time.Instant.ofEpochSecond;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
@@ -63,6 +62,8 @@ import org.trellisldp.api.AccessControlService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
@@ -79,6 +80,8 @@ import org.trellisldp.vocabulary.Trellis;
 public class LdpForbiddenResourceTest extends JerseyTest {
 
     private static final IOService ioService = new JenaIOService(null);
+
+    private static final MementoService mementoService = new NoopMementoService();
 
     private static final Instant time = ofEpochSecond(1496262729);
 
@@ -123,7 +126,8 @@ public class LdpForbiddenResourceTest extends JerseyTest {
         config.register(new TestAuthenticationFilter("testUser", "group"));
         config.register(new AgentAuthorizationFilter(mockAgentService));
         config.register(new WebAcFilter(mockAccessControlService));
-        config.register(new LdpResource(mockResourceService, ioService, mockBinaryService, mockAgentService));
+        config.register(new LdpResource(mockResourceService, ioService, mockBinaryService,
+                    mockAgentService, mementoService, null));
         System.getProperties().remove(CONFIGURATION_BASE_URL);
 
         return config;
@@ -145,7 +149,6 @@ public class LdpForbiddenResourceTest extends JerseyTest {
                         .thenReturn(of(mockVersionedResource));
         Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class)))
                         .thenReturn(of(mockResource));
-        when(mockResourceService.getMementos(any())).thenReturn(emptyList());
 
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
 

--- a/core/http/src/test/java/org/trellisldp/http/LdpResourceNoAgentTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpResourceNoAgentTest.java
@@ -37,7 +37,7 @@ public class LdpResourceNoAgentTest extends AbstractLdpResourceTest {
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new LdpResource(mockResourceService, ioService, mockBinaryService,
-                    new SimpleAgentService(), mockAuditService));
+                    new SimpleAgentService(), mockMementoService, mockAuditService));
         config.register(new MultipartUploader(mockResourceService, mockBinaryResolver));
         config.register(new CacheControlFilter(86400, true, false));
         config.register(new WebSubHeaderFilter(HUB));

--- a/core/http/src/test/java/org/trellisldp/http/LdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpResourceTest.java
@@ -80,7 +80,7 @@ public class LdpResourceTest extends AbstractLdpResourceTest {
         final ResourceConfig config = new ResourceConfig();
 
         config.register(new LdpResource(mockResourceService, ioService, mockBinaryService, mockAgentService,
-                    mockAuditService, null));
+                    mockMementoService, mockAuditService, null));
         config.register(new AgentAuthorizationFilter(mockAgentService));
         config.register(new MultipartUploader(mockResourceService, mockBinaryResolver));
         config.register(new CacheControlFilter(86400, true, false));
@@ -99,7 +99,7 @@ public class LdpResourceTest extends AbstractLdpResourceTest {
         when(mockUriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
 
         final LdpResource filter = new LdpResource(mockResourceService, ioService, mockBinaryService, mockAgentService,
-                    mockAuditService);
+                    mockMementoService, mockAuditService);
 
         filter.filter(mockContext);
         verify(mockContext, never()).abortWith(any());
@@ -108,7 +108,7 @@ public class LdpResourceTest extends AbstractLdpResourceTest {
     @Test
     public void testNoBaseURL() throws Exception {
         final LdpResource matcher = new LdpResource(mockResourceService, ioService, mockBinaryService, mockAgentService,
-                    mockAuditService, null);
+                    mockMementoService, mockAuditService, null);
 
         when(mockLdpRequest.getPath()).thenReturn("repo1/resource");
         when(mockLdpRequest.getBaseUrl()).thenReturn("http://my.example.com/");

--- a/core/http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
@@ -99,9 +99,6 @@ public class LdpUnauthorizedResourceTest extends JerseyTest {
     private Resource mockResource;
 
     @Mock
-    private Resource mockVersionedResource;
-
-    @Mock
     private AccessControlService mockAccessControlService;
 
     @Override
@@ -139,19 +136,10 @@ public class LdpUnauthorizedResourceTest extends JerseyTest {
 
     @BeforeEach
     public void setUpMocks() {
-        Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class), any(Instant.class)))
-                        .thenReturn(of(mockVersionedResource));
         Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class)))
                         .thenReturn(of(mockResource));
 
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
-
-        when(mockVersionedResource.getInteractionModel()).thenReturn(LDP.RDFSource);
-        when(mockVersionedResource.getModified()).thenReturn(time);
-        when(mockVersionedResource.getBinary()).thenReturn(empty());
-        when(mockVersionedResource.isMemento()).thenReturn(true);
-        when(mockVersionedResource.getIdentifier()).thenReturn(identifier);
-        when(mockVersionedResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockResource.getModified()).thenReturn(time);

--- a/core/http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpUnauthorizedResourceTest.java
@@ -143,7 +143,6 @@ public class LdpUnauthorizedResourceTest extends JerseyTest {
                         .thenReturn(of(mockVersionedResource));
         Mockito.<Optional<? extends Resource>>when(mockResourceService.get(any(IRI.class)))
                         .thenReturn(of(mockResource));
-        when(mockResourceService.getMementos(any())).thenReturn(emptyList());
 
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
 

--- a/core/http/src/test/java/org/trellisldp/http/LdpUserResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpUserResourceTest.java
@@ -36,7 +36,7 @@ public class LdpUserResourceTest extends AbstractLdpResourceTest {
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new LdpResource(mockResourceService, ioService, mockBinaryService, mockAgentService,
-                    mockAuditService));
+                    mockMementoService, mockAuditService));
         config.register(new TestAuthenticationFilter("testUser", "group"));
         config.register(new WebAcFilter(mockAccessControlService));
         config.register(new AgentAuthorizationFilter(mockAgentService));

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -14,7 +14,6 @@
 package org.trellisldp.http.impl;
 
 import static java.time.Instant.ofEpochSecond;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Date.from;
@@ -63,6 +62,7 @@ import org.mockito.Mock;
 import org.trellisldp.agent.SimpleAgentService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
@@ -109,7 +109,6 @@ public class DeleteHandlerTest {
         when(mockResource.getModified()).thenReturn(time);
         when(mockResource.getIdentifier()).thenReturn(iri);
         when(mockResourceService.supportedInteractionModels()).thenReturn(singleton(LDP.Resource));
-        when(mockResourceService.getMementos(any())).thenReturn(emptyList());
         when(mockResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
@@ -142,7 +141,7 @@ public class DeleteHandlerTest {
     @Test
     public void testDelete() {
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
-                    agentService, null);
+                    agentService, new NoopMementoService(), null);
 
         final Response res = handler.deleteResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -158,7 +157,7 @@ public class DeleteHandlerTest {
             .thenReturn(completedFuture(false));
         final AuditService badAuditService = new DefaultAuditService() {};
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, badAuditService,
-                    agentService, null);
+                    agentService, new NoopMementoService(), null);
 
         assertThrows(BadRequestException.class, () -> handler.deleteResource(mockResource));
     }
@@ -168,7 +167,7 @@ public class DeleteHandlerTest {
         when(mockResourceService.delete(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(completedFuture(false));
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
-                    agentService, baseUrl);
+                    agentService, new NoopMementoService(), baseUrl);
 
         assertThrows(BadRequestException.class, () -> handler.deleteResource(mockResource));
     }
@@ -179,7 +178,7 @@ public class DeleteHandlerTest {
         when(mockResourceService.delete(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
             .thenReturn(mockFuture);
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
-                    agentService, baseUrl);
+                    agentService, new NoopMementoService(), baseUrl);
 
         final Response res = handler.deleteResource(mockResource).build();
         assertEquals(INTERNAL_SERVER_ERROR, res.getStatusInfo());
@@ -189,7 +188,7 @@ public class DeleteHandlerTest {
     public void testDeletePersistenceSupport() {
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
-                    agentService, baseUrl);
+                    agentService, new NoopMementoService(), baseUrl);
 
         final BadRequestException ex = assertThrows(BadRequestException.class, () ->
                 handler.deleteResource(mockResource));
@@ -205,7 +204,7 @@ public class DeleteHandlerTest {
                         any())).thenReturn(completedFuture(false));
         when(mockLdpRequest.getExt()).thenReturn(ACL);
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
-                    agentService, baseUrl);
+                    agentService, new NoopMementoService(), baseUrl);
 
         assertThrows(BadRequestException.class, () -> handler.deleteResource(mockResource));
     }
@@ -218,7 +217,7 @@ public class DeleteHandlerTest {
             .thenReturn(completedFuture(false));
         when(mockLdpRequest.getExt()).thenReturn(ACL);
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
-                    agentService, baseUrl);
+                    agentService, new NoopMementoService(), baseUrl);
 
         assertThrows(BadRequestException.class, () -> handler.deleteResource(mockResource));
     }
@@ -229,7 +228,7 @@ public class DeleteHandlerTest {
         when(mockRequest.evaluatePreconditions(eq(from(time)), any(EntityTag.class)))
                 .thenReturn(status(PRECONDITION_FAILED));
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
-                    agentService, baseUrl);
+                    agentService, new NoopMementoService(), baseUrl);
 
         assertThrows(WebApplicationException.class, () -> handler.deleteResource(mockResource));
     }
@@ -239,7 +238,7 @@ public class DeleteHandlerTest {
         when(mockResource.isDeleted()).thenReturn(true);
 
         final DeleteHandler handler = new DeleteHandler(mockLdpRequest, mockResourceService, mockAuditService,
-                    agentService, baseUrl);
+                    agentService, new NoopMementoService(), baseUrl);
 
         assertThrows(WebApplicationException.class, () -> handler.deleteResource(mockResource));
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -18,7 +18,6 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.ofInstant;
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Date.from;
 import static java.util.Optional.empty;
@@ -100,6 +99,7 @@ import org.mockito.Mock;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.http.domain.LdpRequest;
@@ -144,7 +144,6 @@ public class GetHandlerTest {
     @BeforeEach
     public void setUp() {
         initMocks(this);
-        when(mockResourceService.getMementos(any())).thenReturn(emptyList());
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockResource.getModified()).thenReturn(time);
         when(mockResource.getBinary()).thenReturn(empty());
@@ -164,7 +163,7 @@ public class GetHandlerTest {
         when(mockIoService.supportedUpdateSyntaxes()).thenReturn(singletonList(SPARQL_UPDATE));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, null);
+                mockIoService, mockBinaryService, new NoopMementoService(), null);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertEquals(OK, res.getStatusInfo());
@@ -207,7 +206,7 @@ public class GetHandlerTest {
             .thenReturn(Prefer.valueOf("return=representation; include=\"http://www.w3.org/ns/ldp#PreferContainment"));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, null);
+                mockIoService, mockBinaryService, new NoopMementoService(), null);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertEquals(OK, res.getStatusInfo());
@@ -229,7 +228,7 @@ public class GetHandlerTest {
         when(mockHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(TEXT_TURTLE_TYPE));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, null);
+                mockIoService, mockBinaryService, new NoopMementoService(), null);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertEquals(OK, res.getStatusInfo());
@@ -272,7 +271,7 @@ public class GetHandlerTest {
         when(mockHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(TEXT_TURTLE_TYPE));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, baseUrl);
+                mockIoService, mockBinaryService, new NoopMementoService(), baseUrl);
 
         assertThrows(WebApplicationException.class, () -> getHandler.getRepresentation(mockResource));
     }
@@ -286,7 +285,7 @@ public class GetHandlerTest {
         when(mockHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(WILDCARD_TYPE));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, baseUrl);
+                mockIoService, mockBinaryService, new NoopMementoService(), baseUrl);
 
         assertThrows(WebApplicationException.class, () -> getHandler.getRepresentation(mockResource));
     }
@@ -303,7 +302,7 @@ public class GetHandlerTest {
         when(mockHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(TEXT_TURTLE_TYPE));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, baseUrl);
+                mockIoService, mockBinaryService, new NoopMementoService(), baseUrl);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertEquals(OK, res.getStatusInfo());
@@ -318,7 +317,7 @@ public class GetHandlerTest {
         when(mockHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(APPLICATION_JSON_TYPE));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, baseUrl);
+                mockIoService, mockBinaryService, new NoopMementoService(), baseUrl);
 
         assertThrows(NotAcceptableException.class, () -> getHandler.getRepresentation(mockResource));
     }
@@ -330,7 +329,7 @@ public class GetHandlerTest {
         when(mockLdpRequest.getPrefer()).thenReturn(Prefer.valueOf("return=minimal"));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, baseUrl);
+                mockIoService, mockBinaryService, new NoopMementoService(), baseUrl);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -376,7 +375,7 @@ public class GetHandlerTest {
                     MediaType.valueOf(APPLICATION_LD_JSON + "; profile=\"" + compacted.getIRIString() + "\"")));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, null);
+                mockIoService, mockBinaryService, new NoopMementoService(), null);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertEquals(OK, res.getStatusInfo());
@@ -426,7 +425,7 @@ public class GetHandlerTest {
         when(mockHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(MediaType.valueOf(RDFA.mediaType())));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, null);
+                mockIoService, mockBinaryService, new NoopMementoService(), null);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertEquals(OK, res.getStatusInfo());
@@ -447,7 +446,7 @@ public class GetHandlerTest {
         when(mockHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(TEXT_TURTLE_TYPE));
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, null);
+                mockIoService, mockBinaryService, new NoopMementoService(), null);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertTrue(res.getMediaType().isCompatible(TEXT_TURTLE_TYPE));
@@ -470,7 +469,7 @@ public class GetHandlerTest {
         when(mockLdpRequest.getExt()).thenReturn(DESCRIPTION);
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, null);
+                mockIoService, mockBinaryService, new NoopMementoService(), null);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertTrue(res.getMediaType().isCompatible(TEXT_TURTLE_TYPE));
@@ -492,7 +491,7 @@ public class GetHandlerTest {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, baseUrl);
+                mockIoService, mockBinaryService, new NoopMementoService(), baseUrl);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertTrue(res.getMediaType().isCompatible(TEXT_PLAIN_TYPE));
@@ -516,7 +515,7 @@ public class GetHandlerTest {
         when(mockLdpRequest.getExt()).thenReturn("acl");
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, baseUrl);
+                mockIoService, mockBinaryService, new NoopMementoService(), baseUrl);
 
         final Response res = getHandler.getRepresentation(mockResource).build();
         assertEquals(OK, res.getStatusInfo());
@@ -536,7 +535,7 @@ public class GetHandlerTest {
         when(mockResource.isDeleted()).thenReturn(true);
 
         final GetHandler getHandler = new GetHandler(mockLdpRequest, mockResourceService,
-                mockIoService, mockBinaryService, null);
+                mockIoService, mockBinaryService, new NoopMementoService(), null);
 
         assertThrows(WebApplicationException.class, () -> getHandler.getRepresentation(mockResource));
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.http.impl;
 
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.empty;
 import static java.util.stream.Stream.of;
@@ -34,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.http.domain.HttpConstants.ACCEPT_PATCH;
@@ -52,6 +50,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.http.domain.LdpRequest;
@@ -79,7 +78,6 @@ public class OptionsHandlerTest {
     @BeforeEach
     public void setUp() {
         initMocks(this);
-        when(mockResourceService.getMementos(any())).thenReturn(emptyList());
         when(mockResource.isMemento()).thenReturn(false);
         when(mockResource.getExtraLinkRelations()).thenAnswer(inv -> empty());
         when(mockRequest.getBaseUrl()).thenReturn(baseUrl);
@@ -92,7 +90,7 @@ public class OptionsHandlerTest {
     public void testOptionsLdprs() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         final OptionsHandler optionsHandler = new OptionsHandler(mockRequest, mockResourceService, mockIOService,
-                null);
+                new NoopMementoService(), null);
 
         final Response res = optionsHandler.ldpOptions(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -113,7 +111,7 @@ public class OptionsHandlerTest {
     public void testOptionsLdpc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         final OptionsHandler optionsHandler = new OptionsHandler(mockRequest, mockResourceService, mockIOService,
-                baseUrl);
+                new NoopMementoService(), baseUrl);
 
         final Response res = optionsHandler.ldpOptions(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -142,7 +140,7 @@ public class OptionsHandlerTest {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockRequest, mockResourceService, mockIOService,
-                null);
+                new NoopMementoService(), null);
 
         final Response res = optionsHandler.ldpOptions(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -163,7 +161,7 @@ public class OptionsHandlerTest {
         when(mockRequest.getExt()).thenReturn("acl");
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockRequest, mockResourceService, mockIOService,
-                baseUrl);
+                new NoopMementoService(), baseUrl);
 
         final Response res = optionsHandler.ldpOptions(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -186,7 +184,7 @@ public class OptionsHandlerTest {
         when(mockResource.isMemento()).thenReturn(true);
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockRequest, mockResourceService, mockIOService,
-                null);
+                new NoopMementoService(), null);
 
         final Response res = optionsHandler.ldpOptions(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -208,7 +206,7 @@ public class OptionsHandlerTest {
         when(mockResource.isDeleted()).thenReturn(true);
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockRequest, mockResourceService, mockIOService,
-                baseUrl);
+                new NoopMementoService(), baseUrl);
 
         assertThrows(WebApplicationException.class, () -> optionsHandler.ldpOptions(mockResource));
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -83,6 +83,7 @@ import org.trellisldp.agent.SimpleAgentService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
@@ -173,7 +174,7 @@ public class PatchHandlerTest {
     @Test
     public void testPatchNoSparql() {
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, null,
-                mockResourceService, mockAuditService, mockIoService, agentService, null);
+                mockResourceService, mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
         assertThrows(WebApplicationException.class, () -> patchHandler.updateResource(mockResource));
     }
 
@@ -187,14 +188,14 @@ public class PatchHandlerTest {
             .thenReturn(completedFuture(false));
         final AuditService badAuditService = new DefaultAuditService() {};
         final PatchHandler handler = new PatchHandler(mockLdpRequest, "", mockResourceService, badAuditService,
-                        mockIoService, agentService, null);
+                        mockIoService, agentService, new NoopMementoService(), null);
         assertThrows(BadRequestException.class, () -> handler.updateResource(mockResource));
     }
 
     @Test
     public void testPatchLdprs() {
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, baseUrl);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), baseUrl);
 
         final Response res = patchHandler.updateResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -208,7 +209,7 @@ public class PatchHandlerTest {
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, null);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
 
         final Response res = patchHandler.updateResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -225,7 +226,7 @@ public class PatchHandlerTest {
         when(mockLdpRequest.getPrefer()).thenReturn(Prefer.valueOf("return=representation"));
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, null);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
 
         final Response res = patchHandler.updateResource(mockResource).build();
 
@@ -248,7 +249,7 @@ public class PatchHandlerTest {
             .thenReturn(singletonList(MediaType.valueOf(RDFA.mediaType())));
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, null);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
 
         final Response res = patchHandler.updateResource(mockResource).build();
 
@@ -269,7 +270,7 @@ public class PatchHandlerTest {
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, null);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
 
         assertThrows(WebApplicationException.class, () -> patchHandler.updateResource(mockResource));
     }
@@ -281,7 +282,7 @@ public class PatchHandlerTest {
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, null);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
 
         assertThrows(WebApplicationException.class, () -> patchHandler.updateResource(mockResource));
     }
@@ -293,7 +294,7 @@ public class PatchHandlerTest {
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, null);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
 
         assertThrows(BadRequestException.class, () -> patchHandler.updateResource(mockResource));
     }
@@ -303,7 +304,7 @@ public class PatchHandlerTest {
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, null);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
 
         final BadRequestException ex = assertThrows(BadRequestException.class, () ->
                 patchHandler.updateResource(mockResource));
@@ -321,7 +322,7 @@ public class PatchHandlerTest {
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, null);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), null);
 
         final Response res = patchHandler.updateResource(mockResource).build();
         assertEquals(INTERNAL_SERVER_ERROR, res.getStatusInfo());
@@ -334,7 +335,7 @@ public class PatchHandlerTest {
         when(mockLdpRequest.getPath()).thenReturn("resource");
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockResourceService,
-                        mockAuditService, mockIoService, agentService, baseUrl);
+                        mockAuditService, mockIoService, agentService, new NoopMementoService(), baseUrl);
 
         assertThrows(BadRequestException.class, () -> patchHandler.updateResource(mockResource));
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -75,6 +75,8 @@ import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.MementoService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
@@ -98,7 +100,9 @@ public class PostHandlerTest {
     @Mock
     private ResourceService mockResourceService;
 
-    private AuditService mockAuditService = none();
+    private AuditService auditService = none();
+
+    private MementoService mementoService = new NoopMementoService();
 
     private final AgentService agentService = new SimpleAgentService();
 
@@ -162,7 +166,7 @@ public class PostHandlerTest {
 
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -184,7 +188,7 @@ public class PostHandlerTest {
             .thenReturn(completedFuture(false));
         final AuditService badAuditService = new DefaultAuditService() {};
         final PostHandler handler = new PostHandler(mockRequest, null, entity, mockResourceService,
-                        badAuditService, mockIoService, mockBinaryService, agentService, null);
+                        badAuditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         assertThrows(BadRequestException.class, handler::createResource);
     }
@@ -193,7 +197,7 @@ public class PostHandlerTest {
     public void testDefaultType1() throws IOException {
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -210,7 +214,7 @@ public class PostHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleData.txt").getFile());
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -227,7 +231,7 @@ public class PostHandlerTest {
 
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -245,7 +249,7 @@ public class PostHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleData.txt").getFile());
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -262,7 +266,7 @@ public class PostHandlerTest {
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
 
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -280,7 +284,7 @@ public class PostHandlerTest {
 
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final BadRequestException ex = assertThrows(BadRequestException.class, postHandler::createResource);
         assertTrue(ex.getResponse().getLinks().stream().anyMatch(link ->
@@ -301,7 +305,7 @@ public class PostHandlerTest {
         when(mockRequest.getContentType()).thenReturn("text/turtle");
 
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -326,7 +330,7 @@ public class PostHandlerTest {
         when(mockRequest.getContentType()).thenReturn("text/plain");
 
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -355,7 +359,7 @@ public class PostHandlerTest {
         when(mockRequest.getDigest()).thenReturn(new Digest("md5", "1VOyRwUXW1CPdC5nelt7GQ=="));
 
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         final Response res = postHandler.createResource().build();
         assertEquals(CREATED, res.getStatusInfo());
@@ -383,7 +387,7 @@ public class PostHandlerTest {
         when(mockRequest.getDigest()).thenReturn(new Digest("md5", "blahblah"));
 
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         assertThrows(BadRequestException.class, postHandler::createResource);
     }
@@ -395,7 +399,7 @@ public class PostHandlerTest {
         when(mockRequest.getDigest()).thenReturn(new Digest("foo", "blahblah"));
 
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         assertThrows(BadRequestException.class, postHandler::createResource);
     }
@@ -407,7 +411,7 @@ public class PostHandlerTest {
         final File entity = new File(new File(getClass().getResource("/simpleData.txt").getFile()).getParent());
 
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, null);
 
         assertThrows(WebApplicationException.class, postHandler::createResource);
     }
@@ -418,7 +422,7 @@ public class PostHandlerTest {
         when(mockRequest.getContentType()).thenReturn("text/plain");
 
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, baseUrl);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, baseUrl);
 
         assertThrows(WebApplicationException.class, postHandler::createResource);
     }
@@ -431,7 +435,7 @@ public class PostHandlerTest {
 
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, baseUrl);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, baseUrl);
 
         assertThrows(BadRequestException.class, postHandler::createResource);
     }
@@ -445,7 +449,7 @@ public class PostHandlerTest {
 
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
         final PostHandler postHandler = new PostHandler(mockRequest, "newresource", entity, mockResourceService,
-                        mockAuditService, mockIoService, mockBinaryService, agentService, baseUrl);
+                        auditService, mockIoService, mockBinaryService, agentService, mementoService, baseUrl);
 
         final Response res = postHandler.createResource().build();
         assertEquals(INTERNAL_SERVER_ERROR, res.getStatusInfo());

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -79,6 +79,7 @@ import org.trellisldp.api.AuditService;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.Session;
@@ -177,7 +178,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleTriple.ttl").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         assertThrows(WebApplicationException.class, () -> putHandler.setResource(mockResource));
     }
@@ -193,7 +194,7 @@ public class PutHandlerTest {
             .thenReturn(completedFuture(false));
         final AuditService badAuditService = new DefaultAuditService() {};
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, badAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         assertThrows(BadRequestException.class, () -> putHandler.setResource(mockResource));
     }
@@ -205,7 +206,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleTriple.ttl").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -225,7 +226,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleTriple.ttl").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -245,7 +246,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleTriple.ttl").getFile() + ".non-existent-file");
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         assertThrows(WebApplicationException.class, () -> putHandler.setResource(mockResource));
     }
@@ -258,7 +259,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleData.txt").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -280,7 +281,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleData.txt").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -302,7 +303,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleLiteral.ttl").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -323,7 +324,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleLiteral.ttl").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -340,7 +341,7 @@ public class PutHandlerTest {
     public void testPutLdpResourceEmpty() {
         final File entity = new File(getClass().getResource("/emptyData.txt").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -361,7 +362,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleData.txt").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         assertThrows(WebApplicationException.class, () -> putHandler.setResource(mockResource));
     }
@@ -374,7 +375,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleTriple.ttl").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService,
-                mockAuditService, mockIoService, mockBinaryService, agentService, null);
+                mockAuditService, mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(NO_CONTENT, res.getStatusInfo());
@@ -392,7 +393,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleTriple.ttl").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final BadRequestException ex = assertThrows(BadRequestException.class, () ->
                 putHandler.setResource(mockResource));
@@ -411,7 +412,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleData.txt").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         assertThrows(BadRequestException.class, () -> putHandler.setResource(mockResource));
     }
@@ -427,7 +428,7 @@ public class PutHandlerTest {
 
         final File entity = new File(getClass().getResource("/simpleData.txt").getFile());
         final PutHandler putHandler = new PutHandler(mockLdpRequest, entity, mockResourceService, mockAuditService,
-                        mockIoService, mockBinaryService, agentService, null);
+                        mockIoService, mockBinaryService, agentService, new NoopMementoService(), null);
 
         final Response res = putHandler.setResource(mockResource).build();
         assertEquals(INTERNAL_SERVER_ERROR, res.getStatusInfo());

--- a/platform/osgi/src/main/resources/OSGI-INF/blueprint/trellis-osgi.xml
+++ b/platform/osgi/src/main/resources/OSGI-INF/blueprint/trellis-osgi.xml
@@ -25,12 +25,14 @@
     <reference id="ioService" interface="org.trellisldp.api.IOService"/>
     <reference id="binaryService" interface="org.trellisldp.api.BinaryService"/>
     <reference id="agentService" interface="org.trellisldp.api.AgentService"/>
+    <reference id="mementoService" interface="org.trellisldp.api.MementoService"/>
 
     <bean id="ldpResource" class="org.trellisldp.http.LdpResource">
       <argument ref="triplestoreService"/>
       <argument ref="ioService"/>
       <argument ref="binaryService"/>
       <argument ref="agentService"/>
+      <argument ref="mementoService"/>
       <argument ref="triplestoreService"/>
       <argument value="${http.baseUrl}"/>
     </bean>

--- a/platform/webapp/src/main/java/org/trellisldp/webapp/TrellisApplication.java
+++ b/platform/webapp/src/main/java/org/trellisldp/webapp/TrellisApplication.java
@@ -61,7 +61,8 @@ public class TrellisApplication extends ResourceConfig {
         final TriplestoreResourceService resourceService = new TriplestoreResourceService(
                 rdfConnection, idService, mementoService, eventService);
 
-        register(new LdpResource(resourceService, ioService, binaryService, agentService, resourceService));
+        register(new LdpResource(resourceService, ioService, binaryService, agentService, mementoService,
+                    resourceService));
         register(new AgentAuthorizationFilter(agentService));
 
         AppUtils.getCacheControlFilter().ifPresent(this::register);

--- a/platform/webapp/src/main/java/org/trellisldp/webapp/TrellisApplication.java
+++ b/platform/webapp/src/main/java/org/trellisldp/webapp/TrellisApplication.java
@@ -59,7 +59,7 @@ public class TrellisApplication extends ResourceConfig {
         final IOService ioService = new JenaIOService(namespaceService);
 
         final TriplestoreResourceService resourceService = new TriplestoreResourceService(
-                rdfConnection, idService, mementoService, eventService);
+                rdfConnection, idService, eventService);
 
         register(new LdpResource(resourceService, ioService, binaryService, agentService, mementoService,
                     resourceService));


### PR DESCRIPTION
Resolves #161 

The first commit removes the `ResourceService::getMementos` method.
The second commit removes the `ResourceService::get(IRI, Instant)` method.
The third commit removes the internal use of `MementoService::put` in the `TriplestoreResourceService`
