### PR TITLE
Adjust injection constructor on IO service

### DIFF
--- a/components/io-jena/src/main/java/org/trellisldp/io/JenaIOService.java
+++ b/components/io-jena/src/main/java/org/trellisldp/io/JenaIOService.java
@@ -127,6 +127,7 @@ public class JenaIOService implements IOService {
     /**
      * Create a serialization service.
      */
+    @Inject
     public JenaIOService() {
         this(findFirst(NamespaceService.class).orElseGet(NoopNamespaceService::new));
     }
@@ -156,7 +157,6 @@ public class JenaIOService implements IOService {
      * @param htmlSerializer the HTML serializer service
      * @param cache a cache for custom JSON-LD profile resolution
      */
-    @Inject
     public JenaIOService(final NamespaceService namespaceService,
             final RDFaWriterService htmlSerializer,
             @TrellisProfileCache final CacheService<String, String> cache) {


### PR DESCRIPTION
This moves the injection point for the Jena-based IO Service to the no-arg constructor.

@ajs6f is this a good idea? Would this make things easier or harder for CDI? We can certainly leave this as it is, if that would be preferable; otherwise, I'd like to start to favor the no-arg constructors for dependency injection.