### PR TITLE
Separate Trellis resource matcher and request filter

### DIFF
--- a/components/app/src/main/java/org/trellisldp/app/AbstractTrellisApplication.java
+++ b/components/app/src/main/java/org/trellisldp/app/AbstractTrellisApplication.java
@@ -37,6 +37,7 @@ import org.trellisldp.app.config.TrellisConfiguration;
 import org.trellisldp.http.AgentAuthorizationFilter;
 import org.trellisldp.http.CacheControlFilter;
 import org.trellisldp.http.CrossOriginResourceSharingFilter;
+import org.trellisldp.http.TrellisHttpFilter;
 import org.trellisldp.http.TrellisHttpResource;
 import org.trellisldp.http.WebAcFilter;
 import org.trellisldp.http.WebSubHeaderFilter;
@@ -118,6 +119,7 @@ public abstract class AbstractTrellisApplication<T extends TrellisConfiguration>
 
         // Filters
         environment.jersey().register(agentFilter);
+        environment.jersey().register(new TrellisHttpFilter());
         environment.jersey().register(new CacheControlFilter(config.getCache().getMaxAge(),
                     config.getCache().getMustRevalidate(), config.getCache().getNoCache()));
 

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http;
+
+import static java.util.Arrays.asList;
+import static java.util.Objects.isNull;
+import static java.util.Optional.ofNullable;
+import static javax.ws.rs.Priorities.AUTHORIZATION;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
+import static javax.ws.rs.core.Response.seeOther;
+import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.UriBuilder.fromUri;
+import static org.trellisldp.http.domain.HttpConstants.TIMEMAP;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Link;
+
+import org.trellisldp.http.domain.AcceptDatetime;
+import org.trellisldp.http.domain.Digest;
+import org.trellisldp.http.domain.Prefer;
+import org.trellisldp.http.domain.Range;
+import org.trellisldp.http.domain.Version;
+
+@PreMatching
+@Priority(AUTHORIZATION + 20)
+public class TrellisHttpFilter implements ContainerRequestFilter {
+
+    private static final List<String> MUTATING_METHODS = asList("POST", "PUT", "DELETE", "PATCH");
+
+    @Override
+    public void filter(final ContainerRequestContext ctx) throws IOException {
+        final String slash = "/";
+        // Check for a trailing slash. If so, redirect
+        final String path = ctx.getUriInfo().getPath();
+        if (path.endsWith(slash) && !path.equals(slash)) {
+            ctx.abortWith(seeOther(fromUri(path.substring(0, path.length() - 1)).build()).build());
+        }
+
+        // Validate header/query parameters
+        ofNullable(ctx.getHeaderString("Accept-Datetime")).filter(x -> isNull(AcceptDatetime.valueOf(x)))
+            .ifPresent(x -> ctx.abortWith(status(BAD_REQUEST).build()));
+
+        ofNullable(ctx.getHeaderString("Slug")).filter(s -> s.contains(slash)).ifPresent(x ->
+            ctx.abortWith(status(BAD_REQUEST).build()));
+
+        ofNullable(ctx.getHeaderString("Prefer")).filter(x -> isNull(Prefer.valueOf(x))).ifPresent(x ->
+            ctx.abortWith(status(BAD_REQUEST).build()));
+
+        ofNullable(ctx.getHeaderString("Range")).filter(x -> isNull(Range.valueOf(x))).ifPresent(x ->
+            ctx.abortWith(status(BAD_REQUEST).build()));
+
+        ofNullable(ctx.getHeaderString("Link")).ifPresent(x -> {
+            try {
+                Link.valueOf(x);
+            } catch (final IllegalArgumentException ex) {
+                ctx.abortWith(status(BAD_REQUEST).build());
+            }
+        });
+
+        ofNullable(ctx.getHeaderString("Digest")).filter(x -> isNull(Digest.valueOf(x))).ifPresent(x ->
+            ctx.abortWith(status(BAD_REQUEST).build()));
+
+        ofNullable(ctx.getUriInfo().getQueryParameters().getFirst("version")).ifPresent(x -> {
+            // Check well-formedness
+            if (isNull(Version.valueOf(x))) {
+                ctx.abortWith(status(BAD_REQUEST).build());
+            // Do not allow mutating versioned resources
+            } else if (MUTATING_METHODS.contains(ctx.getMethod())) {
+                ctx.abortWith(status(METHOD_NOT_ALLOWED).build());
+            }
+        });
+
+        // Do not allow direct manipulation of timemaps
+        ofNullable(ctx.getUriInfo().getQueryParameters().get("ext")).filter(l -> l.contains(TIMEMAP))
+            .filter(x -> MUTATING_METHODS.contains(ctx.getMethod()))
+            .ifPresent(x -> ctx.abortWith(status(METHOD_NOT_ALLOWED).build()));
+    }
+
+
+}

--- a/core/http/src/test/java/org/trellisldp/http/LdpAdminResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpAdminResourceTest.java
@@ -48,6 +48,7 @@ public class LdpAdminResourceTest extends AbstractLdpResourceTest {
         config.register(agentFilter);
         config.register(new CacheControlFilter(86400, true, false));
         config.register(new WebSubHeaderFilter(HUB));
+        config.register(new TrellisHttpFilter());
         config.register(new CrossOriginResourceSharingFilter(asList(origin),
                     asList("PATCH", "POST", "PUT"),
                     asList("Link", "Content-Type", "Accept", "Accept-Datetime"),

--- a/core/http/src/test/java/org/trellisldp/http/LdpResourceNoAgentTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpResourceNoAgentTest.java
@@ -46,6 +46,7 @@ public class LdpResourceNoAgentTest extends AbstractLdpResourceTest {
         config.register(new TrellisHttpResource(mockBundler, baseUri));
         config.register(new CacheControlFilter(86400, true, false));
         config.register(new WebSubHeaderFilter(HUB));
+        config.register(new TrellisHttpFilter());
         config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),
                         asList("Link", "Content-Type", "Accept-Datetime", "Accept"),
                         asList("Link", "Content-Type", "Memento-Datetime"), true, 100));

--- a/core/http/src/test/java/org/trellisldp/http/LdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpResourceTest.java
@@ -34,13 +34,10 @@ import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 import java.util.stream.Stream;
 
 import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
@@ -61,12 +58,6 @@ public class LdpResourceTest extends AbstractLdpResourceTest {
 
     @Mock
     private AsyncResponse mockResponse;
-
-    @Mock
-    private ContainerRequestContext mockContext;
-
-    @Mock
-    private UriInfo mockUriInfo;
 
     @Mock
     private LdpRequest mockLdpRequest;
@@ -99,23 +90,11 @@ public class LdpResourceTest extends AbstractLdpResourceTest {
         config.register(new AgentAuthorizationFilter(mockAgentService));
         config.register(new CacheControlFilter(86400, true, false));
         config.register(new WebSubHeaderFilter(HUB));
+        config.register(new TrellisHttpFilter());
         config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),
                         asList("Link", "Content-Type", "Accept-Datetime", "Accept"),
                         asList("Link", "Content-Type", "Memento-Datetime"), true, 100));
         return config;
-    }
-
-    @Test
-    public void testTestRootSlash() throws Exception {
-
-        when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
-        when(mockUriInfo.getPath()).thenReturn("/");
-        when(mockUriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
-
-        final TrellisHttpResource filter = new TrellisHttpResource(mockBundler);
-
-        filter.filter(mockContext);
-        verify(mockContext, never().description("Trailing slash should trigger a redirect!")).abortWith(any());
     }
 
     @Test

--- a/core/http/src/test/java/org/trellisldp/http/LdpUserResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpUserResourceTest.java
@@ -41,6 +41,7 @@ public class LdpUserResourceTest extends AbstractLdpResourceTest {
         config.register(new AgentAuthorizationFilter(mockAgentService));
         config.register(new CacheControlFilter(86400, true, false));
         config.register(new WebSubHeaderFilter(HUB));
+        config.register(new TrellisHttpFilter());
         config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),
                         asList("Link", "Content-Type", "Accept-Datetime", "Accept"),
                         asList("Link", "Content-Type", "Memento-Datetime"), true, 100));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpFilterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class TrellisHttpFilterTest {
+
+    @Mock
+    private ContainerRequestContext mockContext;
+
+    @Mock
+    private UriInfo mockUriInfo;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void testTestRootSlash() throws Exception {
+
+        when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
+        when(mockUriInfo.getPath()).thenReturn("/");
+        when(mockUriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+
+        final TrellisHttpFilter filter = new TrellisHttpFilter();
+
+        filter.filter(mockContext);
+        verify(mockContext, never().description("Trailing slash should trigger a redirect!")).abortWith(any());
+    }
+}

--- a/platform/webapp/src/main/java/org/trellisldp/webapp/TrellisApplication.java
+++ b/platform/webapp/src/main/java/org/trellisldp/webapp/TrellisApplication.java
@@ -16,6 +16,7 @@ package org.trellisldp.webapp;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.trellisldp.api.ServiceBundler;
 import org.trellisldp.http.AgentAuthorizationFilter;
+import org.trellisldp.http.TrellisHttpFilter;
 import org.trellisldp.http.TrellisHttpResource;
 
 /**
@@ -34,6 +35,7 @@ public class TrellisApplication extends ResourceConfig {
         ldpResource.initialize();
 
         register(ldpResource);
+        register(new TrellisHttpFilter());
         register(new AgentAuthorizationFilter(serviceBundler.getAgentService()));
 
         AppUtils.getCacheControlFilter().ifPresent(this::register);


### PR DESCRIPTION
Resolves #203 

This just extracts the `ContainerRequestFilter` portions of the current `TrellisHttpResource` class into its own class.