### PR TITLE
Simplify how 401 challenges are handled

### DIFF
--- a/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/TrellisConfigurationTest.java
+++ b/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/TrellisConfigurationTest.java
@@ -118,16 +118,13 @@ public class TrellisConfigurationTest {
         assertEquals((Long) 10L, config.getAuth().getWebac().getCacheExpireSeconds(), "Incorrect webac cache expiry!");
         assertTrue(config.getAuth().getBasic().getEnabled(), "Missing basic auth support!");
         assertEquals("users.auth", config.getAuth().getBasic().getUsersFile(), "Incorrect basic auth users file!");
-        assertEquals("trellis", config.getAuth().getBasic().getRealm(), "Incorrect basic auth realm!");
+        assertEquals("trellis", config.getAuth().getRealm(), "Incorrect auth realm!");
 
-        config.getAuth().getBasic().setRealm("foo");
-        assertEquals("foo", config.getAuth().getBasic().getRealm(), "Incorrect basic auth realm!");
+        config.getAuth().setRealm("foo");
+        assertEquals("foo", config.getAuth().getRealm(), "Incorrect auth realm!");
         assertTrue(config.getAuth().getJwt().getEnabled(), "JWT not enabled!");
         assertEquals("xd1GuAwiP2+M+pyK+GlIUEAumSmFx5DP3dziGtVb1tA+/8oLXfSDMDZFkxVghyAd28rXImy18TmttUi+g0iomQ==",
                 config.getAuth().getJwt().getKey(), "Incorrect JWT key!");
-        assertEquals("trellis", config.getAuth().getJwt().getRealm(), "Incorrect JWT realm!");
-        config.getAuth().getJwt().setRealm("bar");
-        assertEquals("bar", config.getAuth().getJwt().getRealm(), "Incorrect JWT realm after reset!");
 
         assertEquals("password", config.getAuth().getJwt().getKeyStorePassword(), "Incorrect JWT keystore password!");
         assertEquals("/tmp/trellisData/keystore.jks", config.getAuth().getJwt().getKeyStore(), "Wrong keystore loc!");

--- a/components/app/src/main/java/org/trellisldp/app/config/AuthConfiguration.java
+++ b/components/app/src/main/java/org/trellisldp/app/config/AuthConfiguration.java
@@ -29,6 +29,9 @@ public class AuthConfiguration {
     private WebacConfiguration webac = new WebacConfiguration();
 
     @NotNull
+    private String realm = "trellis";
+
+    @NotNull
     private List<String> adminUsers = new ArrayList<>();
 
     /**
@@ -101,5 +104,23 @@ public class AuthConfiguration {
     @JsonProperty
     public WebacConfiguration getWebac() {
         return webac;
+    }
+
+    /**
+     * Get the security realm.
+     * @return the realm; by default, this is 'trellis'
+     */
+    @JsonProperty
+    public String getRealm() {
+        return realm;
+    }
+
+    /**
+     * Set the security realm.
+     * @param realm the security realm
+     */
+    @JsonProperty
+    public void setRealm(final String realm) {
+        this.realm = realm;
     }
 }

--- a/components/app/src/main/java/org/trellisldp/app/config/BasicAuthConfiguration.java
+++ b/components/app/src/main/java/org/trellisldp/app/config/BasicAuthConfiguration.java
@@ -15,15 +15,10 @@ package org.trellisldp.app.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.validation.constraints.NotNull;
-
 /**
  * Configuration for Basic AuthN.
  */
 public class BasicAuthConfiguration {
-
-    @NotNull
-    private String realm = "trellis";
 
     private Boolean enabled = true;
 
@@ -63,23 +58,5 @@ public class BasicAuthConfiguration {
     @JsonProperty
     public void setUsersFile(final String usersFile) {
         this.usersFile = usersFile;
-    }
-
-    /**
-     * Get the security realm.
-     * @return the realm; by default, this is 'trellis'
-     */
-    @JsonProperty
-    public String getRealm() {
-        return realm;
-    }
-
-    /**
-     * Set the security realm.
-     * @param realm the security realm
-     */
-    @JsonProperty
-    public void setRealm(final String realm) {
-        this.realm = realm;
     }
 }

--- a/components/app/src/main/java/org/trellisldp/app/config/JwtAuthConfiguration.java
+++ b/components/app/src/main/java/org/trellisldp/app/config/JwtAuthConfiguration.java
@@ -26,9 +26,6 @@ import javax.validation.constraints.NotNull;
  */
 public class JwtAuthConfiguration {
 
-    @NotNull
-    private String realm = "trellis";
-
     private Boolean enabled = true;
 
     private String key;
@@ -149,23 +146,5 @@ public class JwtAuthConfiguration {
     @JsonProperty
     public void setJwks(final String jwks) {
         this.jwks = jwks;
-    }
-
-    /**
-     * Get the security realm.
-     * @return the realm; by default, this is 'trellis'
-     */
-    @JsonProperty
-    public String getRealm() {
-        return realm;
-    }
-
-    /**
-     * Set the security realm.
-     * @param realm the security realm
-     */
-    @JsonProperty
-    public void setRealm(final String realm) {
-        this.realm = realm;
     }
 }

--- a/components/app/src/test/java/org/trellisldp/app/config/TrellisConfigurationTest.java
+++ b/components/app/src/test/java/org/trellisldp/app/config/TrellisConfigurationTest.java
@@ -119,16 +119,13 @@ public class TrellisConfigurationTest {
         assertEquals((Long) 15L, config.getAuth().getWebac().getCacheExpireSeconds(), "Bad auth/webac/cache expiry!");
         assertTrue(config.getAuth().getBasic().getEnabled(), "basic auth not enabled!");
         assertEquals("users.auth", config.getAuth().getBasic().getUsersFile(), "Incorrect basic users file!");
-        assertEquals("trellis", config.getAuth().getBasic().getRealm(), "Incorrect basic auth realm!");
+        assertEquals("trellis", config.getAuth().getRealm(), "Incorrect auth realm!");
 
-        config.getAuth().getBasic().setRealm("foobar");
-        assertEquals("foobar", config.getAuth().getBasic().getRealm(), "Incorrect auth/basic/realm value!");
+        config.getAuth().setRealm("foobar");
+        assertEquals("foobar", config.getAuth().getRealm(), "Incorrect auth/basic/realm value!");
         assertTrue(config.getAuth().getJwt().getEnabled(), "auth/jwt not enabled!");
         assertEquals("Mz4DGzFLQysSGC98ESAnSafMLbxa71ls/zzUFOdCIJw9L0J8Q0Gt7+yCM+Ag73Tm5OTwpBemFOqPFiZ5BeBo4Q==",
                 config.getAuth().getJwt().getKey(), "Incorrect auth/jwt/key");
-        assertEquals("trellis", config.getAuth().getJwt().getRealm(), "Incorrect auth/jwt/realm value!");
-        config.getAuth().getJwt().setRealm("barbaz");
-        assertEquals("barbaz", config.getAuth().getJwt().getRealm(), "Incorrect auth/jwt/realm value after a change!");
 
         assertEquals("password", config.getAuth().getJwt().getKeyStorePassword(), "Wrong auth/jwt/keyStorePassword");
         assertEquals("/tmp/trellisData/keystore.jks", config.getAuth().getJwt().getKeyStore(), "Wrong keystore path!");

--- a/core/http/src/test/java/org/trellisldp/http/WebACFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/WebACFilterTest.java
@@ -118,20 +118,12 @@ public class WebACFilterTest {
         when(mockContext.getMethod()).thenReturn("POST");
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
 
-        final WebAcFilter filter = new WebAcFilter(mockAccessControlService);
-        filter.setChallenges(asList("Foo", "Bar"));
+        final WebAcFilter filter = new WebAcFilter(mockAccessControlService, asList("Foo", "Bar"), "my-realm");
 
         final List<Object> challenges = assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
                 "No auth exception thrown with no access modes!").getChallenges();
 
-        assertTrue(challenges.contains("Foo"), "Foo not among challenges!");
-        assertTrue(challenges.contains("Bar"), "Bar not among challenges!");
-
-        filter.setChallenges(emptyList());
-        final List<Object> challenges2 = assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
-                "No auth exception thrown with no access modes!").getChallenges();
-
-        assertTrue(challenges2.contains("Foo"), "Foo not among challenges after reset!");
-        assertTrue(challenges2.contains("Bar"), "Bar not among challenges after reset!");
+        assertTrue(challenges.contains("Foo realm=\"my-realm\""), "Foo not among challenges!");
+        assertTrue(challenges.contains("Bar realm=\"my-realm\""), "Bar not among challenges!");
     }
 }


### PR DESCRIPTION
Resolves #222

This also moves the realm configuration up a level to `auth`.
It also simplifies the `WebAcFilter`, allowing the challenges
to be set directly in the constructor or by Tamaya configuration.