### PR TITLE
Simplify the BinaryService::getContent method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ ext {
     activationApiVersion = '1.2.0'
     activeMqVersion = '5.15.4'
     commonsCodecVersion = '1.11'
-    commonsCollectionsVersion = '4.1'
     commonsCompressVersion = '1.17'
     commonsIoVersion = '2.6'
     commonsLangVersion = '3.7'

--- a/components/file/build.gradle
+++ b/components/file/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
     implementation("commons-codec:commons-codec:$commonsCodecVersion")
     implementation("commons-io:commons-io:$commonsIoVersion")
-    implementation("org.apache.commons:commons-collections4:$commonsCollectionsVersion")
     implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
     implementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion")
     implementation("org.apache.jena:jena-osgi:$jenaVersion")

--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -124,17 +124,26 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public Optional<InputStream> getContent(final IRI identifier, final Integer from, final Integer to) {
+    public Optional<InputStream> getContent(final IRI identifier) {
         return getFileFromIdentifier(identifier).map(file -> {
             try {
-                if (ofNullable(from).orElse(0) > ofNullable(to).orElse(-1)) {
-                    return new FileInputStream(file);
-                } else {
-                    final InputStream input = new FileInputStream(file);
-                    final long skipped = input.skip(from);
-                    LOGGER.debug("Skipped {} bytes", skipped);
-                    return new BoundedInputStream(input, to - from);
-                }
+                return new FileInputStream(file);
+            } catch (final IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
+        });
+    }
+
+    @Override
+    public Optional<InputStream> getContent(final IRI identifier, final Integer from, final Integer to) {
+        requireNonNull(from, "From value cannot be null!");
+        requireNonNull(to, "To value cannot be null!");
+        return getFileFromIdentifier(identifier).map(file -> {
+            try {
+                final InputStream input = new FileInputStream(file);
+                final long skipped = input.skip(from);
+                LOGGER.debug("Skipped {} bytes", skipped);
+                return new BoundedInputStream(input, to - from);
             } catch (final IOException ex) {
                 throw new UncheckedIOException(ex);
             }

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -144,6 +144,7 @@ public class FileBinaryServiceTest {
         final BinaryService resolver = new FileBinaryService(idService);
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         assertThrows(UncheckedIOException.class, () -> resolver.getContent(fileIRI));
+        assertThrows(UncheckedIOException.class, () -> resolver.getContent(fileIRI, 0, 4));
     }
 
     @Test

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -14,9 +14,7 @@
 package org.trellisldp.file;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.singletonList;
 import static java.util.Optional.of;
-import static org.apache.commons.lang3.Range.between;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -35,11 +33,8 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.simple.SimpleRDF;
@@ -114,28 +109,23 @@ public class FileBinaryServiceTest {
     @Test
     public void testFileContentSegment() {
         final BinaryService resolver = new FileBinaryService(idService);
-        final List<Range<Integer>> range = singletonList(between(1, 5));
-        assertTrue(resolver.getContent(file, range).isPresent());
-        assertEquals(" tes", resolver.getContent(file, range).map(this::uncheckedToString).get());
+        assertTrue(resolver.getContent(file, 1, 5).isPresent());
+        assertEquals(" tes", resolver.getContent(file, 1, 5).map(this::uncheckedToString).get());
     }
 
     @Test
     public void testFileContentSegments() {
         final BinaryService resolver = new FileBinaryService(idService);
-        final List<Range<Integer>> ranges = new ArrayList<>();
-        ranges.add(between(1, 5));
-        ranges.add(between(8, 10));
 
-        assertTrue(resolver.getContent(file, ranges).isPresent());
-        assertEquals(" tesoc", resolver.getContent(file, ranges).map(this::uncheckedToString).get());
+        assertTrue(resolver.getContent(file, 8, 10).isPresent());
+        assertEquals("oc", resolver.getContent(file, 8, 10).map(this::uncheckedToString).get());
     }
 
     @Test
     public void testFileContentSegmentBeyond() {
         final BinaryService resolver = new FileBinaryService(idService);
-        final List<Range<Integer>> range = singletonList(between(1000, 1005));
-        assertTrue(resolver.getContent(file, range).isPresent());
-        assertEquals("", resolver.getContent(file, range).map(this::uncheckedToString).get());
+        assertTrue(resolver.getContent(file, 1000, 1005).isPresent());
+        assertEquals("", resolver.getContent(file, 1000, 1005).map(this::uncheckedToString).get());
     }
 
     @Test

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -13,17 +13,14 @@
  */
 package org.trellisldp.api;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 import java.io.InputStream;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.IRI;
 
 /**
@@ -155,10 +152,11 @@ public interface BinaryService {
      * Get the content of the binary object.
      *
      * @param identifier an identifier used for locating the binary object
-     * @param ranges any segment ranges requested
+     * @param from the starting point of a range request
+     * @param to the ending point of a range request
      * @return the content
      */
-    Optional<InputStream> getContent(IRI identifier, List<Range<Integer>> ranges);
+    Optional<InputStream> getContent(IRI identifier, Integer from, Integer to);
 
     /**
      * Get the content of the binary object.
@@ -167,7 +165,7 @@ public interface BinaryService {
      * @return the content
      */
     default Optional<InputStream> getContent(IRI identifier) {
-        return getContent(identifier, emptyList());
+        return getContent(identifier, 0, -1);
     }
 
     /**

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -164,9 +164,7 @@ public interface BinaryService {
      * @param identifier an identifier used for locating the binary object
      * @return the content
      */
-    default Optional<InputStream> getContent(IRI identifier) {
-        return getContent(identifier, 0, -1);
-    }
+    Optional<InputStream> getContent(IRI identifier);
 
     /**
      * Test whether a binary object exists at the given URI.

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -82,10 +82,9 @@ public class BinaryServiceTest {
 
     @Test
     public void testGetContent() throws IOException {
-        doCallRealMethod().when(mockBinaryService).getContent(eq(identifier));
         when(mockBinaryService.getContent(eq(identifier), any(), any()))
             .thenReturn(of(new ByteArrayInputStream("FooBar".getBytes(UTF_8))));
-        final Optional<InputStream> content = mockBinaryService.getContent(identifier);
+        final Optional<InputStream> content = mockBinaryService.getContent(identifier, 0, 6);
         assertTrue(content.isPresent());
         assertEquals("FooBar", IOUtils.toString(content.get(), UTF_8));
     }

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -83,7 +83,7 @@ public class BinaryServiceTest {
     @Test
     public void testGetContent() throws IOException {
         doCallRealMethod().when(mockBinaryService).getContent(eq(identifier));
-        when(mockBinaryService.getContent(eq(identifier), any()))
+        when(mockBinaryService.getContent(eq(identifier), any(), any()))
             .thenReturn(of(new ByteArrayInputStream("FooBar".getBytes(UTF_8))));
         final Optional<InputStream> content = mockBinaryService.getContent(identifier);
         assertTrue(content.isPresent());

--- a/core/http/src/main/java/org/trellisldp/http/HttpBasedBinaryService.java
+++ b/core/http/src/main/java/org/trellisldp/http/HttpBasedBinaryService.java
@@ -36,7 +36,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -48,7 +47,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.IRI;
 import org.slf4j.Logger;
 import org.trellisldp.api.BinaryService;
@@ -119,16 +117,14 @@ public class HttpBasedBinaryService implements BinaryService {
     }
 
     @Override
-    public Optional<InputStream> getContent(final IRI identifier, final List<Range<Integer>> ranges) {
+    public Optional<InputStream> getContent(final IRI identifier, final Integer from, final Integer to) {
         requireNonNull(identifier,  NON_NULL_IDENTIFIER);
-        requireNonNull(ranges, "Byte ranges may not be null");
         final Response res;
-        if (ranges.isEmpty()) {
+        if (ofNullable(from).orElse(0) > ofNullable(to).orElse(-1)) {
             res = httpClient.target(identifier.getIRIString()).request().get();
         } else {
-            final StringBuilder builder = new StringBuilder();
-            ranges.forEach(r -> builder.append(r.getMinimum() + "-" + r.getMaximum()));
-            res = httpClient.target(identifier.getIRIString()).request().header("Range", "bytes=" + builder).get();
+            res = httpClient.target(identifier.getIRIString()).request()
+                .header("Range", "bytes=" + from + "-" + to).get();
         }
         LOGGER.debug("HTTP GET request to {} returned status {}", identifier, res.getStatus());
         if (res.hasEntity()) {

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -35,7 +35,6 @@ import static javax.ws.rs.core.HttpHeaders.VARY;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.ok;
-import static org.apache.commons.lang3.Range.between;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.http.domain.HttpConstants.ACCEPT_DATETIME;
@@ -319,7 +318,7 @@ public class GetHandler extends BaseLdpHandler {
     private InputStream getBinaryStream(final IRI dsid, final Range range) throws IOException {
         final Optional<InputStream> content = isNull(range)
             ? binaryService.getContent(dsid)
-            : binaryService.getContent(dsid, singletonList(between(range.getFrom(), range.getTo())));
+            : binaryService.getContent(dsid, range.getFrom(), range.getTo());
         return content.orElseThrow(() -> new IOException("Could not retrieve content from: " + dsid));
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -23,7 +23,6 @@ import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.Date.from;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -313,7 +312,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
         when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA")));
         when(mockBinaryService.digest(eq("MD5"), any(InputStream.class))).thenReturn(of("md5-digest"));
         when(mockBinaryService.digest(eq("SHA"), any(InputStream.class))).thenReturn(of("sha1-digest"));
-        when(mockBinaryService.getContent(eq(binaryInternalIdentifier), eq(singletonList(between(3, 10)))))
+        when(mockBinaryService.getContent(eq(binaryInternalIdentifier), eq(3), eq(10)))
             .thenAnswer(x -> of(new ByteArrayInputStream("e input".getBytes(UTF_8))));
         when(mockBinaryService.getContent(eq(binaryInternalIdentifier)))
             .thenAnswer(x -> of(new ByteArrayInputStream("Some input stream".getBytes(UTF_8))));

--- a/core/http/src/test/java/org/trellisldp/http/HttpBasedBinaryServiceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/HttpBasedBinaryServiceTest.java
@@ -14,11 +14,9 @@
 package org.trellisldp.http;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.singletonList;
 import static java.util.Optional.of;
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
-import static org.apache.commons.lang3.Range.between;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -135,7 +133,7 @@ public class HttpBasedBinaryServiceTest {
     public void testGetContentSegment() {
         final BinaryService resolver = new HttpBasedBinaryService(idService);
 
-        final Optional<InputStream> res = resolver.getContent(resource, singletonList(between(5, 20)));
+        final Optional<InputStream> res = resolver.getContent(resource, 5, 20);
         assertTrue(res.isPresent());
         final String str = res.map(this::uncheckedToString).get();
 

--- a/platform/karaf/src/main/resources/features.xml
+++ b/platform/karaf/src/main/resources/features.xml
@@ -42,7 +42,6 @@
     <feature>trellis-vocabulary</feature>
     <feature>aries-blueprint</feature>
 
-    <bundle dependency="true">mvn:org.apache.commons/commons-collections4/${commonsCollectionsVersion}</bundle>
     <bundle dependency="true">mvn:org.apache.tamaya/tamaya-api/${tamayaVersion}</bundle>
     <bundle dependency="true">mvn:commons-codec/commons-codec/${commonsCodecVersion}</bundle>
     <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>


### PR DESCRIPTION
Resolves #169 

This changes the `BinaryService::getContent` method to support only a single range request (e.g. `Range: bytes=300-400` rather than multiple ranges (until there is a real use case for such a thing, I'd prefer to keep the interface as simple as possible).

The new interface is `BinaryService::getContent(IRI identifier, Integer from, Integer to)`

In addition, the default implementation of the `::getContent(IRI)` method has been removed, as it made a lot of assumptions about the implementation details of the 3-arity version of the method.