### PR TITLE
Make async return types consistent

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -96,7 +97,7 @@ public interface ResourceServiceTests {
         final Dataset dataset = buildDataset(identifier, "Creation Test", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
+        assertNull(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
                 .join());
         final Resource res = getResourceService().get(identifier).join();
         res.stream(Trellis.PreferUserManaged)
@@ -116,7 +117,7 @@ public interface ResourceServiceTests {
         final Dataset dataset = buildDataset(identifier, "Replacement Test", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
+        assertNull(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
                 .join());
 
         dataset.clear();
@@ -124,7 +125,7 @@ public interface ResourceServiceTests {
         dataset.add(Trellis.PreferUserManaged, identifier, SKOS.altLabel, rdf.createLiteral("alternate label"));
         dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
-        assertTrue(getResourceService().replace(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
+        assertNull(getResourceService().replace(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
                     .join());
         final Resource res = getResourceService().get(identifier).join();
         res.stream(Trellis.PreferUserManaged).forEach(t ->
@@ -146,11 +147,11 @@ public interface ResourceServiceTests {
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
 
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
+        assertNull(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
                 .join());
         assertNotEquals(DELETED_RESOURCE, getResourceService().get(identifier).join());
 
-        assertTrue(getResourceService().delete(identifier, getSession(), LDP.Resource, rdf.createDataset()).join());
+        assertNull(getResourceService().delete(identifier, getSession(), LDP.Resource, rdf.createDataset()).join());
         assertEquals(DELETED_RESOURCE, getResourceService().get(identifier).join());
     }
 
@@ -165,7 +166,7 @@ public interface ResourceServiceTests {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
         final Dataset dataset0 = buildDataset(identifier, "Immutable Resource Test", SUBJECT2);
 
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset0, ROOT_CONTAINER, null)
+        assertNull(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset0, ROOT_CONTAINER, null)
                 .join());
 
         final IRI audit1 = rdf.createIRI(TRELLIS_BNODE_PREFIX + getResourceService().generateIdentifier());
@@ -175,7 +176,7 @@ public interface ResourceServiceTests {
         dataset1.add(Trellis.PreferAudit, audit1, type, AS.Create);
         dataset1.add(Trellis.PreferAudit, audit1, PROV.atTime, rdf.createLiteral(now().toString(), XSD.dateTime));
 
-        assertTrue(getResourceService().add(identifier, getSession(), dataset1).join());
+        assertNull(getResourceService().add(identifier, getSession(), dataset1).join());
 
         final Resource res = getResourceService().get(identifier).join();
         res.stream(Trellis.PreferAudit).forEach(t ->
@@ -190,7 +191,7 @@ public interface ResourceServiceTests {
         dataset2.add(Trellis.PreferAudit, audit2, type, AS.Update);
         dataset2.add(Trellis.PreferAudit, audit2, PROV.atTime, rdf.createLiteral(now().toString(), XSD.dateTime));
 
-        assertTrue(getResourceService().add(identifier, getSession(), dataset2).join());
+        assertNull(getResourceService().add(identifier, getSession(), dataset2).join());
 
         final Resource res2 = getResourceService().get(identifier).join();
 
@@ -216,7 +217,7 @@ public interface ResourceServiceTests {
         final Dataset dataset = buildDataset(identifier, "Create LDP-RS Test", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
+        assertNull(getResourceService().create(identifier, getSession(), LDP.RDFSource, dataset, ROOT_CONTAINER, null)
                 .join());
         final Resource res = getResourceService().get(identifier).join();
         assertAll(checkResource(res, identifier, LDP.RDFSource, time, dataset));
@@ -240,7 +241,7 @@ public interface ResourceServiceTests {
         final Binary binary = new Binary(binaryLocation, binaryTime, "text/plain", 150L);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.NonRDFSource, dataset, ROOT_CONTAINER,
+        assertNull(getResourceService().create(identifier, getSession(), LDP.NonRDFSource, dataset, ROOT_CONTAINER,
                     binary).join());
         final Resource res = getResourceService().get(identifier).join();
         assertAll(checkResource(res, identifier, LDP.NonRDFSource, time, dataset));
@@ -268,20 +269,20 @@ public interface ResourceServiceTests {
         final Dataset dataset0 = buildDataset(identifier, "Container Test", SUBJECT0);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.Container, dataset0, ROOT_CONTAINER, null)
+        assertNull(getResourceService().create(identifier, getSession(), LDP.Container, dataset0, ROOT_CONTAINER, null)
                 .join());
 
         final IRI child1 = rdf.createIRI(base + "/child01");
         final Dataset dataset1 = buildDataset(child1, "Contained Child 1", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child1).join());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, dataset1, identifier, null).join());
+        assertNull(getResourceService().create(child1, getSession(), LDP.RDFSource, dataset1, identifier, null).join());
 
         final IRI child2 = rdf.createIRI(base + "/child02");
         final Dataset dataset2 = buildDataset(child2, "Contained Child2", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child2).join());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, dataset2, identifier, null).join());
+        assertNull(getResourceService().create(child2, getSession(), LDP.RDFSource, dataset2, identifier, null).join());
 
         final Resource res = getResourceService().get(identifier).join();
         assertAll(checkResource(res, identifier, LDP.Container, time, dataset0));
@@ -307,20 +308,20 @@ public interface ResourceServiceTests {
         final Dataset dataset0 = buildDataset(identifier, "Basic Container Test", SUBJECT0);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.BasicContainer, dataset0, ROOT_CONTAINER,
+        assertNull(getResourceService().create(identifier, getSession(), LDP.BasicContainer, dataset0, ROOT_CONTAINER,
                     null).join());
 
         final IRI child1 = rdf.createIRI(base + "/child11");
         final Dataset dataset1 = buildDataset(child1, "Contained Child 1", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child1).join());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, dataset1, identifier, null).join());
+        assertNull(getResourceService().create(child1, getSession(), LDP.RDFSource, dataset1, identifier, null).join());
 
         final IRI child2 = rdf.createIRI(base + "/child12");
         final Dataset dataset2 = buildDataset(child2, "Contained Child2", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child2).join());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, dataset2, identifier, null).join());
+        assertNull(getResourceService().create(child2, getSession(), LDP.RDFSource, dataset2, identifier, null).join());
 
         final Resource res = getResourceService().get(identifier).join();
         assertAll(checkResource(res, identifier, LDP.BasicContainer, time, dataset0));
@@ -352,20 +353,20 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, LDP.isMemberOfRelation, DC.isPartOf);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.DirectContainer, dataset0, ROOT_CONTAINER,
-                    null).get());
+        assertNull(getResourceService().create(identifier, getSession(), LDP.DirectContainer, dataset0, ROOT_CONTAINER,
+                    null).join());
 
         final IRI child1 = rdf.createIRI(base + "/child1");
         final Dataset dataset1 = buildDataset(child1, "Child 1", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child1).join());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, dataset1, identifier, null).get());
+        assertNull(getResourceService().create(child1, getSession(), LDP.RDFSource, dataset1, identifier, null).join());
 
         final IRI child2 = rdf.createIRI(base + "/child2");
         final Dataset dataset2 = buildDataset(child2, "Child 2", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child2).join());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, dataset2, identifier, null).join());
+        assertNull(getResourceService().create(child2, getSession(), LDP.RDFSource, dataset2, identifier, null).join());
 
         final Resource res = getResourceService().get(identifier).join();
         assertAll(checkResource(res, identifier, LDP.DirectContainer, time, dataset0));
@@ -402,20 +403,20 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, LDP.insertedContentRelation, FOAF.primaryTopic);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join());
-        assertTrue(getResourceService().create(identifier, getSession(), LDP.IndirectContainer, dataset0,
+        assertNull(getResourceService().create(identifier, getSession(), LDP.IndirectContainer, dataset0,
                     ROOT_CONTAINER, null).join());
 
         final IRI child1 = rdf.createIRI(base + "/child1");
         final Dataset dataset1 = buildDataset(child1, "Indirect Container Child 1", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child1).join());
-        assertTrue(getResourceService().create(child1, getSession(), LDP.RDFSource, dataset1, identifier, null).join());
+        assertNull(getResourceService().create(child1, getSession(), LDP.RDFSource, dataset1, identifier, null).join());
 
         final IRI child2 = rdf.createIRI(base + "/child2");
         final Dataset dataset2 = buildDataset(child2, "Indirect Container Child 2", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child2).join());
-        assertTrue(getResourceService().create(child2, getSession(), LDP.RDFSource, dataset2, identifier, null).join());
+        assertNull(getResourceService().create(child2, getSession(), LDP.RDFSource, dataset2, identifier, null).join());
 
         final Resource res = getResourceService().get(identifier).join();
         assertAll(checkResource(res, identifier, LDP.IndirectContainer, time, dataset0));

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -176,7 +177,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.replace(root, mockSession, LDP.BasicContainer, data, null, null).join());
+        assertNull(svc.replace(root, mockSession, LDP.BasicContainer, data, null, null).join());
         final Resource res2 = svc.get(root).join();
         assertAll(checkResource(res2, root, LDP.BasicContainer, later));
         assertAll(checkResourceStream(res2, 4L, 2L, 5L, 1L, 0L, 0L));
@@ -220,7 +221,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.RDFSource, dataset, root, null).join());
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.RDFSource, 1L, 3L, 3L, 0L)),
@@ -239,7 +240,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.RDFSource, dataset, root, null).join());
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.RDFSource, 1L, 3L, 1L, 0L)),
@@ -260,7 +261,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.NonRDFSource, dataset, root, binary).join());
+        assertNull(svc.create(resource, mockSession, LDP.NonRDFSource, dataset, root, binary).join());
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.NonRDFSource, 1L, 7L, 1L, 0L)),
@@ -277,7 +278,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(resource3, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(resource3, mockSession, LDP.RDFSource, dataset, resource, null).join());
 
         allOf(
             svc.get(resource3).thenAccept(res -> {
@@ -312,7 +313,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.Container, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.Container, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 3L, 3L, 3L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -326,7 +327,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 1L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.Container, 3L, 3L, 3L, 1L)),
@@ -344,7 +345,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.replace(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.replace(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 3L, 3L, 2L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.Container, 3L, 3L, 3L, 1L)),
@@ -370,8 +371,8 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.Container, dataset1, root, null).join());
-        assertTrue(svc.add(resource, mockSession, dataset2).join());
+        assertNull(svc.create(resource, mockSession, LDP.Container, dataset1, root, null).join());
+        assertNull(svc.add(resource, mockSession, dataset2).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 2L, 3L, 2L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -391,7 +392,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.Container, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.Container, dataset, root, null).join());
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 2L, 3L, 1L, 0L)),
@@ -407,7 +408,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
 
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 2L, 3L, 1L)),
@@ -426,7 +427,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant preDelete = meanwhile();
 
-        assertTrue(svc.delete(child, mockSession, LDP.Resource, dataset).join());
+        assertNull(svc.delete(child, mockSession, LDP.Resource, dataset).join());
 
         allOf(
             svc.get(child).thenAccept(res -> assertEquals(DELETED_RESOURCE, res)),
@@ -449,7 +450,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.BasicContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.BasicContainer, dataset, root, null).join());
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.BasicContainer, 3L, 3L, 0L, 0L)),
@@ -465,7 +466,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 2L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.BasicContainer, 3L, 3L, 0L, 1L)),
@@ -482,7 +483,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.replace(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.replace(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 2L, 3L, 2L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.BasicContainer, 3L, 3L, 0L, 1L)),
@@ -507,7 +508,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.DirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.DirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 5L, 7L, 0L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -520,7 +521,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 1L, 3L, 0L)),
             svc.get(resource).thenAccept(res -> {
@@ -550,7 +551,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.DirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.DirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 4L, 7L, 0L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -563,7 +564,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater, 1L, 3L, 0L, 0L)),
             svc.get(members).thenAccept(res -> assertFalse(res.getBinary().isPresent())),
@@ -579,7 +580,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 1L, 3L, 0L)),
             svc.get(resource).thenAccept(checkResource(evenLater2, LDP.DirectContainer, 4L, 7L, 0L, 1L)),
@@ -608,7 +609,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.DirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.DirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 4L, 7L, 1L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -626,7 +627,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(resource2, mockSession, LDP.DirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource2, mockSession, LDP.DirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource2).thenAccept(res -> {
                 assertAll(checkResource(res, resource2, LDP.DirectContainer, evenLater));
@@ -644,7 +645,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater2, 2L, 3L, 1L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 4L, 7L, 1L, 0L)),
@@ -664,7 +665,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater3 = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater3, 1L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.DirectContainer, 4L, 7L, 1L, 1L)),
@@ -685,7 +686,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater4 = meanwhile();
 
-        assertTrue(svc.create(child2, mockSession, LDP.RDFSource, dataset, resource2, null).join());
+        assertNull(svc.create(child2, mockSession, LDP.RDFSource, dataset, resource2, null).join());
         allOf(
             svc.get(child2).thenAccept(res -> {
                 assertAll(checkResource(res, child2, LDP.RDFSource, evenLater4));
@@ -721,7 +722,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.DirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.DirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 5L, 7L, 1L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -736,7 +737,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(resource2, mockSession, LDP.DirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource2, mockSession, LDP.DirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource2).thenAccept(res -> {
                 assertAll(checkResource(res, resource2, LDP.DirectContainer, evenLater));
@@ -753,7 +754,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater2, 1L, 3L, 1L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 5L, 7L, 1L, 0L)),
@@ -773,7 +774,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater3 = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(res -> {
                 assertAll(checkResource(res, child, LDP.RDFSource, evenLater3));
@@ -796,7 +797,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater4 = meanwhile();
 
-        assertTrue(svc.create(child2, mockSession, LDP.RDFSource, dataset, resource2, null).join());
+        assertNull(svc.create(child2, mockSession, LDP.RDFSource, dataset, resource2, null).join());
         allOf(
             svc.get(child2).thenAccept(res -> {
                 assertAll(checkResource(res, child2, LDP.RDFSource, evenLater4));
@@ -837,7 +838,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.IndirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.IndirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 7L, 7L, 4L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -855,7 +856,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater, 1L, 3L, 4L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 7L, 7L, 4L, 0L)),
@@ -875,7 +876,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 1L, 3L, 3L)),
             svc.get(resource).thenAccept(checkResource(evenLater2, LDP.IndirectContainer, 7L, 7L, 4L, 1L)),
@@ -906,7 +907,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.IndirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.IndirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 5L, 7L, 1L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -920,7 +921,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater, 1L, 3L, 1L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 5L, 7L, 1L, 0L)),
@@ -937,7 +938,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 1L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater2, LDP.IndirectContainer, 5L, 7L, 1L, 1L)),
@@ -968,7 +969,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.IndirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.IndirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 4L, 7L, 2L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -982,7 +983,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater, 1L, 3L, 1L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 4L, 7L, 2L, 0L)),
@@ -1001,7 +1002,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 2L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater2, LDP.IndirectContainer, 4L, 7L, 2L, 1L)),
@@ -1038,7 +1039,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertTrue(svc.create(resource, mockSession, LDP.IndirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource, mockSession, LDP.IndirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 5L, 7L, 3L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -1054,7 +1055,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertTrue(svc.create(resource2, mockSession, LDP.IndirectContainer, dataset, root, null).join());
+        assertNull(svc.create(resource2, mockSession, LDP.IndirectContainer, dataset, root, null).join());
         allOf(
             svc.get(resource2).thenAccept(res -> {
                 assertAll(checkResource(res, resource2, LDP.IndirectContainer, evenLater));
@@ -1071,7 +1072,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertTrue(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
+        assertNull(svc.create(members, mockSession, LDP.RDFSource, dataset, root, null).join());
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater2, 1L, 3L, 1L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 5L, 7L, 3L, 0L)),
@@ -1092,7 +1093,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater3 = meanwhile();
 
-        assertTrue(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
+        assertNull(svc.create(child, mockSession, LDP.RDFSource, dataset, resource, null).join());
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater3, 1L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater3, LDP.IndirectContainer, 5L, 7L, 3L, 1L)),
@@ -1117,7 +1118,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater4 = meanwhile();
 
-        assertTrue(svc.create(child2, mockSession, LDP.RDFSource, dataset, resource2, null).join());
+        assertNull(svc.create(child2, mockSession, LDP.RDFSource, dataset, resource2, null).join());
         allOf(
             svc.get(child2).thenAccept(res -> {
                 assertAll(checkResource(res, child2, LDP.RDFSource, evenLater4));

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -65,7 +65,10 @@ public interface BinaryService {
      * @param identifier the binary object identifier
      * @param stream the content
      * @param metadata any user metadata
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that the binary
+     * data were successfully stored in the corresponding persistence layer. In the case of an unsuccessful
+     * operation, the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     CompletableFuture<Void> setContent(IRI identifier, InputStream stream, Map<String, String> metadata);
 
@@ -73,7 +76,10 @@ public interface BinaryService {
      * Purge the content from its corresponding datastore.
      *
      * @param identifier the binary object identifier
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that the binary
+     * data were successfully deleted from the corresponding persistence layer. In the case of an unsuccessful
+     * operation, the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     CompletableFuture<Void> purgeContent(IRI identifier);
 

--- a/core/api/src/main/java/org/trellisldp/api/ImmutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ImmutableDataService.java
@@ -34,7 +34,10 @@ public interface ImmutableDataService<T> extends RetrievalService<T> {
      * @param identifier the identifier under which to persist a dataset
      * @param session the session context for this operation
      * @param dataset a dataset to persist
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that the supplied data
+     * were successfully stored in the corresponding persistence layer. In the case of an unsuccessful write operation,
+     * the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     CompletableFuture<Void> add(IRI identifier, Session session, Dataset dataset);
 

--- a/core/api/src/main/java/org/trellisldp/api/ImmutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ImmutableDataService.java
@@ -34,8 +34,8 @@ public interface ImmutableDataService<T> extends RetrievalService<T> {
      * @param identifier the identifier under which to persist a dataset
      * @param session the session context for this operation
      * @param dataset a dataset to persist
-     * @return whether the resource was successfully persisted
+     * @return the new completion stage
      */
-    CompletableFuture<Boolean> add(IRI identifier, Session session, Dataset dataset);
+    CompletableFuture<Void> add(IRI identifier, Session session, Dataset dataset);
 
 }

--- a/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -65,24 +65,24 @@ public abstract class JoiningResourceService implements ResourceService {
     }
 
     @Override
-    public CompletableFuture<Boolean> add(final IRI id, final Session session, final Dataset dataset) {
+    public CompletableFuture<Void> add(final IRI id, final Session session, final Dataset dataset) {
         return immutableData.add(id, session, dataset);
     }
 
     @Override
-    public CompletableFuture<Boolean> create(final IRI id, final Session session, final IRI ixnModel,
+    public CompletableFuture<Void> create(final IRI id, final Session session, final IRI ixnModel,
             final Dataset dataset, final IRI container, final Binary binary) {
         return mutableData.create(id, session, ixnModel, dataset, container, binary);
     }
 
     @Override
-    public CompletableFuture<Boolean> replace(final IRI id, final Session session, final IRI ixnModel,
+    public CompletableFuture<Void> replace(final IRI id, final Session session, final IRI ixnModel,
             final Dataset dataset, final IRI container, final Binary binary) {
         return mutableData.replace(id, session, ixnModel, dataset, container, binary);
     }
 
     @Override
-    public CompletableFuture<Boolean> delete(final IRI id, final Session session, final IRI ixnModel,
+    public CompletableFuture<Void> delete(final IRI id, final Session session, final IRI ixnModel,
             final Dataset dataset) {
         return mutableData.delete(id, session, ixnModel, dataset);
     }

--- a/core/api/src/main/java/org/trellisldp/api/MementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MementoService.java
@@ -32,14 +32,20 @@ public interface MementoService {
      * @param identifier the resource identifier
      * @param time the time of the Memento
      * @param data the data to save
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that Memento resource was
+     * successfully created in the corresponding persistence layer. In the case of an unsuccessful write operation,
+     * the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     CompletableFuture<Void> put(IRI identifier, Instant time, Stream<? extends Quad> data);
 
     /**
      * Create a new Memento for a resource.
      * @param resource the resource
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that Memento resource was
+     * successfully created in the corresponding persistence layer. In the case of an unsuccessful write operation,
+     * the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     default CompletableFuture<Void> put(Resource resource) {
         return put(resource.getIdentifier(), resource.getModified(), resource.stream());
@@ -64,7 +70,10 @@ public interface MementoService {
      * Delete a Memento resource.
      * @param identifier the resource identifier
      * @param time the version at the given time
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that Memento resource was
+     * successfully deleted from the corresponding persistence layer. In the case of an unsuccessful write operation,
+     * the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     CompletableFuture<Void> delete(IRI identifier, Instant time);
 }

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -36,9 +36,9 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param dataset the dataset to be persisted
      * @param container an LDP container for this resource, {@code null} for none
      * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
-     * @return whether the resource was added
+     * @return the new completion stage
      */
-    CompletableFuture<Boolean> create(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
+    CompletableFuture<Void> create(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
             Binary binary);
 
     /**
@@ -50,9 +50,9 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param dataset the dataset to be persisted
      * @param container an LDP container for this resource, {@code null} for none
      * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
-     * @return whether the resource was replaced
+     * @return the new completion stage
      */
-    CompletableFuture<Boolean> replace(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
+    CompletableFuture<Void> replace(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
             Binary binary);
 
     /**
@@ -62,8 +62,8 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param session the session context for this operation
      * @param ixnModel the new LDP interaction model for this resource
      * @param dataset the dataset
-     * @return whether the resource was deleted
+     * @return the new completion stage
      */
-    CompletableFuture<Boolean> delete(IRI identifier, Session session, IRI ixnModel, Dataset dataset);
+    CompletableFuture<Void> delete(IRI identifier, Session session, IRI ixnModel, Dataset dataset);
 
 }

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -28,7 +28,7 @@ import org.apache.commons.rdf.api.IRI;
 public interface MutableDataService<U> extends RetrievalService<U> {
 
     /**
-     * Put a resource into the server.
+     * Create a resource in the server.
      *
      * @param identifier the identifier for the new resource
      * @param session the session context for this operation
@@ -36,7 +36,10 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param dataset the dataset to be persisted
      * @param container an LDP container for this resource, {@code null} for none
      * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that the supplied data were
+     * successfully created in the corresponding persistence layer. In the case of an unsuccessful write operation,
+     * the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     CompletableFuture<Void> create(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
             Binary binary);
@@ -50,7 +53,10 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param dataset the dataset to be persisted
      * @param container an LDP container for this resource, {@code null} for none
      * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that the supplied data
+     * were successfully stored in the corresponding persistence layer. In the case of an unsuccessful write operation,
+     * the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     CompletableFuture<Void> replace(IRI identifier, Session session, IRI ixnModel, Dataset dataset, IRI container,
             Binary binary);
@@ -62,7 +68,10 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param session the session context for this operation
      * @param ixnModel the new LDP interaction model for this resource
      * @param dataset the dataset
-     * @return the new completion stage
+     * @return a new completion stage that, when the stage completes normally, indicates that the resource
+     * was successfully deleted from the corresponding persistence layer. In the case of an unsuccessful delete
+     * operation, the {@link CompletableFuture} will complete exceptionally and can be handled with
+     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
     CompletableFuture<Void> delete(IRI identifier, Session session, IRI ixnModel, Dataset dataset);
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -148,26 +148,6 @@ class BaseLdpHandler {
         return services;
     }
 
-    /**
-     * Handle the results of a pair of writes of resource and audit triples.
-     * @param mutable the mutable data
-     * @param immutable the immutable data
-     * @return true if the writes both succeeded; false otherwise
-     */
-    protected Boolean handleWriteResults(final Boolean mutable, final Boolean immutable) {
-        if (!mutable) {
-            LOGGER.error("Error adding mutable/managed RDF data to {}", getIdentifier());
-        }
-        if (!immutable) {
-            LOGGER.error("Error adding immutable/audit data to {}", getIdentifier());
-        }
-        final boolean result = mutable && immutable;
-        if (result) {
-            LOGGER.debug("Successfully persisted data for {}", getIdentifier());
-        }
-        return result;
-    }
-
     private static String getRequestBaseUrl(final LdpRequest req, final String baseUrl) {
         final String base = ofNullable(baseUrl).orElseGet(req::getBaseUrl);
         if (base.endsWith("/")) {

--- a/core/http/src/test/java/org/trellisldp/http/BaseLdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseLdpResourceTest.java
@@ -240,13 +240,13 @@ abstract class BaseLdpResourceTest extends JerseyTest {
         });
 
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
-            .thenReturn(completedFuture(true));
+            .thenReturn(completedFuture(null));
         when(mockResourceService.delete(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
-            .thenReturn(completedFuture(true));
+            .thenReturn(completedFuture(null));
         when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class),
-                        any(), any())).thenReturn(completedFuture(true));
+                        any(), any())).thenReturn(completedFuture(null));
         when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class),
-                        any(), any())).thenReturn(completedFuture(true));
+                        any(), any())).thenReturn(completedFuture(null));
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/core/http/src/test/java/org/trellisldp/http/impl/HandlerBaseTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/HandlerBaseTest.java
@@ -21,6 +21,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.of;
 import static javax.ws.rs.HttpMethod.DELETE;
@@ -88,6 +89,7 @@ import org.trellisldp.api.NoopAuditService;
 import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.api.ServiceBundler;
 import org.trellisldp.api.Session;
 import org.trellisldp.http.domain.LdpRequest;
@@ -209,17 +211,23 @@ abstract class HandlerBaseTest {
         return hasLink(iri, TYPE);
     }
 
+    protected static CompletableFuture<Void> asyncException() {
+        return runAsync(() -> {
+            throw new RuntimeTrellisException("Expected exception");
+        });
+    }
+
     private void setUpResourceService() {
         when(mockResourceService.supportedInteractionModels()).thenReturn(allInteractionModels);
         when(mockResourceService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockResource));
         when(mockResourceService.create(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class),
-                        any(), any())).thenReturn(completedFuture(true));
+                        any(), any())).thenReturn(completedFuture(null));
         when(mockResourceService.replace(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class),
-                        any(), any())).thenReturn(completedFuture(true));
+                        any(), any())).thenReturn(completedFuture(null));
         when(mockResourceService.delete(any(IRI.class), any(Session.class), any(IRI.class), any(Dataset.class)))
-            .thenReturn(completedFuture(true));
+            .thenReturn(completedFuture(null));
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
-            .thenReturn(completedFuture(true));
+            .thenReturn(completedFuture(null));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(BlankNode.class))).thenAnswer(inv ->

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -15,13 +15,11 @@ package org.trellisldp.http.impl;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Stream.of;
 import static javax.ws.rs.core.Link.fromUri;
 import static javax.ws.rs.core.MediaType.TEXT_HTML_TYPE;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.status;
@@ -46,6 +44,7 @@ import static org.trellisldp.vocabulary.Trellis.PreferUserManaged;
 import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 
 import java.util.Date;
+import java.util.concurrent.CompletionException;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.WebApplicationException;
@@ -88,14 +87,12 @@ public class PatchHandlerTest extends HandlerBaseTest {
         when(mockBundler.getAuditService()).thenReturn(new DefaultAuditService() {});
         // will never store audit
         when(mockResourceService.add(any(IRI.class), any(Session.class), any(Dataset.class)))
-            .thenReturn(completedFuture(false));
+            .thenReturn(asyncException());
 
         final PatchHandler handler = new PatchHandler(mockLdpRequest, "", mockBundler, null);
 
-        final Response res = assertThrows(WebApplicationException.class, () ->
-                unwrapAsyncError(handler.updateResource(handler.initialize(mockResource)))).getResponse();
-
-        assertEquals(INTERNAL_SERVER_ERROR, res.getStatusInfo());
+        assertThrows(CompletionException.class, () ->
+                unwrapAsyncError(handler.updateResource(handler.initialize(mockResource))));
     }
 
     @Test
@@ -183,14 +180,12 @@ public class PatchHandlerTest extends HandlerBaseTest {
         when(mockLdpRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockLdpRequest.getPath()).thenReturn("resource");
         when(mockResourceService.replace(eq(identifier), any(Session.class),
-                    any(IRI.class), any(Dataset.class), any(), any())).thenReturn(completedFuture(false));
+                    any(IRI.class), any(Dataset.class), any(), any())).thenReturn(asyncException());
 
         final PatchHandler patchHandler = new PatchHandler(mockLdpRequest, insert, mockBundler, null);
 
-        final Response res = assertThrows(WebApplicationException.class, () ->
-                unwrapAsyncError(patchHandler.updateResource(patchHandler.initialize(mockResource)))).getResponse();
-
-        assertEquals(INTERNAL_SERVER_ERROR, res.getStatusInfo());
+        assertThrows(CompletionException.class, () ->
+                unwrapAsyncError(patchHandler.updateResource(patchHandler.initialize(mockResource))));
     }
 
     @Test


### PR DESCRIPTION
Resolves #183

The changes mutating async methods such that they return
`CompletableFuture<Void>` rather than `CompletableFuture<Boolean>`.