### PR TITLE
Move getContainer logic inside the WebAC service

### DIFF
--- a/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -28,6 +28,7 @@ import static org.apache.tamaya.ConfigurationProvider.getConfiguration;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.RDFUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.api.RDFUtils.findFirst;
+import static org.trellisldp.api.RDFUtils.getContainer;
 import static org.trellisldp.api.RDFUtils.getInstance;
 import static org.trellisldp.api.RDFUtils.toGraph;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
@@ -271,18 +272,6 @@ public class WebACService implements AccessControlService {
      */
     private static IRI cleanIdentifier(final IRI identifier) {
         return rdf.createIRI(cleanIdentifier(identifier.getIRIString()));
-    }
-
-    /**
-     * Get the structural-logical container for this resource.
-     *
-     * @param identifier the resource identifier
-     * @return a container, if one exists. Only the root resource would return empty here.
-     */
-    private static Optional<IRI> getContainer(final IRI identifier) {
-        final String path = identifier.getIRIString().substring(TRELLIS_DATA_PREFIX.length());
-        return of(path).filter(p -> !p.isEmpty()).map(x -> x.lastIndexOf('/')).map(idx -> idx < 0 ? 0 : idx)
-                    .map(idx -> TRELLIS_DATA_PREFIX + path.substring(0, idx)).map(rdf::createIRI);
     }
 
     @TrellisAuthorizationCache

--- a/components/webac/src/test/java/org/trellisldp/webac/WebACServiceTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebACServiceTest.java
@@ -804,10 +804,6 @@ public class WebACServiceTest {
         when(mockResourceService.get(eq(rootIRI))).thenAnswer(inv -> completedFuture(mockRootResource));
         when(mockResourceService.get(eq(groupIRI))).thenAnswer(inv -> completedFuture(mockGroupResource));
         when(mockResourceService.get(eq(memberIRI))).thenAnswer(inv -> completedFuture(mockMemberResource));
-        when(mockResourceService.getContainer(nonexistentIRI)).thenReturn(of(resourceIRI));
-        when(mockResourceService.getContainer(resourceIRI)).thenReturn(of(childIRI));
-        when(mockResourceService.getContainer(childIRI)).thenReturn(of(parentIRI));
-        when(mockResourceService.getContainer(parentIRI)).thenReturn(of(rootIRI));
     }
 
     private Executable checkCannotRead(final IRI id) {

--- a/core/api/src/main/java/org/trellisldp/api/RDFUtils.java
+++ b/core/api/src/main/java/org/trellisldp/api/RDFUtils.java
@@ -92,6 +92,18 @@ public final class RDFUtils {
     }
 
     /**
+     * Get the structural-logical container for this resource.
+     *
+     * @param identifier the resource identifier
+     * @return a container, if one exists. Only the root resource would return empty here.
+     */
+    public static Optional<IRI> getContainer(final IRI identifier) {
+        final String path = identifier.getIRIString().substring(TRELLIS_DATA_PREFIX.length());
+        return Optional.of(path).filter(p -> !p.isEmpty()).map(x -> x.lastIndexOf('/')).map(idx -> idx < 0 ? 0 : idx)
+                    .map(idx -> TRELLIS_DATA_PREFIX + path.substring(0, idx)).map(rdf::createIRI);
+    }
+
+    /**
      * Collect a stream of Triples into a Graph.
      *
      * @return a graph

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.api;
 
-import static java.util.Optional.of;
 import static org.trellisldp.api.RDFUtils.TRELLIS_BNODE_PREFIX;
 import static org.trellisldp.api.RDFUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.api.RDFUtils.getInstance;
@@ -44,9 +43,7 @@ public interface ResourceService extends MutableDataService<Resource>, Immutable
      *
      */
     default Optional<IRI> getContainer(final IRI identifier) {
-        final String path = identifier.getIRIString().substring(TRELLIS_DATA_PREFIX.length());
-        return of(path).filter(p -> !p.isEmpty()).map(x -> x.lastIndexOf('/')).map(idx -> idx < 0 ? 0 : idx)
-                    .map(idx -> TRELLIS_DATA_PREFIX + path.substring(0, idx)).map(getInstance()::createIRI);
+        return RDFUtils.getContainer(identifier);
     }
 
     /**


### PR DESCRIPTION
Related to #264 

This sets the stage for reworking the ResourceService::getContainer method.