### PR TITLE
Simplify NamespaceService interface

### DIFF
--- a/components/io-jena/src/test/java/org/trellisldp/io/IOServiceTest.java
+++ b/components/io-jena/src/test/java/org/trellisldp/io/IOServiceTest.java
@@ -16,7 +16,6 @@ package org.trellisldp.io;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
-import static java.util.Optional.empty;
 import static java.util.stream.Stream.of;
 import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
 import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
@@ -62,7 +61,6 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -129,12 +127,6 @@ public class IOServiceTest {
         service3 = new JenaIOService(mockNamespaceService, null, mockCache, emptySet(), emptySet());
 
         when(mockNamespaceService.getNamespaces()).thenReturn(namespaces);
-        when(mockNamespaceService.getPrefix(eq("http://purl.org/dc/terms/"))).thenReturn(Optional.of("dc"));
-        when(mockNamespaceService.getPrefix(eq("http://sws.geonames.org/4929022/"))).thenReturn(empty());
-        when(mockNamespaceService.getPrefix(eq("http://www.w3.org/1999/02/22-rdf-syntax-ns#")))
-            .thenReturn(Optional.of("rdf"));
-        when(mockNamespaceService.getPrefix(eq("http://purl.org/dc/dcmitype/")))
-            .thenReturn(Optional.of("dcmitype"));
         when(mockCache.get(anyString(), any(Function.class))).thenAnswer(inv -> {
             final String key = inv.getArgument(0);
             final Function<String, String> mapper = inv.getArgument(1);

--- a/components/namespaces/build.gradle
+++ b/components/namespaces/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
     testImplementation("javax.annotation:javax.annotation-api:$javaxAnnotationsVersion")
     testImplementation("org.apache.tamaya:tamaya-core:$tamayaVersion")
+    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
+    testImplementation project(':trellis-vocabulary')
 }
 
 jar {

--- a/components/namespaces/src/main/java/org/trellisldp/namespaces/NamespacesJsonContext.java
+++ b/components/namespaces/src/main/java/org/trellisldp/namespaces/NamespacesJsonContext.java
@@ -16,7 +16,6 @@ package org.trellisldp.namespaces;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -26,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
@@ -75,16 +73,6 @@ public class NamespacesJsonContext implements NamespaceService {
     @Override
     public Map<String, String> getNamespaces() {
         return unmodifiableMap(data);
-    }
-
-    @Override
-    public Optional<String> getNamespace(final String prefix) {
-        return ofNullable(data.get(prefix));
-    }
-
-    @Override
-    public Optional<String> getPrefix(final String namespace) {
-        return ofNullable(dataRev.get(namespace));
     }
 
     @Override

--- a/components/namespaces/src/test/java/org/trellisldp/namespaces/NamespacesJsonContextTest.java
+++ b/components/namespaces/src/test/java/org/trellisldp/namespaces/NamespacesJsonContextTest.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.namespaces;
 
-import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -52,8 +51,6 @@ public class NamespacesJsonContextTest {
             System.setProperty(NamespacesJsonContext.NAMESPACES_PATH, res.getPath());
             final NamespacesJsonContext svc = new NamespacesJsonContext();
             assertEquals(2, svc.getNamespaces().size(), "Namespace mapping count is incorrect!");
-            assertEquals(of(LDP), svc.getNamespace("ldp"), "LDP namespace is incorrect!");
-            assertEquals(of("ldp"), svc.getPrefix(LDP), "LDP prefix is incorrect!");
         } finally {
             System.clearProperty(NamespacesJsonContext.NAMESPACES_PATH);
         }
@@ -98,16 +95,13 @@ public class NamespacesJsonContextTest {
 
             final NamespacesJsonContext svc1 = new NamespacesJsonContext();
             assertEquals(15, svc1.getNamespaces().size(), "Incorrect namespace mapping count!");
-            assertFalse(svc1.getNamespace("jsonld").isPresent(), "jsonld namespace unexpectedly found!");
-            assertFalse(svc1.getPrefix(JSONLD).isPresent(), "jsonld prefix unexpectedly found!");
+            assertFalse(svc1.getNamespaces().containsKey("jsonld"), "jsonld prefix unexpectedly found!");
             assertTrue(svc1.setPrefix("jsonld", JSONLD), "unable to set jsonld mapping!");
             assertEquals(16, svc1.getNamespaces().size(), "Namespace count was not incremented!");
-            assertEquals(of(JSONLD), svc1.getNamespace("jsonld"), "jsonld namespace not found in mapping!");
-            assertEquals(of("jsonld"), svc1.getPrefix(JSONLD), "jsonld prefix not found in mapping!");
+            assertTrue(svc1.getNamespaces().containsKey("jsonld"), "jsonld prefix not found in mapping!");
 
             final NamespacesJsonContext svc2 = new NamespacesJsonContext();
             assertEquals(16, svc2.getNamespaces().size(), "Incorrect namespace count when reloading from file!");
-            assertEquals(of(JSONLD), svc2.getNamespace("jsonld"), "jsonld namespace not found in mapping!");
             assertFalse(svc2.setPrefix("jsonld", JSONLD), "unexpected response when trying to re-set jsonld mapping!");
         } finally {
             System.getProperties().remove(NamespacesJsonContext.NAMESPACES_PATH);

--- a/components/namespaces/src/test/java/org/trellisldp/namespaces/NamespacesJsonContextTest.java
+++ b/components/namespaces/src/test/java/org/trellisldp/namespaces/NamespacesJsonContextTest.java
@@ -28,6 +28,7 @@ import java.security.SecureRandom;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.trellisldp.vocabulary.JSONLD;
 
 /**
  * @author acoburn
@@ -35,8 +36,6 @@ import org.junit.jupiter.api.Test;
 public class NamespacesJsonContextTest {
 
     private static final String nsDoc = "/testNamespaces.json";
-    private static final String JSONLD = "http://www.w3.org/ns/json-ld#";
-    private static final String LDP = "http://www.w3.org/ns/ldp#";
 
     @AfterAll
     public static void cleanUp() throws IOException {
@@ -96,13 +95,14 @@ public class NamespacesJsonContextTest {
             final NamespacesJsonContext svc1 = new NamespacesJsonContext();
             assertEquals(15, svc1.getNamespaces().size(), "Incorrect namespace mapping count!");
             assertFalse(svc1.getNamespaces().containsKey("jsonld"), "jsonld prefix unexpectedly found!");
-            assertTrue(svc1.setPrefix("jsonld", JSONLD), "unable to set jsonld mapping!");
+            assertTrue(svc1.setPrefix("jsonld", JSONLD.getNamespace()), "unable to set jsonld mapping!");
             assertEquals(16, svc1.getNamespaces().size(), "Namespace count was not incremented!");
             assertTrue(svc1.getNamespaces().containsKey("jsonld"), "jsonld prefix not found in mapping!");
 
             final NamespacesJsonContext svc2 = new NamespacesJsonContext();
             assertEquals(16, svc2.getNamespaces().size(), "Incorrect namespace count when reloading from file!");
-            assertFalse(svc2.setPrefix("jsonld", JSONLD), "unexpected response when trying to re-set jsonld mapping!");
+            assertFalse(svc2.setPrefix("jsonld", JSONLD.getNamespace()),
+                    "unexpected response when trying to re-set jsonld mapping!");
         } finally {
             System.getProperties().remove(NamespacesJsonContext.NAMESPACES_PATH);
         }

--- a/components/rdfa/build.gradle
+++ b/components/rdfa/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     implementation("commons-io:commons-io:$commonsIoVersion")
     implementation("com.github.spullara.mustache.java:compiler:$mustacheVersion")
+    implementation("org.apache.jena:jena-osgi:$jenaVersion")
     implementation("org.apache.tamaya:tamaya-api:$tamayaVersion")
     implementation("org.slf4j:slf4j-api:$slf4jVersion")
     implementation project(':trellis-vocabulary')
@@ -22,7 +23,6 @@ dependencies {
     testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
     testImplementation("org.apache.commons:commons-compress:$commonsCompressVersion")
     testImplementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion")
-    testImplementation("org.apache.jena:jena-osgi:$jenaVersion")
     testImplementation("org.apache.tamaya:tamaya-core:$tamayaVersion")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
 }

--- a/components/rdfa/src/test/java/org/trellisldp/rdfa/HtmlSerializerTest.java
+++ b/components/rdfa/src/test/java/org/trellisldp/rdfa/HtmlSerializerTest.java
@@ -14,7 +14,6 @@
 package org.trellisldp.rdfa;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Optional.empty;
 import static java.util.stream.Stream.of;
 import static org.apache.jena.graph.NodeFactory.createBlankNode;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
@@ -30,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -41,7 +39,6 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.Triple;
@@ -76,18 +73,13 @@ public class HtmlSerializerTest {
     public void setUp() {
         initMocks(this);
         final Map<String, String> namespaces = new HashMap<>();
-        namespaces.put("dcterms", DCTerms.NS);
+        namespaces.put("dc", DCTerms.NS);
         namespaces.put("rdf", RDF.uri);
+        namespaces.put("dcmitype", "http://purl.org/dc/dcmitype/");
+        when(mockNamespaceService.getNamespaces()).thenReturn(namespaces);
 
         service = new HtmlSerializer(mockNamespaceService);
 
-        when(mockNamespaceService.getNamespaces()).thenReturn(namespaces);
-        when(mockNamespaceService.getPrefix(eq("http://purl.org/dc/terms/"))).thenReturn(Optional.of("dc"));
-        when(mockNamespaceService.getPrefix(eq("http://sws.geonames.org/4929022/"))).thenReturn(empty());
-        when(mockNamespaceService.getPrefix(eq("http://www.w3.org/1999/02/22-rdf-syntax-ns#")))
-            .thenReturn(Optional.of("rdf"));
-        when(mockNamespaceService.getPrefix(eq("http://purl.org/dc/dcmitype/")))
-            .thenReturn(Optional.of("dcmitype"));
     }
 
     @Test

--- a/core/api/src/main/java/org/trellisldp/api/NamespaceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NamespaceService.java
@@ -14,7 +14,6 @@
 package org.trellisldp.api;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Namespaces may be stored globally across the server, and the NamespaceService
@@ -30,22 +29,6 @@ public interface NamespaceService {
      * @return the namespace mapping as prefix, namespace pairs
      */
     Map<String, String> getNamespaces();
-
-    /**
-     * Fetch the namespace for a particular prefix.
-     *
-     * @param prefix the prefix
-     * @return the corresponding namespace
-     */
-    Optional<String> getNamespace(String prefix);
-
-    /**
-     * Fetch the prefix for a particular namespace.
-     *
-     * @param namespace the namespace
-     * @return the corresponding prefix
-     */
-    Optional<String> getPrefix(String namespace);
 
     /**
      * Set the namespace for a given prefix.

--- a/core/api/src/main/java/org/trellisldp/api/NoopNamespaceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopNamespaceService.java
@@ -16,7 +16,6 @@ package org.trellisldp.api;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * A {@link NamespaceService} that stores nothing and offers nothing.
@@ -29,16 +28,6 @@ public class NoopNamespaceService implements NamespaceService {
     @Override
     public Map<String, String> getNamespaces() {
         return Collections.emptyMap();
-    }
-
-    @Override
-    public Optional<String> getNamespace(final String prefix) {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<String> getPrefix(final String namespace) {
-        return Optional.empty();
     }
 
     @Override

--- a/core/api/src/test/java/org/trellisldp/api/NoopNamespaceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopNamespaceServiceTest.java
@@ -14,7 +14,6 @@
 
 package org.trellisldp.api;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -25,8 +24,6 @@ public class NoopNamespaceServiceTest {
     public void noAction() {
         final NamespaceService testService = new NoopNamespaceService();
         testService.setPrefix("foo", "http://bar/");
-        assertFalse(testService.getNamespace("foo").isPresent(), "Prefix present in no-op namespace svc!");
         assertTrue(testService.getNamespaces().isEmpty(), "Namespace list not empty in no-op service!");
-        assertFalse(testService.getPrefix("http://bar/").isPresent(), "Namespace present in no-op service!");
     }
 }


### PR DESCRIPTION
Resolves #221

This removes some NamespaceService methods that either aren't used or which could be easily refactored out of existence.