### PR TITLE
Update/normalize configuration names

### DIFF
--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
@@ -47,10 +47,10 @@ public class BasicAuthFilter implements ContainerRequestFilter {
     private static final Logger LOGGER = getLogger(BasicAuthFilter.class);
 
     /** The configuration key controlling the location of the basic auth credentials file. **/
-    public static final String CREDENTIALS_FILE = "trellis.auth.basic.credentialsfile";
+    public static final String CONFIG_AUTH_BASIC_CREDENTIALS = "trellis.auth.basic.credentials";
 
     /** The configuration key controlling the realm used in a WWW-Authenticate header, or 'trellis' by default. **/
-    public static final String TRELLIS_AUTH_REALM = "trellis.auth.realm";
+    public static final String CONFIG_AUTH_REALM = "trellis.auth.realm";
 
     private final File file;
     private final String challenge;
@@ -60,7 +60,7 @@ public class BasicAuthFilter implements ContainerRequestFilter {
      */
     @Inject
     public BasicAuthFilter() {
-        this(getConfiguration().get(CREDENTIALS_FILE));
+        this(getConfiguration().get(CONFIG_AUTH_BASIC_CREDENTIALS));
     }
 
     /**
@@ -76,7 +76,7 @@ public class BasicAuthFilter implements ContainerRequestFilter {
      * @param file the credentials file
      */
     public BasicAuthFilter(final File file) {
-        this(file, getConfiguration().getOrDefault(TRELLIS_AUTH_REALM, "trellis"));
+        this(file, getConfiguration().getOrDefault(CONFIG_AUTH_REALM, "trellis"));
     }
 
     /**

--- a/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthFilterTest.java
+++ b/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthFilterTest.java
@@ -88,7 +88,7 @@ public class BasicAuthFilterTest {
     @Test
     public void testCredentialsViaConfiguration() throws Exception {
         try {
-            System.setProperty(BasicAuthFilter.CREDENTIALS_FILE, getAuthFile());
+            System.setProperty(BasicAuthFilter.CONFIG_AUTH_BASIC_CREDENTIALS, getAuthFile());
             final BasicAuthFilter filter = new BasicAuthFilter();
             final String webid = "https://madison.example.com/profile/#me";
             final String token = encodeCredentials("user", "password");
@@ -100,7 +100,7 @@ public class BasicAuthFilterTest {
             assertFalse(securityArgument.getValue().isSecure(), "Unexpected secure flag!");
             assertTrue(securityArgument.getValue().isUserInRole("some role"), "Not in user role!");
         } finally {
-            System.clearProperty(BasicAuthFilter.CREDENTIALS_FILE);
+            System.clearProperty(BasicAuthFilter.CONFIG_AUTH_BASIC_CREDENTIALS);
         }
     }
 

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/OAuthFilter.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/OAuthFilter.java
@@ -47,16 +47,21 @@ import org.slf4j.Logger;
 public class OAuthFilter implements ContainerRequestFilter {
 
     /** The configuration key controlling the realm used in a WWW-Authenticate header, or 'trellis' by default. **/
-    public static final String TRELLIS_AUTH_REALM = "trellis.auth.realm";
+    public static final String CONFIG_AUTH_REALM = "trellis.auth.realm";
+    /** The configuration key controlling the OAuth Keystore path. **/
+    public static final String CONFIG_AUTH_OAUTH_KEYSTORE_PATH = "trellis.auth.oauth.keystore.path";
+    /** The configuration key controlling the OAuth Keystore credentials. **/
+    public static final String CONFIG_AUTH_OAUTH_KEYSTORE_CREDENTIALS = "trellis.auth.oauth.keystore.credentials";
+    /** The configuration key controlling the OAuth Keystore ids. **/
+    public static final String CONFIG_AUTH_OAUTH_KEYSTORE_IDS = "trellis.auth.oauth.keystore.ids";
+    /** The configuration key controlling the OAuth HMAC shared secret. **/
+    public static final String CONFIG_AUTH_OAUTH_SHARED_SECRET = "trellis.auth.oauth.sharedsecret";
+    /** The configuration key controlling the OAuth JWK URL. **/
+    public static final String CONFIG_AUTH_OAUTH_JWK_URL = "trellis.auth.oauth.jwk";
+    /** The authentication scheme used by this module. **/
+    public static final String SCHEME = "Bearer";
 
     private static final Logger LOGGER = getLogger(OAuthFilter.class);
-
-    public static final String SCHEME = "Bearer";
-    public static final String KEYSTORE_PATH = "trellis.oauth.keystore.path";
-    public static final String KEYSTORE_CREDENTIALS = "trellis.oauth.keystore.password";
-    public static final String KEY_IDS = "trellis.oauth.keyids";
-    public static final String SHARED_SECRET = "trellis.oauth.sharedsecret";
-    public static final String JWK_LOCATION = "trellis.oauth.jwk.location";
 
     private final Authenticator authenticator;
     private final String challenge;
@@ -74,7 +79,7 @@ public class OAuthFilter implements ContainerRequestFilter {
      * @param authenticator the authenticator
      */
     public OAuthFilter(final Authenticator authenticator) {
-        this(authenticator, getConfiguration().getOrDefault(TRELLIS_AUTH_REALM, "trellis"));
+        this(authenticator, getConfiguration().getOrDefault(CONFIG_AUTH_REALM, "trellis"));
     }
 
     /**
@@ -139,24 +144,24 @@ public class OAuthFilter implements ContainerRequestFilter {
         final Configuration config = getConfiguration();
 
         final Authenticator jwksAuthenticator = OAuthUtils.buildAuthenticatorWithJwk(
-                config.get(JWK_LOCATION));
+                config.get(CONFIG_AUTH_OAUTH_JWK_URL));
         if (nonNull(jwksAuthenticator)) {
             return jwksAuthenticator;
         }
 
         final Authenticator keystoreAuthenticator = OAuthUtils.buildAuthenticatorWithTruststore(
-                config.get(KEYSTORE_PATH), config.getOrDefault(KEYSTORE_CREDENTIALS, "").toCharArray(),
-                asList(config.getOrDefault(KEY_IDS, "").split(",")));
+                config.get(CONFIG_AUTH_OAUTH_KEYSTORE_PATH),
+                config.getOrDefault(CONFIG_AUTH_OAUTH_KEYSTORE_CREDENTIALS, "").toCharArray(),
+                asList(config.getOrDefault(CONFIG_AUTH_OAUTH_KEYSTORE_IDS, "").split(",")));
         if (nonNull(keystoreAuthenticator)) {
             return keystoreAuthenticator;
         }
 
         final Authenticator sharedKeyAuthenticator = OAuthUtils.buildAuthenticatorWithSharedSecret(
-                config.get(SHARED_SECRET));
+                config.get(CONFIG_AUTH_OAUTH_SHARED_SECRET));
         if (nonNull(sharedKeyAuthenticator)) {
             return sharedKeyAuthenticator;
         }
-
         return new NullAuthenticator();
     }
 }

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthFilterTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthFilterTest.java
@@ -136,10 +136,11 @@ public class OAuthFilterTest {
     public void testFilterGenericWebid() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
         try {
-            System.setProperty(OAuthFilter.SHARED_SECRET,
+            System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET,
                     "y7MCBmoOx7TH70q1fabSGLzOrEYx+liUmLWPkwIPUTfWMXn/J5MDZuepBd8mcRObUDYYQN3MIS8p40ZT5EhvWw==");
             final String token = Jwts.builder().claim("webid", webid)
-                .signWith(hmacShaKeyFor(getConfiguration().get(OAuthFilter.SHARED_SECRET).getBytes(UTF_8))).compact();
+                .signWith(hmacShaKeyFor(getConfiguration()
+                            .get(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET).getBytes(UTF_8))).compact();
             when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
 
             final OAuthFilter filter = new OAuthFilter();
@@ -151,7 +152,7 @@ public class OAuthFilterTest {
             assertFalse(securityArgument.getValue().isSecure(), "Unexpected secure flag!");
             assertTrue(securityArgument.getValue().isUserInRole("some role"), "Not in user role!");
         } finally {
-            System.clearProperty(OAuthFilter.SHARED_SECRET);
+            System.clearProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET);
         }
     }
 
@@ -159,10 +160,11 @@ public class OAuthFilterTest {
     public void testFilterGenericJwtSecret() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
         try {
-            System.setProperty(OAuthFilter.SHARED_SECRET,
+            System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET,
                     "y7MCBmoOx7TH70q1fabSGLzOrEYx+liUmLWPkwIPUTfWMXn/J5MDZuepBd8mcRObUDYYQN3MIS8p40ZT5EhvWw==");
             final String token = Jwts.builder().claim("webid", webid)
-                .signWith(hmacShaKeyFor(getConfiguration().get(OAuthFilter.SHARED_SECRET).getBytes(UTF_8))).compact();
+                .signWith(hmacShaKeyFor(getConfiguration()
+                            .get(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET).getBytes(UTF_8))).compact();
             when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("BEARER " + token);
 
             final OAuthFilter filter = new OAuthFilter();
@@ -174,7 +176,7 @@ public class OAuthFilterTest {
             assertFalse(securityArgument.getValue().isSecure(), "Unexpected secure flag!");
             assertTrue(securityArgument.getValue().isUserInRole("some role"), "Not in user role!");
         } finally {
-            System.clearProperty(OAuthFilter.SHARED_SECRET);
+            System.clearProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET);
         }
     }
 
@@ -182,24 +184,25 @@ public class OAuthFilterTest {
     public void testFilterNotBasicAuth() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
         try {
-            System.setProperty(OAuthFilter.SHARED_SECRET,
+            System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET,
                     "y7MCBmoOx7TH70q1fabSGLzOrEYx+liUmLWPkwIPUTfWMXn/J5MDZuepBd8mcRObUDYYQN3MIS8p40ZT5EhvWw==");
             final String token = Jwts.builder().claim("webid", webid)
-                .signWith(hmacShaKeyFor(getConfiguration().get(OAuthFilter.SHARED_SECRET).getBytes(UTF_8))).compact();
+                .signWith(hmacShaKeyFor(getConfiguration()
+                            .get(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET).getBytes(UTF_8))).compact();
             when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Basic " + token);
 
             final OAuthFilter filter = new OAuthFilter();
             filter.filter(mockContext);
             verify(mockContext, never()).setSecurityContext(any());
         } finally {
-            System.clearProperty(OAuthFilter.SHARED_SECRET);
+            System.clearProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET);
         }
     }
 
     @Test
     public void testFilterNoToken() throws Exception {
         try {
-            System.setProperty(OAuthFilter.SHARED_SECRET,
+            System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET,
                     "y7MCBmoOx7TH70q1fabSGLzOrEYx+liUmLWPkwIPUTfWMXn/J5MDZuepBd8mcRObUDYYQN3MIS8p40ZT5EhvWw==");
             when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer");
 
@@ -207,7 +210,7 @@ public class OAuthFilterTest {
             filter.filter(mockContext);
             verify(mockContext, never()).setSecurityContext(any());
         } finally {
-            System.clearProperty(OAuthFilter.SHARED_SECRET);
+            System.clearProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET);
         }
     }
 
@@ -237,7 +240,7 @@ public class OAuthFilterTest {
             "38zhMXE5VLC6PzhR3i_4KKpe4nq2otsrJ3KlEc7Me6UeiMXxPYz8rrPovW5L3LFWDmntGs5q923fBZFLFg8yBgMdTineaahEQ"));
 
         try {
-            System.setProperty(OAuthFilter.JWK_LOCATION, "https://www.trellisldp.org/tests/jwks.json");
+            System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_JWK_URL, "https://www.trellisldp.org/tests/jwks.json");
 
             final Key key = KeyFactory.getInstance("RSA").generatePrivate(new RSAPrivateKeySpec(modulus, exponent));
             final String token = Jwts.builder().setHeaderParam(JwsHeader.KEY_ID, "trellis-test")
@@ -250,7 +253,7 @@ public class OAuthFilterTest {
             verify(mockContext).setSecurityContext(securityArgument.capture());
             assertEquals(webid, securityArgument.getValue().getUserPrincipal().getName(), "Unexpected agent IRI!");
         } finally {
-            System.clearProperty(OAuthFilter.JWK_LOCATION);
+            System.clearProperty(OAuthFilter.CONFIG_AUTH_OAUTH_JWK_URL);
         }
     }
 
@@ -260,9 +263,9 @@ public class OAuthFilterTest {
         final String webid = "https://people.apache.org/~acoburn/#me";
         try {
             final String keystorePath = OAuthUtilsTest.class.getResource("/keystore.jks").getPath();
-            System.setProperty(OAuthFilter.KEYSTORE_PATH, keystorePath);
-            System.setProperty(OAuthFilter.KEYSTORE_CREDENTIALS, passphrase);
-            System.setProperty(OAuthFilter.KEY_IDS, "trellis,trellis-ec");
+            System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_KEYSTORE_PATH, keystorePath);
+            System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_KEYSTORE_CREDENTIALS, passphrase);
+            System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_KEYSTORE_IDS, "trellis,trellis-ec");
 
             final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
             ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase.toCharArray());
@@ -278,9 +281,9 @@ public class OAuthFilterTest {
             verify(mockContext).setSecurityContext(securityArgument.capture());
             assertEquals(webid, securityArgument.getValue().getUserPrincipal().getName(), "Unexpected agent IRI!");
         } finally {
-            System.clearProperty(OAuthFilter.KEYSTORE_PATH);
-            System.clearProperty(OAuthFilter.KEYSTORE_CREDENTIALS);
-            System.clearProperty(OAuthFilter.KEY_IDS);
+            System.clearProperty(OAuthFilter.CONFIG_AUTH_OAUTH_KEYSTORE_PATH);
+            System.clearProperty(OAuthFilter.CONFIG_AUTH_OAUTH_KEYSTORE_CREDENTIALS);
+            System.clearProperty(OAuthFilter.CONFIG_AUTH_OAUTH_KEYSTORE_IDS);
         }
     }
 }

--- a/components/app/src/main/java/org/trellisldp/app/AbstractTrellisApplication.java
+++ b/components/app/src/main/java/org/trellisldp/app/AbstractTrellisApplication.java
@@ -52,7 +52,7 @@ public abstract class AbstractTrellisApplication<T extends TrellisConfiguration>
     private static final Logger LOGGER = getLogger(AbstractTrellisApplication.class);
 
     /** The configuration key controlling whether an application should initialize its own root resource. **/
-    public static final String APPLICATION_SELF_INITIALIZE = "trellis.app.initialize.root";
+    public static final String CONFIG_APP_INITIALIZE_ROOT = "trellis.app.initialize.root";
 
     /**
      * Get the Trellis {@link ServiceBundler}. This object collects the various
@@ -111,7 +111,7 @@ public abstract class AbstractTrellisApplication<T extends TrellisConfiguration>
 
         // Resource matchers
         environment.jersey().register(getLdpComponent(config, ConfigurationProvider.getConfiguration()
-                    .getOrDefault(APPLICATION_SELF_INITIALIZE, Boolean.class, true)));
+                    .getOrDefault(CONFIG_APP_INITIALIZE_ROOT, Boolean.class, true)));
 
         // Authentication
         final AgentAuthorizationFilter agentFilter = new AgentAuthorizationFilter(getServiceBundler().getAgentService(),

--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -82,13 +82,13 @@ import org.trellisldp.api.IdentifierService;
 public class FileBinaryService implements BinaryService {
 
     /** The configuration key controlling the base filesystem path for the binary service. */
-    public static final String BINARY_BASE_PATH = "trellis.file.binary.basepath";
+    public static final String CONFIG_FILE_BINARY_BASE_PATH = "trellis.file.binary.basepath";
 
     /** The configuration key controlling the levels of hierarchy in a binary storage layout. */
-    public static final String BINARY_HIERARCHY = "trellis.file.binary.hierarchy";
+    public static final String CONFIG_FILE_BINARY_HIERARCHY = "trellis.file.binary.hierarchy";
 
     /** The configuration key controlling the length of each level of hierarchy in a filesystem layout. */
-    public static final String BINARY_LENGTH = "trellis.file.binary.length";
+    public static final String CONFIG_FILE_BINARY_LENGTH = "trellis.file.binary.length";
 
     private static final Logger LOGGER = getLogger(FileBinaryService.class);
     private static final String SHA = "SHA";
@@ -122,15 +122,15 @@ public class FileBinaryService implements BinaryService {
      */
     public FileBinaryService(final IdentifierService idService, final String basePath,
             final Integer hierarchy, final Integer length) {
-        requireNonNull(basePath, BINARY_BASE_PATH + " configuration may not be null!");
+        requireNonNull(basePath, CONFIG_FILE_BINARY_BASE_PATH + " configuration may not be null!");
         this.basePath = basePath;
         this.idSupplier = idService.getSupplier("file:///", hierarchy, length);
     }
 
     private FileBinaryService(final IdentifierService idService, final Configuration config) {
-        this(idService, config.get(BINARY_BASE_PATH),
-                config.getOrDefault(BINARY_HIERARCHY, Integer.class, DEFAULT_HIERARCHY),
-                config.getOrDefault(BINARY_LENGTH, Integer.class, DEFAULT_LENGTH));
+        this(idService, config.get(CONFIG_FILE_BINARY_BASE_PATH),
+                config.getOrDefault(CONFIG_FILE_BINARY_HIERARCHY, Integer.class, DEFAULT_HIERARCHY),
+                config.getOrDefault(CONFIG_FILE_BINARY_LENGTH, Integer.class, DEFAULT_LENGTH));
     }
 
     @Override

--- a/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
@@ -62,7 +62,7 @@ import org.trellisldp.api.Resource;
 public class FileMementoService implements MementoService {
 
     /** The configuration key controlling the base filesystem path for memento storage. **/
-    public static final String MEMENTO_BASE_PATH = "trellis.file.memento.basepath";
+    public static final String CONFIG_FILE_MEMENTO_BASE_PATH = "trellis.file.memento.basepath";
 
     private final File directory;
 
@@ -71,7 +71,7 @@ public class FileMementoService implements MementoService {
      */
     @Inject
     public FileMementoService() {
-        this(ConfigurationProvider.getConfiguration().get(MEMENTO_BASE_PATH));
+        this(ConfigurationProvider.getConfiguration().get(CONFIG_FILE_MEMENTO_BASE_PATH));
     }
 
     /**

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -63,12 +63,12 @@ public class FileBinaryServiceTest {
 
     @BeforeAll
     public static void setUpEverything() {
-        System.setProperty(FileBinaryService.BINARY_BASE_PATH, directory);
+        System.setProperty(FileBinaryService.CONFIG_FILE_BINARY_BASE_PATH, directory);
     }
 
     @AfterAll
     public static void cleanUp() {
-        System.clearProperty(FileBinaryService.BINARY_BASE_PATH);
+        System.clearProperty(FileBinaryService.CONFIG_FILE_BINARY_BASE_PATH);
     }
 
     @Test

--- a/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
@@ -73,7 +73,7 @@ public class FileMementoServiceTest {
         assertTrue(dir.isDirectory(), "Resource directory isn't a valid directory");
 
         try {
-            System.setProperty(FileMementoService.MEMENTO_BASE_PATH, dir.getAbsolutePath());
+            System.setProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH, dir.getAbsolutePath());
 
             final MementoService svc = new FileMementoService();
 
@@ -89,7 +89,7 @@ public class FileMementoServiceTest {
             svc.get(identifier, MAX).thenAccept(res -> assertEquals(time2, res.getModified(), "Incorrect date!"))
                 .join();
         } finally {
-            System.clearProperty(FileMementoService.MEMENTO_BASE_PATH);
+            System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
     }
 
@@ -98,7 +98,7 @@ public class FileMementoServiceTest {
         final File dir = new File(getClass().getResource("/versions").getFile());
 
         try {
-            System.setProperty(FileMementoService.MEMENTO_BASE_PATH, dir.getAbsolutePath());
+            System.setProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH, dir.getAbsolutePath());
 
             final MementoService svc = new FileMementoService();
             final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "nonexistent");
@@ -108,7 +108,7 @@ public class FileMementoServiceTest {
             assertTrue(svc.list(identifier).join().isEmpty(), "Resource directory isn't empty!");
             assertEquals(MISSING_RESOURCE, svc.get(identifier, now()).join(), "Wrong response for missing resource!");
         } finally {
-            System.clearProperty(FileMementoService.MEMENTO_BASE_PATH);
+            System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
     }
 
@@ -117,7 +117,7 @@ public class FileMementoServiceTest {
         final File dir = new File(getClass().getResource("/versions").getFile());
 
         try {
-            System.setProperty(FileMementoService.MEMENTO_BASE_PATH, dir.getAbsolutePath());
+            System.setProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH, dir.getAbsolutePath());
 
             final MementoService svc = new FileMementoService();
             final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "empty");
@@ -127,7 +127,7 @@ public class FileMementoServiceTest {
             assertEquals(MISSING_RESOURCE, svc.get(identifier, now()).join(), "Wrong response for missing resource!");
             assertTrue(svc.list(identifier).join().isEmpty(), "Memento list isn't empty!");
         } finally {
-            System.clearProperty(FileMementoService.MEMENTO_BASE_PATH);
+            System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
     }
 
@@ -141,7 +141,7 @@ public class FileMementoServiceTest {
         assertFalse(versionDir.exists(), "Version directory already exists!");
 
         try {
-            System.setProperty(FileMementoService.MEMENTO_BASE_PATH, versionDir.getAbsolutePath());
+            System.setProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH, versionDir.getAbsolutePath());
 
             final MementoService svc = new FileMementoService();
 
@@ -159,7 +159,7 @@ public class FileMementoServiceTest {
             assertNull(svc.delete(identifier, time.plusSeconds(10)).join(), "Error with Memento deletion (+10s)!");
             assertEquals(1L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
         } finally {
-            System.clearProperty(FileMementoService.MEMENTO_BASE_PATH);
+            System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
     }
 
@@ -173,7 +173,7 @@ public class FileMementoServiceTest {
         assumeTrue(readonly.setReadOnly(), "Unable to set directory read-only, skipping test!");
 
         try {
-            System.setProperty(FileMementoService.MEMENTO_BASE_PATH, dir.getAbsolutePath());
+            System.setProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH, dir.getAbsolutePath());
 
             final MementoService svc = new FileMementoService();
             assertEquals(2L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
@@ -191,7 +191,7 @@ public class FileMementoServiceTest {
                     "Error deleting non-existent Memento (+10s)!");
             assertEquals(2L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
         } finally {
-            System.clearProperty(FileMementoService.MEMENTO_BASE_PATH);
+            System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
     }
 
@@ -205,7 +205,7 @@ public class FileMementoServiceTest {
         assumeTrue(unreadable.setReadable(false), "Couldn't set directory as unreadable, skipping test!");
 
         try {
-            System.setProperty(FileMementoService.MEMENTO_BASE_PATH, dir.getAbsolutePath());
+            System.setProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH, dir.getAbsolutePath());
 
             final MementoService svc = new FileMementoService();
 
@@ -215,7 +215,7 @@ public class FileMementoServiceTest {
                 return emptyList();
             }).join().isEmpty(), "Memento list wasn't empty!");
         } finally {
-            System.clearProperty(FileMementoService.MEMENTO_BASE_PATH);
+            System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
     }
 

--- a/components/io-jena/src/main/java/org/trellisldp/io/JenaIOService.java
+++ b/components/io-jena/src/main/java/org/trellisldp/io/JenaIOService.java
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 package org.trellisldp.io;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
@@ -97,15 +98,13 @@ import org.trellisldp.api.RuntimeTrellisException;
 public class JenaIOService implements IOService {
 
     /** The configuration key listing valid JSON-LD profile documents. **/
-    public static final String IO_JSONLD_PROFILES = "trellis.io.jsonld.profiles";
+    public static final String CONFIG_IO_JSONLD_PROFILES = "trellis.io.jsonld.profiles";
 
     /** The configuration key listing valid JSON-LD profile domains. **/
-    public static final String IO_JSONLD_DOMAINS = "trellis.io.jsonld.domains";
+    public static final String CONFIG_IO_JSONLD_DOMAINS = "trellis.io.jsonld.domains";
 
     private static final Logger LOGGER = getLogger(JenaIOService.class);
-
     private static final JenaRDF rdf = new JenaRDF();
-
     private static final Map<IRI, RDFFormat> JSONLD_FORMATS = unmodifiableMap(Stream.of(
                 new SimpleEntry<>(compacted, JSONLD_COMPACT_FLAT),
                 new SimpleEntry<>(flattened, JSONLD_FLATTEN_FLAT),
@@ -119,7 +118,6 @@ public class JenaIOService implements IOService {
     private final RDFaWriterService htmlSerializer;
     private final Set<String> whitelist;
     private final Set<String> whitelistDomains;
-
     private final List<RDFSyntax> readable;
     private final List<RDFSyntax> writable;
     private final List<RDFSyntax> updatable;
@@ -161,8 +159,8 @@ public class JenaIOService implements IOService {
             final RDFaWriterService htmlSerializer,
             @TrellisProfileCache final CacheService<String, String> cache) {
         this(namespaceService, htmlSerializer, cache,
-                ConfigurationProvider.getConfiguration().getOrDefault(IO_JSONLD_PROFILES, ""),
-                ConfigurationProvider.getConfiguration().getOrDefault(IO_JSONLD_DOMAINS, ""));
+                ConfigurationProvider.getConfiguration().getOrDefault(CONFIG_IO_JSONLD_PROFILES, ""),
+                ConfigurationProvider.getConfiguration().getOrDefault(CONFIG_IO_JSONLD_DOMAINS, ""));
     }
 
     /**

--- a/components/namespaces/src/main/java/org/trellisldp/namespaces/NamespacesJsonContext.java
+++ b/components/namespaces/src/main/java/org/trellisldp/namespaces/NamespacesJsonContext.java
@@ -41,7 +41,7 @@ import org.trellisldp.api.NamespaceService;
 public class NamespacesJsonContext implements NamespaceService {
 
     /** The configuration key controlling the path to a JSON-formatted namespace file. **/
-    public static final String NAMESPACES_PATH = "trellis.namespaces.path";
+    public static final String CONFIG_NAMESPACES_PATH = "trellis.namespaces.path";
 
     private static final Logger LOGGER = getLogger(NamespacesJsonContext.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -55,7 +55,7 @@ public class NamespacesJsonContext implements NamespaceService {
      */
     @Inject
     public NamespacesJsonContext() {
-        this(ConfigurationProvider.getConfiguration().get(NAMESPACES_PATH));
+        this(ConfigurationProvider.getConfiguration().get(CONFIG_NAMESPACES_PATH));
     }
 
     /**

--- a/components/namespaces/src/test/java/org/trellisldp/namespaces/NamespacesJsonContextTest.java
+++ b/components/namespaces/src/test/java/org/trellisldp/namespaces/NamespacesJsonContextTest.java
@@ -47,11 +47,11 @@ public class NamespacesJsonContextTest {
     public void testReadFromJson() {
         final URL res = NamespacesJsonContext.class.getResource(nsDoc);
         try {
-            System.setProperty(NamespacesJsonContext.NAMESPACES_PATH, res.getPath());
+            System.setProperty(NamespacesJsonContext.CONFIG_NAMESPACES_PATH, res.getPath());
             final NamespacesJsonContext svc = new NamespacesJsonContext();
             assertEquals(2, svc.getNamespaces().size(), "Namespace mapping count is incorrect!");
         } finally {
-            System.clearProperty(NamespacesJsonContext.NAMESPACES_PATH);
+            System.clearProperty(NamespacesJsonContext.CONFIG_NAMESPACES_PATH);
         }
     }
 
@@ -59,11 +59,11 @@ public class NamespacesJsonContextTest {
     public void testReadError() {
         final URL res = NamespacesJsonContext.class.getResource("/thisIsNot.json");
         try {
-            System.setProperty(NamespacesJsonContext.NAMESPACES_PATH, res.getPath());
+            System.setProperty(NamespacesJsonContext.CONFIG_NAMESPACES_PATH, res.getPath());
             assertThrows(UncheckedIOException.class, NamespacesJsonContext::new,
                     "Loaded namespaces from invalid file!");
         } finally {
-            System.clearProperty(NamespacesJsonContext.NAMESPACES_PATH);
+            System.clearProperty(NamespacesJsonContext.CONFIG_NAMESPACES_PATH);
         }
     }
 
@@ -72,7 +72,7 @@ public class NamespacesJsonContextTest {
         final URL res = NamespacesJsonContext.class.getResource("/readonly.json");
 
         try {
-            System.setProperty(NamespacesJsonContext.NAMESPACES_PATH, res.getPath());
+            System.setProperty(NamespacesJsonContext.CONFIG_NAMESPACES_PATH, res.getPath());
 
             final NamespacesJsonContext svc = new NamespacesJsonContext();
             final File file = new File(res.toURI());
@@ -80,7 +80,7 @@ public class NamespacesJsonContextTest {
             assertThrows(UncheckedIOException.class, () ->
                     svc.setPrefix("ex", "http://example.com/"), "Set prefix on unwritable namespace file!");
         } finally {
-            System.getProperties().remove(NamespacesJsonContext.NAMESPACES_PATH);
+            System.getProperties().remove(NamespacesJsonContext.CONFIG_NAMESPACES_PATH);
         }
     }
 
@@ -90,7 +90,7 @@ public class NamespacesJsonContextTest {
         final String filename = file.getParent() + "/" + randomFilename();
 
         try {
-            System.setProperty(NamespacesJsonContext.NAMESPACES_PATH, filename);
+            System.setProperty(NamespacesJsonContext.CONFIG_NAMESPACES_PATH, filename);
 
             final NamespacesJsonContext svc1 = new NamespacesJsonContext();
             assertEquals(15, svc1.getNamespaces().size(), "Incorrect namespace mapping count!");
@@ -104,7 +104,7 @@ public class NamespacesJsonContextTest {
             assertFalse(svc2.setPrefix("jsonld", JSONLD.getNamespace()),
                     "unexpected response when trying to re-set jsonld mapping!");
         } finally {
-            System.getProperties().remove(NamespacesJsonContext.NAMESPACES_PATH);
+            System.getProperties().remove(NamespacesJsonContext.CONFIG_NAMESPACES_PATH);
         }
     }
 

--- a/components/rdfa/src/main/java/org/trellisldp/rdfa/HtmlSerializer.java
+++ b/components/rdfa/src/main/java/org/trellisldp/rdfa/HtmlSerializer.java
@@ -49,16 +49,16 @@ public class HtmlSerializer implements RDFaWriterService {
     private static final MustacheFactory mf = new DefaultMustacheFactory();
 
     /** The configuration key controlling the HTML template to use. **/
-    public static final String HTML_TEMPLATE = "trellis.html.template";
+    public static final String CONFIG_RDFA_TEMPLATE = "trellis.rdfa.template";
 
     /** The configuration key controlling the CSS URLs to use. **/
-    public static final String HTML_CSS = "trellis.html.css";
+    public static final String CONFIG_RDFA_CSS = "trellis.rdfa.css";
 
     /** The configuration key controlling the web icon to use. **/
-    public static final String HTML_ICON = "trellis.html.icon";
+    public static final String CONFIG_RDFA_ICON = "trellis.rdfa.icon";
 
     /** The configuration key controlling the JS URLs to use. **/
-    public static final String HTML_JS = "trellis.html.js";
+    public static final String CONFIG_RDFA_JS = "trellis.rdfa.js";
 
     private final NamespaceService namespaceService;
     private final Mustache template;
@@ -73,9 +73,9 @@ public class HtmlSerializer implements RDFaWriterService {
      */
     @Inject
     public HtmlSerializer(final NamespaceService namespaceService) {
-        this(namespaceService, getConfiguration().get(HTML_TEMPLATE),
-                getConfiguration().get(HTML_CSS), getConfiguration().get(HTML_JS),
-                getConfiguration().get(HTML_ICON));
+        this(namespaceService, getConfiguration().get(CONFIG_RDFA_TEMPLATE),
+                getConfiguration().get(CONFIG_RDFA_CSS), getConfiguration().get(CONFIG_RDFA_JS),
+                getConfiguration().get(CONFIG_RDFA_ICON));
     }
 
     /**

--- a/components/rdfa/src/test/resources/META-INF/javaconfiguration.properties
+++ b/components/rdfa/src/test/resources/META-INF/javaconfiguration.properties
@@ -1,3 +1,3 @@
-trellis.html.icon=//www.trellisldp.org/assets/img/trellis.png
-trellis.html.css=//www.trellisldp.org/assets/css/trellis.css
-trellis.html.js=
+trellis.rdfa.icon=//www.trellisldp.org/assets/img/trellis.png
+trellis.rdfa.css=//www.trellisldp.org/assets/css/trellis.css
+trellis.rdfa.js=

--- a/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -70,7 +70,7 @@ import org.trellisldp.vocabulary.VCARD;
 public class WebACService implements AccessControlService {
 
     /** The configuration key controlling whether to check member resources at the AuthZ enforcement point. **/
-    public static final String WEBAC_MEMBERSHIP_CHECK = "trellis.webac.membership.check";
+    public static final String CONFIG_WEBAC_MEMBERSHIP_CHECK = "trellis.webac.membership.check";
 
     private static final Logger LOGGER = getLogger(WebACService.class);
     private static final RDF rdf = getInstance();
@@ -106,7 +106,8 @@ public class WebACService implements AccessControlService {
     @Inject
     public WebACService(final ResourceService resourceService,
             @TrellisAuthorizationCache final CacheService<String, Set<IRI>> cache) {
-        this(resourceService, cache, getConfiguration().getOrDefault(WEBAC_MEMBERSHIP_CHECK, Boolean.class, false));
+        this(resourceService, cache, getConfiguration()
+                .getOrDefault(CONFIG_WEBAC_MEMBERSHIP_CHECK, Boolean.class, false));
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/CacheControlFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/CacheControlFilter.java
@@ -40,11 +40,11 @@ import org.apache.tamaya.Configuration;
 public class CacheControlFilter implements ContainerResponseFilter {
 
     /** The configuration key for setting a cache-control max-age header. **/
-    public static final String CONFIG_CACHE_AGE = "trellis.http.cache.maxage";
+    public static final String CONFIG_HTTP_CACHE_AGE = "trellis.http.cache.maxage";
     /** The configuration key for setting a cache-control must-revalidate header. **/
-    public static final String CONFIG_CACHE_REVALIDATE = "trellis.http.cache.revalidate";
+    public static final String CONFIG_HTTP_CACHE_REVALIDATE = "trellis.http.cache.revalidate";
     /** The configuration key for setting a cache-control no-cache header. **/
-    public static final String CONFIG_CACHE_NOCACHE = "trellis.http.cache.nocache";
+    public static final String CONFIG_HTTP_CACHE_NOCACHE = "trellis.http.cache.nocache";
 
     private static final Configuration config = getConfiguration();
 
@@ -57,9 +57,9 @@ public class CacheControlFilter implements ContainerResponseFilter {
      */
     @Inject
     public CacheControlFilter() {
-        this(config.getOrDefault(CONFIG_CACHE_AGE, Integer.class, 86400),
-             config.getOrDefault(CONFIG_CACHE_REVALIDATE, Boolean.class, true),
-             config.getOrDefault(CONFIG_CACHE_NOCACHE, Boolean.class, false));
+        this(config.getOrDefault(CONFIG_HTTP_CACHE_AGE, Integer.class, 86400),
+             config.getOrDefault(CONFIG_HTTP_CACHE_REVALIDATE, Boolean.class, true),
+             config.getOrDefault(CONFIG_HTTP_CACHE_NOCACHE, Boolean.class, false));
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/CrossOriginResourceSharingFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/CrossOriginResourceSharingFilter.java
@@ -55,17 +55,17 @@ import org.slf4j.Logger;
 public class CrossOriginResourceSharingFilter implements ContainerResponseFilter {
 
     /** The configuration key controlling the CORS -Allow-Origin header. **/
-    public static final String CONFIG_CORS_ORIGIN = "trellis.http.cors.origin";
+    public static final String CONFIG_HTTP_CORS_ALLOW_ORIGIN = "trellis.http.cors.alloworigin";
     /** The configuration key controlling the CORS -Allow-Methods header. **/
-    public static final String CONFIG_CORS_ALLOW_METHODS = "trellis.http.cors.allowedmethods";
+    public static final String CONFIG_HTTP_CORS_ALLOW_METHODS = "trellis.http.cors.allowmethods";
     /** The configuration key controlling the CORS -Allow-Headers header. **/
-    public static final String CONFIG_CORS_ALLOW_HEADERS = "trellis.http.cors.allowedheaders";
+    public static final String CONFIG_HTTP_CORS_ALLOW_HEADERS = "trellis.http.cors.allowheaders";
     /** The configuration key controlling the CORS -Expose-Headers header. **/
-    public static final String CONFIG_CORS_EXPOSE_HEADERS = "trellis.http.cors.exposedheaders";
+    public static final String CONFIG_HTTP_CORS_EXPOSE_HEADERS = "trellis.http.cors.exposeheaders";
     /** The configuration key controlling the CORS -Allow-Credentials header. **/
-    public static final String CONFIG_CORS_ALLOW_CREDENTIALS = "trellis.http.cors.allowcredentials";
+    public static final String CONFIG_HTTP_CORS_ALLOW_CREDENTIALS = "trellis.http.cors.allowcredentials";
     /** The configuration key controlling the CORS -Max-Age header. **/
-    public static final String CONFIG_CORS_MAX_AGE = "trellis.http.cors.maxage";
+    public static final String CONFIG_HTTP_CORS_MAX_AGE = "trellis.http.cors.maxage";
 
     private static final Logger LOGGER = getLogger(CrossOriginResourceSharingFilter.class);
     private static final Configuration config = getConfiguration();
@@ -86,16 +86,16 @@ public class CrossOriginResourceSharingFilter implements ContainerResponseFilter
      */
     @Inject
     public CrossOriginResourceSharingFilter() {
-        this(populateFieldNames(config.getOrDefault(CONFIG_CORS_ORIGIN, "*")),
-             populateFieldNames(config.getOrDefault(CONFIG_CORS_ALLOW_METHODS,
+        this(populateFieldNames(config.getOrDefault(CONFIG_HTTP_CORS_ALLOW_ORIGIN, "*")),
+             populateFieldNames(config.getOrDefault(CONFIG_HTTP_CORS_ALLOW_METHODS,
                      "GET,HEAD,OPTIONS,POST,PUT,PATCH,DELETE")),
-             populateFieldNames(config.getOrDefault(CONFIG_CORS_ALLOW_HEADERS,
+             populateFieldNames(config.getOrDefault(CONFIG_HTTP_CORS_ALLOW_HEADERS,
                      "Content-Type,Link,Accept,Accept-DateTIme,Prefer,Want-Digest,Slug,Digest,Origin")),
-             populateFieldNames(config.getOrDefault(CONFIG_CORS_EXPOSE_HEADERS,
+             populateFieldNames(config.getOrDefault(CONFIG_HTTP_CORS_EXPOSE_HEADERS,
                      "Content-Type,Link,Memento-Datetime,Preference-Applied,Location,Accept-Patch,Accept-Post," +
                      "Digest,Accept-Ranges,ETag,Vary")),
-             config.getOrDefault(CONFIG_CORS_ALLOW_CREDENTIALS, Boolean.class, true),
-             config.getOrDefault(CONFIG_CORS_MAX_AGE, Integer.class, 180));
+             config.getOrDefault(CONFIG_HTTP_CORS_ALLOW_CREDENTIALS, Boolean.class, true),
+             config.getOrDefault(CONFIG_HTTP_CORS_MAX_AGE, Integer.class, 180));
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -23,7 +23,7 @@ import static org.trellisldp.api.RDFUtils.getInstance;
 import static org.trellisldp.api.RDFUtils.toQuad;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
-import static org.trellisldp.http.domain.HttpConstants.CONFIGURATION_BASE_URL;
+import static org.trellisldp.http.domain.HttpConstants.CONFIG_HTTP_BASE_URL;
 import static org.trellisldp.http.domain.HttpConstants.TIMEMAP;
 
 import com.codahale.metrics.annotation.Timed;
@@ -98,7 +98,7 @@ public class TrellisHttpResource {
      */
     @Inject
     public TrellisHttpResource(final ServiceBundler trellis) {
-        this(trellis, ConfigurationProvider.getConfiguration().get(CONFIGURATION_BASE_URL));
+        this(trellis, ConfigurationProvider.getConfiguration().get(CONFIG_HTTP_BASE_URL));
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/WebAcFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/WebAcFilter.java
@@ -71,10 +71,10 @@ public class WebAcFilter implements ContainerRequestFilter, ContainerResponseFil
      *
      * <p>Multiple challenges should be separated with commas.
      **/
-    public static final String TRELLIS_AUTH_CHALLENGES = "trellis.auth.challenges";
+    public static final String CONFIG_AUTH_CHALLENGES = "trellis.auth.challenges";
 
     /** The configuration key controlling the realm used in a WWW-Authenticate header, or 'trellis' by default. **/
-    public static final String TRELLIS_AUTH_REALM = "trellis.auth.realm";
+    public static final String CONFIG_AUTH_REALM = "trellis.auth.realm";
 
     private static final Logger LOGGER = getLogger(WebAcFilter.class);
     private static final RDF rdf = getInstance();
@@ -93,8 +93,8 @@ public class WebAcFilter implements ContainerRequestFilter, ContainerResponseFil
      */
     @Inject
     public WebAcFilter(final AccessControlService accessService) {
-        this(accessService, asList(config.getOrDefault(TRELLIS_AUTH_CHALLENGES, "").split(",")),
-                config.getOrDefault(TRELLIS_AUTH_REALM, "trellis"));
+        this(accessService, asList(config.getOrDefault(CONFIG_AUTH_CHALLENGES, "").split(",")),
+                config.getOrDefault(CONFIG_AUTH_REALM, "trellis"));
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
@@ -39,7 +39,7 @@ import javax.ws.rs.container.ContainerResponseFilter;
 public class WebSubHeaderFilter implements ContainerResponseFilter {
 
     /** The configuration key controlling the location of a web-sub-hub. **/
-    public static final String CONF_WEB_SUB_HUB = "trellis.http.websubhub";
+    public static final String CONFIG_HTTP_WEB_SUB_HUB = "trellis.http.websubhub";
 
     private final String hub;
 
@@ -48,7 +48,7 @@ public class WebSubHeaderFilter implements ContainerResponseFilter {
      */
     @Inject
     public WebSubHeaderFilter() {
-        this(getConfiguration().get(CONF_WEB_SUB_HUB));
+        this(getConfiguration().get(CONFIG_HTTP_WEB_SUB_HUB));
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/domain/HttpConstants.java
+++ b/core/http/src/main/java/org/trellisldp/http/domain/HttpConstants.java
@@ -43,7 +43,7 @@ public final class HttpConstants {
 
     public static final String APPLICATION_LINK_FORMAT = "application/link-format";
 
-    public static final String CONFIGURATION_BASE_URL = "trellis.http.baseUrl";
+    public static final String CONFIG_HTTP_BASE_URL = "trellis.http.baseUrl";
 
     public static final String EXT = "ext";
 

--- a/core/http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/LdpForbiddenResourceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.http.domain.HttpConstants.APPLICATION_LINK_FORMAT;
-import static org.trellisldp.http.domain.HttpConstants.CONFIGURATION_BASE_URL;
+import static org.trellisldp.http.domain.HttpConstants.CONFIG_HTTP_BASE_URL;
 import static org.trellisldp.http.domain.RdfMediaType.APPLICATION_N_TRIPLES_TYPE;
 import static org.trellisldp.http.domain.RdfMediaType.APPLICATION_SPARQL_UPDATE_TYPE;
 
@@ -56,14 +56,17 @@ public class LdpForbiddenResourceTest extends BaseLdpResourceTest {
         initMocks(this);
 
         BASE_URL = getBaseUri().toString();
-        System.getProperties().setProperty(CONFIGURATION_BASE_URL, BASE_URL);
-
         final ResourceConfig config = new ResourceConfig();
-        config.register(new TestAuthenticationFilter("testUser", "group"));
-        config.register(new AgentAuthorizationFilter(mockAgentService));
-        config.register(new WebAcFilter(mockAccessControlService));
-        config.register(new TrellisHttpResource(mockBundler, null));
-        System.getProperties().remove(CONFIGURATION_BASE_URL);
+        try {
+            System.setProperty(CONFIG_HTTP_BASE_URL, BASE_URL);
+
+            config.register(new TestAuthenticationFilter("testUser", "group"));
+            config.register(new AgentAuthorizationFilter(mockAgentService));
+            config.register(new WebAcFilter(mockAccessControlService));
+            config.register(new TrellisHttpResource(mockBundler, null));
+        } finally {
+            System.clearProperty(CONFIG_HTTP_BASE_URL);
+        }
 
         return config;
     }

--- a/notifications/amqp/src/main/java/org/trellisldp/amqp/AmqpPublisher.java
+++ b/notifications/amqp/src/main/java/org/trellisldp/amqp/AmqpPublisher.java
@@ -44,16 +44,16 @@ public class AmqpPublisher implements EventService {
         .orElseThrow(() -> new RuntimeTrellisException("No ActivityStream service available!"));
 
     /** The configuration key controlling the AMQP exchange name. **/
-    public static final String AMQP_EXCHANGE_NAME = "trellis.amqp.exchangename";
+    public static final String CONFIG_AMQP_EXCHANGE_NAME = "trellis.amqp.exchangename";
 
     /** The configuration key controlling the AMQP routing key. **/
-    public static final String AMQP_ROUTING_KEY = "trellis.amqp.routingkey";
+    public static final String CONFIG_AMQP_ROUTING_KEY = "trellis.amqp.routingkey";
 
     /** The configuration key controlling whether publishing is mandatory. **/
-    public static final String AMQP_MANDATORY = "trellis.amqp.mandatory";
+    public static final String CONFIG_AMQP_MANDATORY = "trellis.amqp.mandatory";
 
     /** The configuration key controlling whether publishing is immediate. **/
-    public static final String AMQP_IMMEDIATE = "trellis.amqp.immediate";
+    public static final String CONFIG_AMQP_IMMEDIATE = "trellis.amqp.immediate";
 
     private final Channel channel;
     private final String exchangeName;
@@ -71,9 +71,9 @@ public class AmqpPublisher implements EventService {
     }
 
     private AmqpPublisher(final Channel channel, final Configuration config) {
-        this(channel, config.get(AMQP_EXCHANGE_NAME), config.get(AMQP_ROUTING_KEY),
-            config.getOrDefault(AMQP_MANDATORY, Boolean.class, true),
-            config.getOrDefault(AMQP_IMMEDIATE, Boolean.class, false));
+        this(channel, config.get(CONFIG_AMQP_EXCHANGE_NAME), config.get(CONFIG_AMQP_ROUTING_KEY),
+            config.getOrDefault(CONFIG_AMQP_MANDATORY, Boolean.class, true),
+            config.getOrDefault(CONFIG_AMQP_IMMEDIATE, Boolean.class, false));
     }
 
     /**

--- a/notifications/jms/src/main/java/org/trellisldp/jms/JmsPublisher.java
+++ b/notifications/jms/src/main/java/org/trellisldp/jms/JmsPublisher.java
@@ -40,7 +40,7 @@ import org.trellisldp.api.RuntimeTrellisException;
 public class JmsPublisher implements EventService {
 
     /** The configuration key controlling the JMS queue name. **/
-    public static final String JMS_QUEUE_NAME = "trellis.jms.queue";
+    public static final String CONFIG_JMS_QUEUE_NAME = "trellis.jms.queue";
 
     private static final Logger LOGGER = getLogger(JmsPublisher.class);
 
@@ -59,7 +59,7 @@ public class JmsPublisher implements EventService {
     @Inject
     public JmsPublisher(final Connection conn) throws JMSException {
         this(conn.createSession(false, AUTO_ACKNOWLEDGE),
-                ConfigurationProvider.getConfiguration().get(JMS_QUEUE_NAME));
+                ConfigurationProvider.getConfiguration().get(CONFIG_JMS_QUEUE_NAME));
     }
 
     /**

--- a/notifications/kafka/src/main/java/org/trellisldp/kafka/KafkaPublisher.java
+++ b/notifications/kafka/src/main/java/org/trellisldp/kafka/KafkaPublisher.java
@@ -39,7 +39,7 @@ public class KafkaPublisher implements EventService {
         .orElseThrow(() -> new RuntimeTrellisException("No ActivityStream service available!"));
 
     /** The configuration key controlling the name of the kafka topic. **/
-    public static final String KAFKA_TOPIC = "trellis.kafka.topic";
+    public static final String CONFIG_KAFKA_TOPIC = "trellis.kafka.topic";
 
     private final Producer<String, String> producer;
     private final String topic;
@@ -50,7 +50,7 @@ public class KafkaPublisher implements EventService {
      */
     @Inject
     public KafkaPublisher(final Producer<String, String> producer) {
-        this(producer, ConfigurationProvider.getConfiguration().get(KAFKA_TOPIC));
+        this(producer, ConfigurationProvider.getConfiguration().get(CONFIG_KAFKA_TOPIC));
     }
 
     /**

--- a/platform/webapp/build.gradle
+++ b/platform/webapp/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile("javax.ws.rs:javax.ws.rs-api:$jaxrsVersion")
     compile("org.apache.jena:jena-osgi:$jenaVersion")
     compile("org.apache.commons:commons-compress:$commonsCompressVersion")
+    compile("org.apache.commons:commons-lang3:$commonsLangVersion")
     compile("org.apache.tamaya:tamaya-api:$tamayaVersion")
     compile("org.apache.tamaya:tamaya-core:$tamayaVersion")
     compile("org.glassfish.jersey.core:jersey-server:$jerseyVersion")

--- a/platform/webapp/src/main/java/org/trellisldp/webapp/WebappServiceBundler.java
+++ b/platform/webapp/src/main/java/org/trellisldp/webapp/WebappServiceBundler.java
@@ -14,8 +14,6 @@
 package org.trellisldp.webapp;
 
 import org.apache.jena.rdfconnection.RDFConnection;
-import org.apache.tamaya.Configuration;
-import org.apache.tamaya.ConfigurationProvider;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
@@ -41,8 +39,6 @@ import org.trellisldp.triplestore.TriplestoreResourceService;
  */
 public class WebappServiceBundler implements ServiceBundler {
 
-    private static final Configuration config = ConfigurationProvider.getConfiguration();
-
     private final AgentService agentService;
     private final MementoService mementoService;
     private final AuditService auditService;
@@ -56,7 +52,7 @@ public class WebappServiceBundler implements ServiceBundler {
      */
     public WebappServiceBundler() {
         final IdentifierService idService = AppUtils.loadFirst(IdentifierService.class);
-        final RDFConnection rdfConnection = AppUtils.getRDFConnection(config.get("trellis.rdf.location"));
+        final RDFConnection rdfConnection = AppUtils.getRDFConnection();
 
         eventService = AppUtils.loadWithDefault(EventService.class, NoopEventService::new);
         agentService = AppUtils.loadFirst(AgentService.class);

--- a/platform/webapp/src/main/resources/META-INF/javaconfiguration.properties
+++ b/platform/webapp/src/main/resources/META-INF/javaconfiguration.properties
@@ -8,23 +8,24 @@ trellis.file.binary.basepath=data/trellis/binaries
 # (empty) == in memory
 # (http://hostname) == external triplestore
 # (/some/path) == on-disk TDB database
-trellis.rdf.location=
+trellis.webapp.rdf.location=
 
 # The path to a JSON namespaces file
 trellis.namespaces.path=data/trellis/namespaces.json
 
 # The path to a credentials file
-trellis.auth.basic.credentialsfile=data/trellis/users.auth
+trellis.auth.basic.credentials=data/trellis/users.auth
 
 # The base URL
 trellis.http.baseUrl=
 
-trellis.cache.enabled=true
-trellis.cache.maxAge=86400
+trellis.webapp.cache.enabled=true
+trellis.http.cache.maxage=86400
 
-trellis.cors.enabled=true
-trellis.cors.allowOrigin=*
-trellis.cors.allowMethods=PUT,DELETE,PATCH,GET,HEAD,OPTIONS,POST
-trellis.cors.allowHeaders=Content-Type,Link,Accept,Accept-Datetime,Prefer,Want-Digest,Slug,Digest,Origin
-trellis.cors.exposeHeaders=Content-Type,Link,Memento-Datetime,Preference-Applied,Location,Accept-Patch,Accept-Post,Digest,Accept-Range,ETag,Vary
-trellis.cors.maxAge=180
+trellis.webapp.cors.enabled=true
+trellis.http.cors.alloworigin=*
+trellis.http.cors.allowmethods=PUT,DELETE,PATCH,GET,HEAD,OPTIONS,POST
+trellis.http.cors.allowheaders=Content-Type,Link,Accept,Accept-Datetime,Prefer,Want-Digest,Slug,Digest,Origin
+trellis.http.cors.exposeheaders=Content-Type,Link,Memento-Datetime,Preference-Applied,Location,Accept-Patch,Accept-Post,Digest,Accept-Range,ETag,Vary
+trellis.http.cors.allowcredentials=false
+trellis.http.cors.maxage=180

--- a/platform/webapp/src/test/java/org/trellisldp/webapp/AppUtilsTest.java
+++ b/platform/webapp/src/test/java/org/trellisldp/webapp/AppUtilsTest.java
@@ -58,7 +58,7 @@ public class AppUtilsTest {
 
     @Test
     public void testRDFConnectionMem() {
-        final RDFConnection conn = AppUtils.getRDFConnection(null);
+        final RDFConnection conn = AppUtils.getRDFConnection();
 
         assertNotNull(conn, "No connection found!");
         assertTrue(conn instanceof RDFConnectionLocal, "Unexpected RDFConnection type!");
@@ -67,38 +67,53 @@ public class AppUtilsTest {
 
     @Test
     public void testRDFConnectionLocal() {
-        final RDFConnection conn = AppUtils.getRDFConnection(config.get("trellis.rdf.location"));
+        try {
+            System.setProperty(AppUtils.CONFIG_WEBAPP_RDF_LOCATION, "./build/data");
+            final RDFConnection conn = AppUtils.getRDFConnection();
 
-        assertNotNull(conn, "No connection found!");
-        assertTrue(conn instanceof RDFConnectionLocal, "Unexpected RDFConnection type!");
-        assertFalse(conn.isClosed(), "Connection closed prematurely!");
+            assertNotNull(conn, "No connection found!");
+            assertTrue(conn instanceof RDFConnectionLocal, "Unexpected RDFConnection type!");
+            assertFalse(conn.isClosed(), "Connection closed prematurely!");
+        } finally {
+            System.clearProperty(AppUtils.CONFIG_WEBAPP_RDF_LOCATION);
+        }
     }
 
     @Test
     public void testRDFConnectionRemote() {
-        final RDFConnection conn = AppUtils.getRDFConnection("http://example.com");
+        try {
+            System.setProperty(AppUtils.CONFIG_WEBAPP_RDF_LOCATION, "http://example.com");
+            final RDFConnection conn = AppUtils.getRDFConnection();
 
-        assertNotNull(conn, "No connection found!");
-        assertTrue(conn instanceof RDFConnectionRemote, "Unexpected RDFConnection type!");
-        assertFalse(conn.isClosed(), "Connection closed prematurely!");
+            assertNotNull(conn, "No connection found!");
+            assertTrue(conn instanceof RDFConnectionRemote, "Unexpected RDFConnection type!");
+            assertFalse(conn.isClosed(), "Connection closed prematurely!");
+        } finally {
+            System.clearProperty(AppUtils.CONFIG_WEBAPP_RDF_LOCATION);
+        }
     }
 
     @Test
     public void testRDFConnectionRemoteSSL() {
-        final RDFConnection conn = AppUtils.getRDFConnection("https://example.com");
+        try {
+            System.setProperty(AppUtils.CONFIG_WEBAPP_RDF_LOCATION, "https://example.com");
+            final RDFConnection conn = AppUtils.getRDFConnection();
 
-        assertNotNull(conn, "No connection found!");
-        assertTrue(conn instanceof RDFConnectionRemote, "Unexpected RDFConnection type!");
-        assertFalse(conn.isClosed(), "Connection closed prematurely!");
+            assertNotNull(conn, "No connection found!");
+            assertTrue(conn instanceof RDFConnectionRemote, "Unexpected RDFConnection type!");
+            assertFalse(conn.isClosed(), "Connection closed prematurely!");
+        } finally {
+            System.clearProperty(AppUtils.CONFIG_WEBAPP_RDF_LOCATION);
+        }
     }
 
     @Test
     public void testNoCORSFilter() {
         try {
-            System.setProperty("trellis.cors.enabled", "false");
+            System.setProperty(AppUtils.CONFIG_WEBAPP_CORS_ENABLED, "false");
             assertFalse(AppUtils.getCORSFilter().isPresent(), "Unexpected CORS filter!");
         } finally {
-            System.clearProperty("trellis.cors.enabled");
+            System.clearProperty(AppUtils.CONFIG_WEBAPP_CORS_ENABLED);
         }
     }
 
@@ -110,10 +125,10 @@ public class AppUtilsTest {
     @Test
     public void testNoCacheFilter() {
         try {
-            System.setProperty("trellis.cache.enabled", "false");
+            System.setProperty(AppUtils.CONFIG_WEBAPP_CACHE_ENABLED, "false");
             assertFalse(AppUtils.getCacheControlFilter().isPresent(), "Unexpected cache filter!");
         } finally {
-            System.clearProperty("trellis.cache.enabled");
+            System.clearProperty(AppUtils.CONFIG_WEBAPP_CACHE_ENABLED);
         }
     }
 


### PR DESCRIPTION
Resolves #225 

With this PR, the defined configuration properties will be as is described below. 
One area with a bit of inconsistency is the `trellis.auth.realm`, which is used in `trellis-http` and both auth modules. Other than `trellis-api`, there is no common dependency, so that string is defined in three separate classes. One option would be to define it in `org.trellisldp.api.RDFUtils`, but it seems a little overkill to define that string in the API layer (but maybe that wouldn't be too bad).


### auth/basic
CONFIG_AUTH_REALM = trellis.auth.realm
CONFIG_AUTH_BASIC_CREDENTIALS = trellis.auth.basic.credentials

### auth/oauth
CONFIG_AUTH_REALM = trellis.auth.realm
CONFIG_AUTH_OAUTH_KEYSTORE_PATH = trellis.auth.oauth.keystore.path
CONFIG_AUTH_OAUTH_KEYSTORE_CREDENTIALS = trellis.auth.oauth.keystore.credentials
CONFIG_AUTH_OAUTH_KEYSTORE_IDS = trellis.auth.oauth.keystore.ids
CONFIG_AUTH_OAUTH_SHARED_SECRET = trellis.auth.oauth.sharedsecret
CONFIG_AUTH_OAUTH_JWK_URL = trellis.auth.oauth.jwk

### components/app
CONFIG_APP_INITIALIZE_ROOT = trellis.app.initialize.root

### components/file
CONFIG_FILE_BINARY_BASE_PATH = trellis.file.binary.basepath
CONFIG_FILE_BINARY_HIERARCHY = trellis.file.binary.hierarchy
CONFIG_FILE_BINARY_LENGTH = trellis.file.binary.length
CONFIG_FILE_MEMENTO_BASE_PATH = trellis.file.memento.basepath

### components/io-jena
CONFIG_IO_JSONLD_PROFILES = trellis.io.jsonld.profiles
CONFIG_IO_JSONLD_DOMAINS = trellis.io.jsonld.domains

### components/namespaces
CONFIG_NAMESPACES_PATH = trellis.namespaces.path

### components/rdfa
CONFIG_RDFA_TEMPLATE = trellis.rdfa.template
CONFIG_RDFA_CSS = trellis.rdfa.css
CONFIG_RDFA_ICON = trellis.rdfa.icon
CONFIG_RDFA_JS = trellis.rdfa.js

### components/webac
CONFIG_WEBAC_MEMBERSHIP_CHECK = trellis.webac.membership.check

### core/http
CONFIG_AUTH_CHALLENGES = trellis.auth.challenges
CONFIG_AUTH_REALM = trellis.auth.realm
CONFIG_HTTP_WEB_SUB_HUB = trellis.http.websubhub
CONFIG_HTTP_CORS_ORIGIN = trellis.http.cors.origin
CONFIG_HTTP_CORS_ALLOW_METHODS = trellis.http.cors.allowmethods
CONFIG_HTTP_CORS_ALLOW_HEADERS = trellis.http.cors.allowheaders
CONFIG_HTTP_CORS_EXPOSE_HEADERS = trellis.http.cors.exposeheaders
CONFIG_HTTP_CORS_ALLOW_CREDENTIALS = trellis.http.cors.allowcredentials
CONFIG_HTTP_CORS_MAX_AGE = trellis.http.cors.maxage
CONFIG_HTTP_BASE_URL = trellis.http.baseUrl
CONFIG_HTTP_CACHE_AGE = trellis.http.cache.maxage
CONFIG_HTTP_CACHE_REVALIDATE = trellis.http.cache.revalidate
CONFIG_HTTP_CACHE_NOCACHE = trellis.http.cache.nocache

### notifications/amqp
CONFIG_AMQP_EXCHANGE_NAME = trellis.amqp.exchangename
CONFIG_AMQP_ROUTING_KEY = trellis.amqp.routingkey
CONFIG_AMQP_MANDATORY = trellis.amqp.mandatory
CONFIG_AMQP_IMMEDIATE = trellis.amqp.immediate

### notifications/jms
CONFIG_JMS_QUEUE_NAME = trellis.jms.queue

### notifications/kafka
CONFIG_KAFKA_TOPIC = trellis.kafka.topic

### platform/webapp
CONFIG_WEBAPP_CACHE_ENABLED = trellis.webapp.cache.enabled
CONFIG_WEBAPP_CORS_ENABLED = trellis.webapp.cors.enabled
CONFIG_WEBAPP_RDF_LOCATION = trellis.webapp.rdf.location