### PR TITLE
Remove ResourceService::compact method

### DIFF
--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -663,11 +663,6 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public Stream<IRI> compact(final IRI identifier, final Instant from, final Instant until) {
-        throw new UnsupportedOperationException("compact is not supported");
-    }
-
-    @Override
     public Stream<IRI> purge(final IRI identifier) {
         throw new UnsupportedOperationException("purge is not supported");
     }

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -174,16 +174,6 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testCompact() {
-        final JenaDataset dataset = rdf.createDataset();
-        final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService,
-                mockMementoService, mockEventService);
-        assertThrows(UnsupportedOperationException.class, () ->
-                svc.compact(rdf.createIRI(TRELLIS_DATA_PREFIX + "identifier"), now(), now()));
-    }
-
-    @Test
     public void testScan() {
         final IRI one = rdf.createIRI(TRELLIS_DATA_PREFIX + "1");
         final IRI two = rdf.createIRI(TRELLIS_DATA_PREFIX + "2");

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -66,16 +66,6 @@ public interface ResourceService extends MutableDataService<Resource>, Immutable
     List<Range<Instant>> getMementos(IRI identifier);
 
     /**
-     * Compact (rewrite the history) of a resource.
-     *
-     * @param identifier the identifier
-     * @param from a time after which a resource is to be compacted
-     * @param until a time before which a resource is to be compacted
-     * @return a stream of binary IRIs that can be safely purged
-     */
-    Stream<IRI> compact(IRI identifier, Instant from, Instant until);
-
-    /**
      * Purge a resource from the server.
      *
      * @param identifier the identifier

--- a/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -138,11 +138,6 @@ public class JoiningResourceServiceTest {
         }
 
         @Override
-        public Stream<IRI> compact(final IRI identifier, final Instant from, final Instant until) {
-            return Stream.empty();
-        }
-
-        @Override
         public Stream<IRI> purge(final IRI identifier) {
             return Stream.empty();
         }


### PR DESCRIPTION
Resolves #162 

This removes some code that is not used, and there are no plans to start using it.