### PR TITLE
Datetime negotiation of non-existent Mementos

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/MementoTimeGateTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoTimeGateTests.java
@@ -20,7 +20,7 @@ import static javax.ws.rs.core.HttpHeaders.VARY;
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.REDIRECTION;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.fromStatusCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -134,7 +134,7 @@ public interface MementoTimeGateTests extends MementoCommonTests {
         try (final Response res = target(getResourceLocation()).request()
                 .header(ACCEPT_DATETIME, RFC_1123_DATE_TIME.withZone(UTC).format(time)).get()) {
             assertEquals(CLIENT_ERROR, res.getStatusInfo().getFamily());
-            assertEquals(NOT_FOUND, fromStatusCode(res.getStatus()));
+            assertEquals(NOT_ACCEPTABLE, fromStatusCode(res.getStatus()));
         }
     }
 }

--- a/core/http/src/main/java/org/trellisldp/http/LdpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/LdpResource.java
@@ -45,6 +45,7 @@ import javax.ws.rs.BeanParam;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
+import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
@@ -352,7 +353,7 @@ public class LdpResource implements ContainerRequestFilter {
             return trellis.getMementoService().get(identifier, req.getDatetime().getInstant())
                 .thenCombine(trellis.getMementoService().list(identifier), (res, mementos) -> {
                     if (MISSING_RESOURCE.equals(res)) {
-                        throw new NotFoundException();
+                        throw new NotAcceptableException();
                     }
                     return new MementoResource(trellis).getTimeGateBuilder(mementos, req, urlBase);
                 });

--- a/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractLdpResourceTest.java
@@ -385,7 +385,7 @@ abstract class AbstractLdpResourceTest extends BaseLdpResourceTest {
     public void testGetTimegateNotFound() {
         final Response res = target(NON_EXISTENT_PATH).request()
             .header(ACCEPT_DATETIME, "Wed, 16 May 2018 13:18:57 GMT").get();
-        assertEquals(SC_NOT_FOUND, res.getStatus());
+        assertEquals(SC_NOT_ACCEPTABLE, res.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Resolves #188

Datetime negotiation that would result in a non-existent
Memento should result in a `406 Not Acceptable` rather than
a `404 Not Found`.