### PR TITLE
Initial refactor with CompletableFuture interfaces

### DIFF
--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -54,7 +54,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -144,15 +144,15 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public Future<Boolean> create(final IRI id, final Session session, final IRI ixnModel, final Dataset dataset,
-                    final IRI container, final Binary binary) {
+    public CompletableFuture<Boolean> create(final IRI id, final Session session, final IRI ixnModel,
+            final Dataset dataset, final IRI container, final Binary binary) {
         LOGGER.debug("Creating: {}", id);
         return supplyAsync(() ->
                 createOrReplace(id, session, ixnModel, dataset, OperationType.CREATE, container, binary));
     }
 
     @Override
-    public Future<Boolean> delete(final IRI identifier, final Session session, final IRI ixnModel,
+    public CompletableFuture<Boolean> delete(final IRI identifier, final Session session, final IRI ixnModel,
             final Dataset dataset) {
         LOGGER.debug("Deleting: {}", identifier);
         return supplyAsync(() -> {
@@ -164,8 +164,8 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public Future<Boolean> replace(final IRI id, final Session session, final IRI ixnModel, final Dataset dataset,
-                    final IRI container, final Binary binary) {
+    public CompletableFuture<Boolean> replace(final IRI id, final Session session, final IRI ixnModel,
+            final Dataset dataset, final IRI container, final Binary binary) {
         LOGGER.debug("Updating: {}", id);
         return supplyAsync(() ->
                 createOrReplace(id, session, ixnModel, dataset, OperationType.REPLACE, container, binary));
@@ -644,7 +644,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public Future<Boolean> add(final IRI id, final Session session, final Dataset dataset) {
+    public CompletableFuture<Boolean> add(final IRI id, final Session session, final Dataset dataset) {
         return supplyAsync(() -> {
             final IRI graphName = rdf.createIRI(id.getIRIString() + "?ext=audit");
             try (final Dataset data = rdf.createDataset()) {

--- a/core/api/src/main/java/org/trellisldp/api/ImmutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ImmutableDataService.java
@@ -14,7 +14,7 @@
 
 package org.trellisldp.api;
 
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
@@ -36,6 +36,6 @@ public interface ImmutableDataService<T> extends RetrievalService<T> {
      * @param dataset a dataset to persist
      * @return whether the resource was successfully persisted
      */
-    Future<Boolean> add(IRI identifier, Session session, Dataset dataset);
+    CompletableFuture<Boolean> add(IRI identifier, Session session, Dataset dataset);
 
 }

--- a/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -18,7 +18,7 @@ import static java.util.stream.Stream.concat;
 
 import java.time.Instant;
 import java.util.Optional;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.Dataset;
@@ -61,24 +61,24 @@ public abstract class JoiningResourceService implements ResourceService {
     }
 
     @Override
-    public Future<Boolean> add(final IRI id, final Session session, final Dataset dataset) {
+    public CompletableFuture<Boolean> add(final IRI id, final Session session, final Dataset dataset) {
         return immutableData.add(id, session, dataset);
     }
 
     @Override
-    public Future<Boolean> create(final IRI id, final Session session, final IRI ixnModel, final Dataset dataset,
-            final IRI container, final Binary binary) {
+    public CompletableFuture<Boolean> create(final IRI id, final Session session, final IRI ixnModel,
+            final Dataset dataset, final IRI container, final Binary binary) {
         return mutableData.create(id, session, ixnModel, dataset, container, binary);
     }
 
     @Override
-    public Future<Boolean> replace(final IRI id, final Session session, final IRI ixnModel, final Dataset dataset,
-            final IRI container, final Binary binary) {
+    public CompletableFuture<Boolean> replace(final IRI id, final Session session, final IRI ixnModel,
+            final Dataset dataset, final IRI container, final Binary binary) {
         return mutableData.replace(id, session, ixnModel, dataset, container, binary);
     }
 
     @Override
-    public Future<Boolean> delete(final IRI id, final Session session, final IRI ixnModel,
+    public CompletableFuture<Boolean> delete(final IRI id, final Session session, final IRI ixnModel,
             final Dataset dataset) {
         return mutableData.delete(id, session, ixnModel, dataset);
     }

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -14,7 +14,7 @@
 
 package org.trellisldp.api;
 
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
@@ -38,7 +38,7 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
      * @return whether the resource was added
      */
-    Future<Boolean> create(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
+    CompletableFuture<Boolean> create(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
             Binary binary);
 
     /**
@@ -52,7 +52,7 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
      * @return whether the resource was replaced
      */
-    Future<Boolean> replace(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
+    CompletableFuture<Boolean> replace(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
             Binary binary);
 
     /**
@@ -64,6 +64,6 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param dataset the dataset
      * @return whether the resource was deleted
      */
-    Future<Boolean> delete(IRI identifier, Session session, IRI ixnModel, Dataset dataset);
+    CompletableFuture<Boolean> delete(IRI identifier, Session session, IRI ixnModel, Dataset dataset);
 
 }

--- a/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
@@ -88,7 +87,7 @@ public class JoiningResourceServiceTest {
                     implements ImmutableDataService<Resource> {
 
         @Override
-        public Future<Boolean> add(final IRI identifier, final Session session, final Dataset dataset) {
+        public CompletableFuture<Boolean> add(final IRI identifier, final Session session, final Dataset dataset) {
             resources.compute(identifier, (id, old) -> {
                 final TestResource newRes = new TestResource(id, dataset);
                 return old == null ? newRes : new RetrievableResource(old, newRes);
@@ -101,21 +100,21 @@ public class JoiningResourceServiceTest {
                     implements MutableDataService<Resource> {
 
         @Override
-        public Future<Boolean> create(final IRI id, final Session session, final IRI ixnModel, final Dataset dataset,
-                        final IRI container, final Binary binary) {
+        public CompletableFuture<Boolean> create(final IRI id, final Session session, final IRI ixnModel,
+                final Dataset dataset, final IRI container, final Binary binary) {
             resources.put(id, new TestResource(id, dataset));
             return isntBadId(id);
         }
 
         @Override
-        public Future<Boolean> replace(final IRI id, final Session session, final IRI ixnModel, final Dataset dataset,
-                        final IRI container, final Binary binary) {
+        public CompletableFuture<Boolean> replace(final IRI id, final Session session, final IRI ixnModel,
+                final Dataset dataset, final IRI container, final Binary binary) {
             resources.replace(id, new TestResource(id, dataset));
             return isntBadId(id);
         }
 
         @Override
-        public Future<Boolean> delete(final IRI identifier, final Session session, final IRI ixnModel,
+        public CompletableFuture<Boolean> delete(final IRI identifier, final Session session, final IRI ixnModel,
                         final Dataset dataset) {
             resources.remove(identifier);
             return isntBadId(identifier);

--- a/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -98,8 +98,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -226,7 +226,7 @@ abstract class AbstractLdpResourceTest extends JerseyTest {
     private InputStream mockInputStream;
 
     @Mock
-    private Future<Boolean> mockFuture;
+    private CompletableFuture<Boolean> mockFuture;
 
     @BeforeAll
     public void before() throws Exception {

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -41,7 +41,7 @@ import static org.trellisldp.http.domain.RdfMediaType.TEXT_TURTLE;
 import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 
 import java.time.Instant;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import javax.ws.rs.BadRequestException;
@@ -107,7 +107,7 @@ public class DeleteHandlerTest {
     private LdpRequest mockLdpRequest;
 
     @Mock
-    private Future<Boolean> mockFuture;
+    private CompletableFuture<Boolean> mockFuture;
 
     @BeforeEach
     public void setUp() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -57,7 +57,7 @@ import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 
 import java.time.Instant;
 import java.util.Date;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import javax.ws.rs.BadRequestException;
@@ -140,7 +140,7 @@ public class PatchHandlerTest {
     private SecurityContext mockSecurityContext;
 
     @Mock
-    private Future<Boolean> mockFuture;
+    private CompletableFuture<Boolean> mockFuture;
 
     @BeforeEach
     public void setUp() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -49,7 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -123,7 +123,7 @@ public class PostHandlerTest {
     private LdpRequest mockRequest;
 
     @Mock
-    private Future<Boolean> mockFuture;
+    private CompletableFuture<Boolean> mockFuture;
 
     @Mock
     private SecurityContext mockSecurityContext;

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -53,7 +53,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Set;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import javax.ws.rs.BadRequestException;
@@ -137,7 +137,7 @@ public class PutHandlerTest {
     private SecurityContext mockSecurityContext;
 
     @Mock
-    private Future<Boolean> mockFuture;
+    private CompletableFuture<Boolean> mockFuture;
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
This is an incremental PR that includes the simplest parts of a refactor related to #148. In particular, this changes existing `Future` types to `CompletableFuture` types in the `ResourceService` mutating methods. It does not change any of the fetching methods. Changing the `::get` method will result in more significant changes, which will happen separately.