### PR TITLE
Add injectable, no-arg constructors for HTTP filters

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
@@ -13,15 +13,18 @@
  */
 package org.trellisldp.http;
 
+import static java.util.Objects.nonNull;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.Priorities.USER;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.Link.fromUri;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
+import static org.apache.tamaya.ConfigurationProvider.getConfiguration;
 
 import java.io.IOException;
 
 import javax.annotation.Priority;
+import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -35,7 +38,18 @@ import javax.ws.rs.container.ContainerResponseFilter;
 @Priority(USER)
 public class WebSubHeaderFilter implements ContainerResponseFilter {
 
+    /** The configuration key controlling the location of a web-sub-hub. **/
+    public static final String CONF_WEB_SUB_HUB = "trellis.http.websubhub";
+
     private final String hub;
+
+    /**
+     * Create a new WebSub header Decorator.
+     */
+    @Inject
+    public WebSubHeaderFilter() {
+        this(getConfiguration().get(CONF_WEB_SUB_HUB));
+    }
 
     /**
      * Create a new WebSub Header Decorator.
@@ -48,7 +62,7 @@ public class WebSubHeaderFilter implements ContainerResponseFilter {
 
     @Override
     public void filter(final ContainerRequestContext req, final ContainerResponseContext res) throws IOException {
-        if (req.getMethod().equals(GET) && SUCCESSFUL.equals(res.getStatusInfo().getFamily())) {
+        if (req.getMethod().equals(GET) && SUCCESSFUL.equals(res.getStatusInfo().getFamily()) && nonNull(hub)) {
             res.getHeaders().add(LINK, fromUri(hub).rel("hub").build());
         }
     }

--- a/core/http/src/test/java/org/trellisldp/http/BaseCORSTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseCORSTest.java
@@ -13,14 +13,23 @@
  */
 package org.trellisldp.http;
 
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * @author acoburn
@@ -39,5 +48,26 @@ abstract class BaseCORSTest extends BaseLdpResourceTest {
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.connectorProvider(new ApacheConnectorProvider());
         return ClientBuilder.newClient(clientConfig);
+    }
+
+    protected Stream<Executable> checkAllowMethods(final Response res, final List<String> expected) {
+        final List<String> actual = stream(res.getHeaderString("Access-Control-Allow-Methods").split(","))
+            .collect(toList());
+        return Stream.concat(
+                expected.stream().map(method -> () -> assertTrue(actual.contains(method),
+                        "Method " + method + " not in actual -Allow-Methods header!")),
+                actual.stream().map(method -> () -> assertTrue(expected.contains(method),
+                        "Method " + method + " not in expected -Allow-Methods header!")));
+    }
+
+    protected Stream<Executable> checkNoCORSHeaders(final Response res) {
+        return Stream.of(
+                () -> assertNull(res.getHeaderString("Access-Control-Allow-Origin"), "Unexpected -Allow-Origin!"),
+                () -> assertNull(res.getHeaderString("Access-Control-Allow-Credentials"),
+                                 "Unexpected -Allow-Credentials!"),
+                () -> assertNull(res.getHeaderString("Access-Control-Max-Age"), "Unexpected -Max-Age header!"),
+                () -> assertNull(res.getHeaderString("Access-Control-Expose-Headers"), "Unexpected -Expose-Headers!"),
+                () -> assertNull(res.getHeaderString("Access-Control-Allow-Headers"), "Unexpected -Allow-Headers!"),
+                () -> assertNull(res.getHeaderString("Access-Control-Allow-Methods"), "Unexpected -Allow-Methods!"));
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/CacheControlFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CacheControlFilterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http;
+
+import static javax.ws.rs.HttpMethod.GET;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class CacheControlFilterTest {
+
+    @Mock
+    private ContainerRequestContext mockRequest;
+
+    @Mock
+    private ContainerResponseContext mockResponse;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void testCacheControlNull() throws Exception {
+
+        when(mockRequest.getMethod()).thenReturn(GET);
+        when(mockResponse.getStatusInfo()).thenReturn(OK);
+
+        final CacheControlFilter filter = new CacheControlFilter(0, true, false);
+
+        filter.filter(mockRequest, mockResponse);
+        verify(mockResponse, never()).getHeaders();
+    }
+}

--- a/core/http/src/test/java/org/trellisldp/http/LdpAdminResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpAdminResourceTest.java
@@ -46,7 +46,7 @@ public class LdpAdminResourceTest extends AbstractLdpResourceTest {
         config.register(new TestAuthenticationFilter("testUser", ""));
         config.register(new WebAcFilter(mockAccessControlService));
         config.register(agentFilter);
-        config.register(new CacheControlFilter(86400, true, false));
+        config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
         config.register(new CrossOriginResourceSharingFilter(asList(origin),

--- a/core/http/src/test/java/org/trellisldp/http/LdpResourceNoAgentTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpResourceNoAgentTest.java
@@ -44,7 +44,7 @@ public class LdpResourceNoAgentTest extends AbstractLdpResourceTest {
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler, baseUri));
-        config.register(new CacheControlFilter(86400, true, false));
+        config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
         config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),

--- a/core/http/src/test/java/org/trellisldp/http/LdpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpResourceTest.java
@@ -88,7 +88,7 @@ public class LdpResourceTest extends AbstractLdpResourceTest {
 
         config.register(new TrellisHttpResource(mockBundler, null));
         config.register(new AgentAuthorizationFilter(mockAgentService));
-        config.register(new CacheControlFilter(86400, true, false));
+        config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
         config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),

--- a/core/http/src/test/java/org/trellisldp/http/LdpUserResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpUserResourceTest.java
@@ -39,7 +39,7 @@ public class LdpUserResourceTest extends AbstractLdpResourceTest {
         config.register(new TestAuthenticationFilter("testUser", "group"));
         config.register(new WebAcFilter(mockAccessControlService));
         config.register(new AgentAuthorizationFilter(mockAgentService));
-        config.register(new CacheControlFilter(86400, true, false));
+        config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
         config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),

--- a/core/http/src/test/java/org/trellisldp/http/WebSubHeaderFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/WebSubHeaderFilterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http;
+
+import static javax.ws.rs.HttpMethod.GET;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class WebSubHeaderFilterTest {
+
+    @Mock
+    private ContainerRequestContext mockRequest;
+
+    @Mock
+    private ContainerResponseContext mockResponse;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void testWebSubNull() throws Exception {
+
+        when(mockRequest.getMethod()).thenReturn(GET);
+        when(mockResponse.getStatusInfo()).thenReturn(OK);
+
+        final WebSubHeaderFilter filter = new WebSubHeaderFilter();
+
+        filter.filter(mockRequest, mockResponse);
+        verify(mockResponse, never()).getHeaders();
+    }
+}


### PR DESCRIPTION
Resolves #223

This adds no-arg constructors to the existing CORS, WebSub and CacheControl filters.
