### PR TITLE
Add ResourceService::touch method

### DIFF
--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -511,6 +511,13 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
+    public CompletableFuture<Void> touch(final IRI identifier) {
+        return runAsync(() -> {
+            // TODO - implement this
+        });
+    }
+
+    @Override
     public Set<IRI> supportedInteractionModels() {
         return supportedIxnModels;
     }

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -182,11 +182,13 @@ public class TriplestoreResourceServiceTest {
 
         assertThrows(ExecutionException.class, () ->
                 svc.create(resource, LDP.RDFSource, rdf.createDataset(), root, null).get(),
-                "No exception with dropped backend connection!");
+                "No (create) exception with dropped backend connection!");
         assertThrows(ExecutionException.class, () -> svc.add(resource, rdf.createDataset()).get(),
-                "No exception with dropped backend connection!");
+                "No (add) exception with dropped backend connection!");
         assertThrows(ExecutionException.class, () -> svc.delete(resource, root).get(),
-                "No exception with dropped backend connection!");
+                "No (delete) exception with dropped backend connection!");
+        assertThrows(ExecutionException.class, () -> svc.touch(resource).get(),
+                "No (touch) exception with dropped backend connection!");
     }
 
     @Test
@@ -217,8 +219,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.RDFSource, 1L, 3L, 3L, 0L)),
@@ -237,8 +240,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.RDFSource, 1L, 3L, 1L, 0L)),
@@ -260,8 +264,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.NonRDFSource, dataset, root, binary).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.NonRDFSource, dataset, root, binary),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.NonRDFSource, 1L, 7L, 1L, 0L)),
@@ -276,13 +281,13 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource3, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                svc.create(resource3, LDP.RDFSource, dataset, null, null).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource3).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, resource3, LDP.RDFSource, evenLater));
-                assertAll("Check resource stream", checkResourceStream(res, 1L, 3L, 0L, 1L, 0L, 0L));
+                assertAll("Check resource stream", checkResourceStream(res, 1L, 2L, 0L, 1L, 0L, 0L));
                 assertFalse(res.getBinary().isPresent(), "Unexpected binary metadata!");
             }),
             svc.get(root).thenAccept(checkRoot(later, 1L)),
@@ -310,8 +315,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.Container, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.Container, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 3L, 3L, 3L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -323,8 +330,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 1L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.Container, 3L, 3L, 3L, 1L)),
@@ -366,9 +375,11 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.Container, dataset1, root, null).join(),
-                "Unsuccessful create operation!");
-        assertDoesNotThrow(() -> svc.add(resource, dataset2).join(), "Unsuccessful add operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.Container, dataset1, root, null),
+                      svc.add(resource, dataset2),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 2L, 3L, 2L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -387,8 +398,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.Container, dataset, root, null).join(),
-                "Unsuccessful create operaion!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.Container, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 2L, 3L, 1L, 0L)),
@@ -402,8 +414,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 2L, 3L, 1L)),
@@ -420,8 +433,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant preDelete = meanwhile();
 
-        assertDoesNotThrow(() -> svc.delete(child, resource).join(),
-                "Unsuccessful delete operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.delete(child, resource),
+                      svc.touch(resource)).join(), "Unsuccessful delete operation!");
 
         allOf(
             svc.get(child).thenAccept(res -> assertEquals(DELETED_RESOURCE, res, "Incorrect resource object!")),
@@ -443,8 +457,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.BasicContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.BasicContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.BasicContainer, 3L, 3L, 0L, 0L)),
@@ -458,8 +473,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 2L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.BasicContainer, 3L, 3L, 0L, 1L)),
@@ -476,6 +493,7 @@ public class TriplestoreResourceServiceTest {
 
         assertDoesNotThrow(() -> svc.replace(child, LDP.RDFSource, dataset, resource, null).join(),
                 "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 2L, 3L, 2L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.BasicContainer, 3L, 3L, 0L, 1L)),
@@ -499,8 +517,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.DirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.DirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 5L, 7L, 0L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -511,8 +531,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 1L, 3L, 0L)),
             svc.get(resource).thenAccept(res -> {
@@ -541,8 +563,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.DirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.DirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 4L, 7L, 0L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -553,8 +577,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(members, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater, 1L, 3L, 0L, 0L)),
             svc.get(members).thenAccept(res -> assertFalse(res.getBinary().isPresent(), "Unexpected binary metadata!")),
@@ -568,8 +594,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 1L, 3L, 0L)),
             svc.get(resource).thenAccept(checkResource(evenLater2, LDP.DirectContainer, 4L, 7L, 0L, 1L)),
@@ -597,8 +625,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.DirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.DirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 4L, 7L, 1L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -614,8 +644,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource2, LDP.DirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource2, LDP.DirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource2).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, resource2, LDP.DirectContainer, evenLater));
@@ -631,8 +663,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(members, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater2, 2L, 3L, 1L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 4L, 7L, 1L, 0L)),
@@ -649,8 +683,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater3 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater3, 1L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater, LDP.DirectContainer, 4L, 7L, 1L, 1L)),
@@ -669,8 +705,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater4 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child2, LDP.RDFSource, dataset, resource2, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child2, LDP.RDFSource, dataset, resource2, null),
+                      svc.touch(members), svc.touch(resource2)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child2).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, child2, LDP.RDFSource, evenLater4));
@@ -705,8 +743,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.DirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.DirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 5L, 7L, 1L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -719,8 +759,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource2, LDP.DirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource2, LDP.DirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource2).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, resource2, LDP.DirectContainer, evenLater));
@@ -735,8 +777,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(members, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater2, 1L, 3L, 1L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 5L, 7L, 1L, 0L)),
@@ -753,8 +797,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater3 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, child, LDP.RDFSource, evenLater3));
@@ -775,8 +821,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater4 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child2, LDP.RDFSource, dataset, resource2, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child2, LDP.RDFSource, dataset, resource2, null),
+                      svc.touch(resource2)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child2).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, child2, LDP.RDFSource, evenLater4));
@@ -816,8 +864,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.IndirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.IndirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 7L, 7L, 4L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -833,8 +883,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(members, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater, 1L, 3L, 4L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 7L, 7L, 4L, 0L)),
@@ -852,8 +904,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 1L, 3L, 3L)),
             svc.get(resource).thenAccept(checkResource(evenLater2, LDP.IndirectContainer, 7L, 7L, 4L, 1L)),
@@ -883,8 +937,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.IndirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.IndirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 5L, 7L, 1L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -898,8 +954,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(members, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 5L, 7L, 1L, 0L)),
             svc.get(resource).thenAccept(checkPredates(evenLater)),
@@ -914,8 +972,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 1L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater2, LDP.IndirectContainer, 5L, 7L, 1L, 1L)),
@@ -945,8 +1005,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.IndirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.IndirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 4L, 7L, 2L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -961,8 +1023,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(members, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater, 1L, 3L, 3L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 4L, 7L, 2L, 0L)),
@@ -979,8 +1043,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 2L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater2, LDP.IndirectContainer, 4L, 7L, 2L, 1L)),
@@ -1016,8 +1082,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource, LDP.IndirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource, LDP.IndirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 5L, 7L, 3L, 0L)),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
@@ -1031,8 +1099,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(resource2, LDP.IndirectContainer, dataset, root, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(resource2, LDP.IndirectContainer, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(resource2).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, resource2, LDP.IndirectContainer, evenLater));
@@ -1047,8 +1117,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(members, LDP.RDFSource, dataset, root, null).join(),
-                "Unsuccessfult create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                      svc.touch(root)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater2, 1L, 3L, 1L, 0L)),
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 5L, 7L, 3L, 0L)),
@@ -1066,8 +1138,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater3 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child, LDP.RDFSource, dataset, resource, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                      svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater3, 1L, 3L, 1L)),
             svc.get(resource).thenAccept(checkResource(evenLater3, LDP.IndirectContainer, 5L, 7L, 3L, 1L)),
@@ -1090,8 +1164,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater4 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.create(child2, LDP.RDFSource, dataset, resource2, null).join(),
-                "Unsuccessful create operation!");
+        assertDoesNotThrow(() ->
+                allOf(svc.create(child2, LDP.RDFSource, dataset, resource2, null),
+                      svc.touch(members), svc.touch(resource2)).join(), "Unsuccessful create operation!");
+
         allOf(
             svc.get(child2).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, child2, LDP.RDFSource, evenLater4));

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -121,9 +121,9 @@ public interface ResourceService extends MutableDataService<Resource>, Immutable
     /**
      * Update the modification date of the provided resource.
      *
-     * @apiNote there may be cases where the resource with the given identifier does not (yet) exist.
-     *          In those cases, the implementation should return a completed future as if the resource
-     *          existed. Exceptions should be thrown only if there is an error updating an existing resource.
+     * @apiNote In general, when this method is called, it can be expected that the target resource
+     *          will already exist. In cases where that resource does not already exist, an implementation
+     *          may choose to throw an exception, log an error or simply do nothing.
      * @param identifier the identifier of the resource
      * @return a new completion stage that, when the stage completes normally, indicates that the
      *         identified resource has been updated with a new modification date.

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -20,6 +20,7 @@ import static org.trellisldp.api.RDFUtils.getInstance;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.rdf.api.BlankNode;
 import org.apache.commons.rdf.api.IRI;
@@ -116,6 +117,18 @@ public interface ResourceService extends MutableDataService<Resource>, Immutable
         }
         return term;
     }
+
+    /**
+     * Update the modification date of the provided resource.
+     *
+     * @apiNote there may be cases where the resource with the given identifier does not (yet) exist.
+     *          In those cases, the implementation should return a completed future as if the resource
+     *          existed. Exceptions should be thrown only if there is an error updating an existing resource.
+     * @param identifier the identifier of the resource
+     * @return a new completion stage that, when the stage completes normally, indicates that the
+     *         identified resource has been updated with a new modification date.
+     */
+    CompletableFuture<Void> touch(IRI identifier);
 
     /**
      * Return a collection of interaction models supported by this Resource Service.

--- a/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -142,6 +142,11 @@ public class JoiningResourceServiceTest {
         public Set<IRI> supportedInteractionModels() {
             return emptySet();
         }
+
+        @Override
+        public CompletableFuture<Void> touch(final IRI identifier) {
+            return completedFuture(null);
+        }
     }
 
     private static class TestResource implements Resource {

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -229,6 +229,7 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(BlankNode.class))).thenAnswer(inv ->
                 rdf.createIRI(TRELLIS_BNODE_PREFIX + ((BlankNode) inv.getArgument(0)).uniqueReference()));
+        when(mockResourceService.touch(any(IRI.class))).thenReturn(completedFuture(null));
         when(mockResource.stream()).thenAnswer(inv -> Stream.of(
                 rdf.createQuad(PreferUserManaged, identifier, DC.title, rdf.createLiteral("A title")),
                 rdf.createQuad(PreferServerManaged, identifier, DC.created,

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -235,6 +235,7 @@ abstract class BaseTestHandler {
         when(mockResourceService.getContainer(any(IRI.class))).thenCallRealMethod();
         when(mockResourceService.toInternal(any(RDFTerm.class), any())).thenCallRealMethod();
         when(mockResourceService.toExternal(any(RDFTerm.class), any())).thenCallRealMethod();
+        when(mockResourceService.touch(any(IRI.class))).thenReturn(completedFuture(null));
     }
 
     private void setUpBinaryService() {


### PR DESCRIPTION
Resolves #257 

This adjusts the core interfaces to introduce a `ResourceService::touch` method, and applies the changes to the HTTP layer.

The first commit adds the method and makes use of it in the HTTP layer.
The second commit adds an implementation in the triplestore persistence layer.