### PR TITLE
Remove ::scan and ::export from ResourceService

### DIFF
--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -39,7 +39,6 @@ import static org.trellisldp.triplestore.TriplestoreUtils.getBaseIRI;
 import static org.trellisldp.triplestore.TriplestoreUtils.getInstance;
 import static org.trellisldp.triplestore.TriplestoreUtils.getObject;
 import static org.trellisldp.triplestore.TriplestoreUtils.getPredicate;
-import static org.trellisldp.triplestore.TriplestoreUtils.getSubject;
 import static org.trellisldp.vocabulary.Trellis.DeletedResource;
 import static org.trellisldp.vocabulary.Trellis.PreferAccessControl;
 import static org.trellisldp.vocabulary.Trellis.PreferAudit;
@@ -530,34 +529,6 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
         }
         LOGGER.warn("No baseURL defined. Emitting message with resource's internal IRI: {}", identifier);
         return identifier.getIRIString();
-    }
-
-    @Override
-    public Stream<Triple> scan() {
-        /*
-         * SELECT ?subject ?object
-         * WHERE {
-         *   GRAPH trellis:PreferServerManaged { ?subject rdf:type ?object }
-         * }
-         */
-        final Query q = new Query();
-        q.setQuerySelectType();
-        q.addResultVar(SUBJECT);
-        q.addResultVar(OBJECT);
-
-        final ElementPathBlock epb = new ElementPathBlock();
-        epb.addTriple(triple(SUBJECT, rdf.asJenaNode(RDF.type), OBJECT));
-
-        final ElementNamedGraph ng = new ElementNamedGraph(rdf.asJenaNode(PreferServerManaged), epb);
-
-        final ElementGroup elg = new ElementGroup();
-        elg.addElement(ng);
-
-        q.setQueryPattern(elg);
-
-        final Stream.Builder<Triple> builder = builder();
-        rdfConnection.querySelect(q, qs -> builder.accept(rdf.createTriple(getSubject(qs), RDF.type, getObject(qs))));
-        return builder.build();
     }
 
     /**

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -122,25 +122,6 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testScan() {
-        final IRI one = rdf.createIRI(TRELLIS_DATA_PREFIX + "1");
-        final IRI two = rdf.createIRI(TRELLIS_DATA_PREFIX + "2");
-        final IRI three = rdf.createIRI(TRELLIS_DATA_PREFIX + "3");
-        final JenaDataset dataset = rdf.createDataset();
-        dataset.add(Trellis.PreferServerManaged, one, RDF.type, LDP.Container);
-        dataset.add(Trellis.PreferServerManaged, two, RDF.type, LDP.NonRDFSource);
-        dataset.add(Trellis.PreferServerManaged, three, RDF.type, LDP.RDFSource);
-
-        final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final ResourceService svc = new TriplestoreResourceService(rdfConnection, idService, mockEventService);
-        assertEquals(4L, svc.scan().count());
-        assertTrue(svc.scan().anyMatch(t -> t.getSubject().equals(root) && t.getObject().equals(LDP.BasicContainer)));
-        assertTrue(svc.scan().anyMatch(t -> t.getSubject().equals(one) && t.getObject().equals(LDP.Container)));
-        assertTrue(svc.scan().anyMatch(t -> t.getSubject().equals(two) && t.getObject().equals(LDP.NonRDFSource)));
-        assertTrue(svc.scan().anyMatch(t -> t.getSubject().equals(three) && t.getObject().equals(LDP.RDFSource)));
-    }
-
-    @Test
     public void testInitializeRoot() {
         final Instant early = now();
         final JenaDataset dataset = rdf.createDataset();

--- a/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -39,7 +39,6 @@ import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
 import org.apache.commons.rdf.api.RDFTerm;
-import org.apache.commons.rdf.api.Triple;
 import org.junit.jupiter.api.Test;
 import org.trellisldp.api.JoiningResourceService.RetrievableResource;
 import org.trellisldp.vocabulary.LDP;
@@ -126,11 +125,6 @@ public class JoiningResourceServiceTest {
         public TestableJoiningResourceService(final ImmutableDataService<Resource> immutableData,
                         final MutableDataService<Resource> mutableData) {
             super(mutableData, immutableData);
-        }
-
-        @Override
-        public Stream<? extends Triple> scan() {
-            return Stream.empty();
         }
 
         @Override

--- a/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -13,10 +13,8 @@
  */
 package org.trellisldp.api;
 
-import static java.util.Arrays.asList;
 import static java.util.Optional.of;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,27 +23,17 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.trellisldp.vocabulary.RDF.type;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.BlankNode;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Literal;
-import org.apache.commons.rdf.api.Quad;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.jena.JenaRDF;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.trellisldp.vocabulary.DC;
-import org.trellisldp.vocabulary.LDP;
-import org.trellisldp.vocabulary.Trellis;
 
 /**
  * @author acoburn
@@ -77,14 +65,10 @@ public class ResourceServiceTest {
         doCallRealMethod().when(mockResourceService).skolemize(any());
         doCallRealMethod().when(mockResourceService).unskolemize(any());
         doCallRealMethod().when(mockResourceService).getContainer(any());
-        doCallRealMethod().when(mockResourceService).export(any());
         doCallRealMethod().when(mockResourceService).toInternal(any(), any());
         doCallRealMethod().when(mockResourceService).toExternal(any(), any());
 
         when(mockRetrievalService.get(eq(existing))).thenAnswer(inv -> completedFuture(mockResource));
-
-        when(mockResourceService.scan()).thenAnswer(inv ->
-            asList(rdf.createTriple(existing, type, LDP.Container)).stream());
     }
 
     @Test
@@ -114,27 +98,6 @@ public class ResourceServiceTest {
         assertFalse(mockResourceService.unskolemize(rdf.createLiteral("Test")) instanceof BlankNode);
         assertFalse(mockResourceService.unskolemize(resource) instanceof BlankNode);
         assertFalse(mockResourceService.skolemize(rdf.createLiteral("Test2")) instanceof IRI);
-    }
-
-    @Test
-    public void testExport() {
-        final Set<IRI> graphs = new HashSet<>();
-        graphs.add(Trellis.PreferAccessControl);
-        graphs.add(Trellis.PreferAudit);
-        graphs.add(Trellis.PreferServerManaged);
-        graphs.add(Trellis.PreferUserManaged);
-        when(mockResource.getIdentifier()).thenReturn(existing);
-        when(mockResource.stream(eq(graphs))).thenAnswer(inv ->
-                Stream.of(rdf.createTriple(existing, DC.title, rdf.createLiteral("A title"))));
-        Mockito.<CompletableFuture<? extends Resource>>when(mockResourceService.get(eq(existing)))
-            .thenReturn(completedFuture(mockResource));
-
-        final List<Quad> export = mockResourceService.export(graphs).collect(toList());
-        assertEquals(1L, export.size());
-        assertEquals(of(existing), export.get(0).getGraphName());
-        assertEquals(existing, export.get(0).getSubject());
-        assertEquals(DC.title, export.get(0).getPredicate());
-        assertEquals(rdf.createLiteral("A title"), export.get(0).getObject());
     }
 
     @Test


### PR DESCRIPTION
Resolves #179 

See related [discussion](https://github.com/trellis-ldp/trellis/pull/177#discussion_r205971740)