### PR TITLE
Adjust how the webac module interprets acl:default

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/AbstractApplicationAuthTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AbstractApplicationAuthTests.java
@@ -282,6 +282,18 @@ public abstract class AbstractApplicationAuthTests {
                 container = res.getLocation().toString();
             }
 
+            // Add an ACL for this container, with no permissions
+            final String rootAcl = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+                + prefixAcl
+                + "INSERT DATA { [ acl:accessTo <" + container + ">; acl:agentClass foaf:Agent; \n"
+                + "    acl:default <" + container + ">]}";
+
+            // Add an ACL for the quasi-root container
+            try (final Response res = target(container + EXT_ACL).request().header(AUTHORIZATION, jwt)
+                    .method(PATCH, entity(rootAcl, APPLICATION_SPARQL_UPDATE))) {
+                assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily());
+            }
+
             // POST a public container
             try (final Response res = target(container).request()
                     .header(LINK, fromUri(LDP.BasicContainer.getIRIString()).rel(TYPE).build())
@@ -303,10 +315,10 @@ public abstract class AbstractApplicationAuthTests {
             final String publicAcl = "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
                 + prefixAcl
                 + "INSERT DATA { [acl:accessTo <" + publicContainer + ">; acl:mode acl:Read; "
-                + "   acl:agentClass foaf:Agent ] }; \n"
+                + "   acl:agentClass foaf:Agent; acl:default <" + publicContainer + "> ] }; \n"
                 + prefixAcl
                 + "INSERT DATA { [acl:accessTo <" + publicContainer + ">; acl:mode acl:Read, acl:Write;"
-                + "   acl:agentClass acl:AuthenticatedAgent ] }";
+                + "   acl:agentClass acl:AuthenticatedAgent; acl:default <" + publicContainer + ">] }";
 
             // Add an ACL for the public container
             try (final Response res = target(getPublicContainer() + EXT_ACL).request().header(AUTHORIZATION, jwt)
@@ -335,11 +347,12 @@ public abstract class AbstractApplicationAuthTests {
             final String protectedAcl = prefixAcl
                 + "INSERT DATA { \n"
                 + "[acl:accessTo  <" + protectedContainer + ">;  acl:mode acl:Read, acl:Write;"
-                + "   acl:agent <https://people.apache.org/~acoburn/#i> ] };"
+                + "   acl:agent <https://people.apache.org/~acoburn/#i>; acl:default <" + protectedContainer + "> ] };"
                 + prefixAcl
                 + "INSERT DATA { \n"
                 + "[acl:accessTo  <" + protectedContainer + ">; acl:mode acl:Read, acl:Append; "
-                + "   acl:agent <https://madison.example.com/profile/#me> ] }";
+                + "   acl:agent <https://madison.example.com/profile/#me>; "
+                + "   acl:default <" + protectedContainer + "> ] }";
 
             // Add an ACL for the protected container
             try (final Response res = target(getProtectedContainer() + EXT_ACL).request().header(AUTHORIZATION, jwt)
@@ -368,7 +381,7 @@ public abstract class AbstractApplicationAuthTests {
             final String privateAcl = prefixAcl
                 + "INSERT DATA { "
                 + "[acl:accessTo  <" + privateContainer + ">; acl:mode acl:Read, acl:Write; "
-                + "   acl:agent <http://example.com/administrator> ] }";
+                + "   acl:agent <http://example.com/administrator>; acl:default <" + privateContainer + "> ] }";
 
             // Add an ACL for the private container
             try (final Response res = target(getPrivateContainer() + EXT_ACL).request().header(AUTHORIZATION, jwt)
@@ -416,11 +429,11 @@ public abstract class AbstractApplicationAuthTests {
             final String groupAcl = prefixAcl
                 + "INSERT DATA {  "
                 + "[acl:accessTo <" + groupContainer + ">; acl:mode acl:Read, acl:Write; "
-                + " acl:agentGroup <" + groupResource + "#Developers> ] };\n"
+                + " acl:agentGroup <" + groupResource + "#Developers>; acl:default <" + groupContainer + "> ] };\n"
                 + prefixAcl
                 + "INSERT DATA {  "
                 + "[acl:accessTo <" + groupContainer + ">; acl:mode acl:Read; "
-                + " acl:agentGroup <" + groupResource + "#Management> ] }";
+                + " acl:agentGroup <" + groupResource + "#Management>; acl:default <" + groupContainer + "> ] }";
 
             // Add an ACL for the private container
             try (final Response res = target(groupContainer + EXT_ACL).request().header(AUTHORIZATION, jwt)
@@ -452,7 +465,6 @@ public abstract class AbstractApplicationAuthTests {
                 + "[acl:accessTo <" + defaultContainer + ">; acl:mode acl:Read; acl:agentClass foaf:Agent ] }; \n"
                 + prefixAcl
                 + "INSERT DATA { [acl:accessTo <" + defaultContainer + ">; acl:mode acl:Read, acl:Write; \n"
-                + "   acl:default <" + defaultContainer + ">; \n"
                 + "   acl:agent <https://people.apache.org/~acoburn/#i> ] }";
 
             // Add an ACL for the public container

--- a/components/test/src/main/java/org/trellisldp/test/AuthAnonymousTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuthAnonymousTests.java
@@ -348,10 +348,10 @@ public interface AuthAnonymousTests extends AuthCommonTests {
     }
 
     /**
-     * Verify that an anonymous user can read a default ACL resource.
+     * Verify that an anonymous user can read a non-inheriting ACL resource.
      */
     @Test
-    @DisplayName("Verify that an anonymous user can read a default ACL resource")
+    @DisplayName("Verify that an anonymous user can read a non-inheriting ACL resource")
     default void testCanReadDefaultAclResource() {
         try (final Response res = target(getDefaultContainer()).request().get()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily());
@@ -359,10 +359,11 @@ public interface AuthAnonymousTests extends AuthCommonTests {
     }
 
     /**
-     * Verify that an anonymous user cannot read the child of a default ACL resource.
+     * Verify that an anonymous user cannot read the child of a resource with no
+     * default ACL inheritance.
      */
     @Test
-    @DisplayName("Verify that an anonymous user cannot read the child of a default ACL resource")
+    @DisplayName("Verify that an anonymous user can read the child of a default ACL resource")
     default void testCanReadDefaultAclResourceChild() {
         try (final Response res = target(getDefaultContainerChild()).request().get()) {
             assertEquals(UNAUTHORIZED, fromStatusCode(res.getStatus()));

--- a/components/test/src/main/java/org/trellisldp/test/AuthUserTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuthUserTests.java
@@ -101,7 +101,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot control a public resource")
-    default void testUserCanControlPublicResource() {
+    default void testUserCannotControlPublicResource() {
         try (final Response res = target(getPublicContainer() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -113,7 +113,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot control the child of a public resource")
-    default void testUserCanControlPublicResourceChild() {
+    default void testUserCannotControlPublicResourceChild() {
         try (final Response res = target(getPublicContainerChild() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -187,7 +187,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot control a protected resource")
-    default void testUserCanControlProtectedResource() {
+    default void testUserCannotControlProtectedResource() {
         try (final Response res = target(getProtectedContainer() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -199,7 +199,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot control the child of a protected resource")
-    default void testUserCanControlProtectedResourceChild() {
+    default void testUserCannotControlProtectedResourceChild() {
         try (final Response res = target(getProtectedContainerChild() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -211,7 +211,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot read a private resource")
-    default void testUserCanReadPrivateResource() {
+    default void testUserCannotReadPrivateResource() {
         try (final Response res = target(getPrivateContainer()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -223,7 +223,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot read the child of a private resource")
-    default void testUserCanReadPrivateResourceChild() {
+    default void testUserCannotReadPrivateResourceChild() {
         try (final Response res = target(getPrivateContainerChild()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -235,7 +235,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot append to a private resource")
-    default void testUserCanAppendPrivateResource() {
+    default void testUserCannotAppendPrivateResource() {
         try (final Response res = target(getPrivateContainer()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).post(entity("", TEXT_TURTLE))) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -247,7 +247,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot write to a private resource")
-    default void testUserCanWritePrivateResource() {
+    default void testUserCannotWritePrivateResource() {
         try (final Response res = target(getPrivateContainer()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader())
                 .method(PATCH, entity(INSERT_PROP_FOO, APPLICATION_SPARQL_UPDATE))) {
@@ -260,7 +260,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot write to the child of a private resource")
-    default void testUserCanWritePrivateResourceChild() {
+    default void testUserCannotWritePrivateResourceChild() {
         try (final Response res = target(getPrivateContainerChild()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader())
                 .method(PATCH, entity(INSERT_PROP_FOO, APPLICATION_SPARQL_UPDATE))) {
@@ -273,7 +273,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot control a private resource")
-    default void testUserCanControlPrivateResource() {
+    default void testUserCannotControlPrivateResource() {
         try (final Response res = target(getPrivateContainer() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -285,7 +285,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot control the child of a private resource")
-    default void testUserCanControlPrivateResourceChild() {
+    default void testUserCannotControlPrivateResourceChild() {
         try (final Response res = target(getPrivateContainerChild() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -347,7 +347,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot control a group-controlled resource")
-    default void testCanControlGroupResource() {
+    default void testCannotControlGroupResource() {
         try (final Response res = target(getGroupContainer() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -359,7 +359,7 @@ public interface AuthUserTests extends AuthCommonTests {
      */
     @Test
     @DisplayName("Verify that a user cannot control the child of a group-controlled resource")
-    default void testCanControlGroupResourceChild() {
+    default void testCannotControlGroupResourceChild() {
         try (final Response res = target(getGroupContainerChild() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -367,10 +367,10 @@ public interface AuthUserTests extends AuthCommonTests {
     }
 
     /**
-     * Verify that a user can read a default ACL resource.
+     * Verify that a user can read a non-inheritable ACL resource.
      */
     @Test
-    @DisplayName("Verify that a user can read a default ACL resource")
+    @DisplayName("Verify that a user can read a non-inheritable ACL resource")
     default void testCanReadDefaultAclResource() {
         try (final Response res = target(getDefaultContainer()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
@@ -379,22 +379,22 @@ public interface AuthUserTests extends AuthCommonTests {
     }
 
     /**
-     * Verify that a user can read the child of a default ACL resource.
+     * Verify that a user cannot read the child of a non-inheritable ACL resource.
      */
     @Test
-    @DisplayName("Verify that a user can read the child of a default ACL resource")
-    default void testCanReadDefaultAclResourceChild() {
+    @DisplayName("Verify that a user cannot read the child of a non-inheritable ACL resource")
+    default void testCannotReadDefaultAclResourceChild() {
         try (final Response res = target(getDefaultContainerChild()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
-            assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily());
+            assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
         }
     }
 
     /**
-     * Verify that a user can write to a default ACL resource.
+     * Verify that a user can write to a non-inheritable ACL resource.
      */
     @Test
-    @DisplayName("Verify that a user can write to a default ACL resource")
+    @DisplayName("Verify that a user can write to a non-inheritable ACL resource")
     default void testCanWriteDefaultAclResource() {
         try (final Response res = target(getDefaultContainer()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader())
@@ -404,24 +404,24 @@ public interface AuthUserTests extends AuthCommonTests {
     }
 
     /**
-     * Verify that a user can write to the child of a default ACL resource.
+     * Verify that a user cannot write to the child of a non-inheritable ACL resource.
      */
     @Test
-    @DisplayName("Verify that a user can write to the child of a default ACL resource")
-    default void testCanWriteDefaultAclResourceChild() {
+    @DisplayName("Verify that a user cannot write to the child of a non-inheritable ACL resource")
+    default void testCannotWriteDefaultAclResourceChild() {
         try (final Response res = target(getDefaultContainerChild()).request()
                 .header(AUTHORIZATION, getAuthorizationHeader())
                 .method(PATCH, entity(INSERT_PROP_FOO, APPLICATION_SPARQL_UPDATE))) {
-            assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily());
+            assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
         }
     }
 
     /**
-     * Verify that a user cannot control a default ACL resource.
+     * Verify that a user cannot control a non-inheritable ACL resource.
      */
     @Test
-    @DisplayName("Verify that a user cannot control a default ACL resource")
-    default void testCanControlDefaultAclResource() {
+    @DisplayName("Verify that a user cannot control a non-inheritable ACL resource")
+    default void testCannotControlDefaultAclResource() {
         try (final Response res = target(getDefaultContainer() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));
@@ -429,11 +429,11 @@ public interface AuthUserTests extends AuthCommonTests {
     }
 
     /**
-     * Verify that a user cannot control the child of a default ACL resource.
+     * Verify that a user cannot control the child of a non-inheritable ACL resource.
      */
     @Test
-    @DisplayName("Verify that a user cannot control the child of a default ACL resource")
-    default void testCanControlDefaultAclResourceChild() {
+    @DisplayName("Verify that a user cannot control the child of a non-inheritable ACL resource")
+    default void testCannotControlDefaultAclResourceChild() {
         try (final Response res = target(getDefaultContainerChild() + EXT_ACL).request()
                 .header(AUTHORIZATION, getAuthorizationHeader()).get()) {
             assertEquals(FORBIDDEN, fromStatusCode(res.getStatus()));


### PR DESCRIPTION
Resolves #199 

The change here is that a parent resource with an Authorization with `<> acl:default <>` will have its ACL statements inherited; if that `acl:default` statement is not present, then a further parent container will be checked. The root resource does not need the `acl:default` statement, as it is a global catch-all.