### PR TITLE
Rework MementoService interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ ext {
     /* Core dependencies */
     commonsCodecVersion = '1.11'
     commonsIoVersion = '2.6'
-    commonsLangVersion = '3.8.1'
     commonsRdfVersion = '0.5.0'
     javaxAnnotationsVersion = '1.3.2'
     javaxInjectVersion = '2.5.0-b62'
@@ -313,7 +312,6 @@ subprojects { subproj ->
             links "https://docs.oracle.com/javase/8/docs/api/"
             links 'https://docs.oracle.com/javaee/7/api/'
             links 'https://trellis-ldp.github.io/trellis/apidocs/'
-            links 'https://commons.apache.org/proper/commons-lang/javadocs/api-3.8/'
             links 'https://commons.apache.org/proper/commons-rdf/apidocs/'
             links 'https://activemq.apache.org/maven/5.15.6/apidocs/'
             links 'https://jena.apache.org/documentation/javadoc/rdfconnection/'
@@ -367,7 +365,6 @@ configure(rootProject) {
             links "https://docs.oracle.com/javase/8/docs/api/"
             links 'https://docs.oracle.com/javaee/7/api/'
             links 'https://trellis-ldp.github.io/trellis/apidocs/'
-            links 'https://commons.apache.org/proper/commons-lang/javadocs/api-3.8/'
             links 'https://commons.apache.org/proper/commons-rdf/apidocs/'
             links 'https://activemq.apache.org/maven/5.15.6/apidocs/'
             links 'https://jena.apache.org/documentation/javadoc/rdfconnection/'

--- a/components/file/build.gradle
+++ b/components/file/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
     implementation("commons-codec:commons-codec:$commonsCodecVersion")
     implementation("commons-io:commons-io:$commonsIoVersion")
-    implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
     implementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion")
     implementation("org.apache.jena:jena-osgi:$jenaVersion")
     implementation("org.apache.tamaya:tamaya-api:$tamayaVersion")

--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -33,7 +33,6 @@ import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_1;
 import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_256;
 import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_384;
 import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_512;
-import static org.apache.commons.lang3.StringUtils.stripStart;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.TrellisUtils.findFirst;
 
@@ -228,7 +227,7 @@ public class FileBinaryService implements BinaryService {
     private File getFileFromIdentifier(final IRI identifier) {
         requireNonNull(identifier, "Identifier may not be null!");
         return of(identifier).map(IRI::getIRIString).filter(x -> x.startsWith("file:")).map(URI::create)
-            .map(URI::getSchemeSpecificPart).map(x -> stripStart(x, "/")).map(x -> new File(basePath, x))
+            .map(URI::getSchemeSpecificPart).map(x -> trimStart(x, "/")).map(x -> new File(basePath, x))
             .orElseThrow(() -> new IllegalArgumentException("Could not create File object from IRI: " + identifier));
     }
 
@@ -240,4 +239,12 @@ public class FileBinaryService implements BinaryService {
             throw new UncheckedIOException(ex);
         }
     }
+
+    private static String trimStart(final String str, final String trim) {
+        if (str.startsWith(trim)) {
+            return trimStart(str.substring(trim.length()), trim);
+        }
+        return str;
+    }
+
 }

--- a/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
@@ -16,7 +16,7 @@ package org.trellisldp.file;
 import static java.time.Instant.MAX;
 import static java.time.Instant.now;
 import static java.time.Instant.parse;
-import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySortedSet;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -77,7 +77,7 @@ public class FileMementoServiceTest {
 
             final MementoService svc = new FileMementoService();
 
-            assertEquals(2L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(2L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
             svc.get(identifier, now()).thenAccept(res -> assertEquals(time2, res.getModified(), "Incorrect date!"))
                 .join();
             svc.get(identifier, time).thenAccept(res -> assertEquals(time, res.getModified(), "Incorrect date!"))
@@ -105,7 +105,7 @@ public class FileMementoServiceTest {
 
             assertTrue(dir.exists(), "Resource directory doesn't exist!");
             assertTrue(dir.isDirectory(), "Invalid resource directory!");
-            assertTrue(svc.list(identifier).join().isEmpty(), "Resource directory isn't empty!");
+            assertTrue(svc.mementos(identifier).join().isEmpty(), "Resource directory isn't empty!");
             assertEquals(MISSING_RESOURCE, svc.get(identifier, now()).join(), "Wrong response for missing resource!");
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
@@ -125,7 +125,7 @@ public class FileMementoServiceTest {
             assertTrue(dir.exists(), "Resource directory doesn't exist!");
             assertTrue(dir.isDirectory(), "Invalid resource directory!");
             assertEquals(MISSING_RESOURCE, svc.get(identifier, now()).join(), "Wrong response for missing resource!");
-            assertTrue(svc.list(identifier).join().isEmpty(), "Memento list isn't empty!");
+            assertTrue(svc.mementos(identifier).join().isEmpty(), "Memento list isn't empty!");
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
@@ -145,19 +145,19 @@ public class FileMementoServiceTest {
 
             final MementoService svc = new FileMementoService();
 
-            assertTrue(svc.list(identifier).join().isEmpty(), "Memento list isn't empty!");
+            assertTrue(svc.mementos(identifier).join().isEmpty(), "Memento list isn't empty!");
             final File file = new File(getClass().getResource("/resource.nq").getFile());
             assertTrue(file.exists(), "Memento resource doesn't exist!");
             final Resource res = new FileResource(identifier, file);
             final Instant time = now();
             svc.put(identifier, time, res.stream()).join();
 
-            assertEquals(1L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(1L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
             svc.put(identifier, time.plusSeconds(10), res.stream()).join();
-            assertEquals(2L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(2L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
             assertNull(svc.delete(identifier, time.plusSeconds(15)).join(), "Error with Memento deletion (+15s)!");
             assertNull(svc.delete(identifier, time.plusSeconds(10)).join(), "Error with Memento deletion (+10s)!");
-            assertEquals(1L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(1L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
@@ -176,7 +176,7 @@ public class FileMementoServiceTest {
             System.setProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH, dir.getAbsolutePath());
 
             final MementoService svc = new FileMementoService();
-            assertEquals(2L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(2L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
             final File file = new File(getClass().getResource("/resource.nq").getFile());
             assertTrue(file.exists(), "Memento resource doesn't exist!");
             final Resource res = new FileResource(identifier, file);
@@ -184,12 +184,12 @@ public class FileMementoServiceTest {
             final Instant time = parse("2017-02-16T11:15:01Z");
             svc.put(identifier, time.plusSeconds(10), res.stream()).handle(this::assertError).join();
 
-            assertEquals(2L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(2L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
             assertNull(svc.delete(identifier, time).handle(this::assertError).join(),
                     "Completion error deleting Memento!");
             assertNull(svc.delete(identifier, time.plusSeconds(10)).join(),
                     "Error deleting non-existent Memento (+10s)!");
-            assertEquals(2L, svc.list(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(2L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
@@ -209,10 +209,10 @@ public class FileMementoServiceTest {
 
             final MementoService svc = new FileMementoService();
 
-            assertTrue(svc.list(identifier).handle((m, err) -> {
+            assertTrue(svc.mementos(identifier).handle((m, err) -> {
                 assertNull(m, "There shouldn't be a value for an unreadable directory!");
                 assertNotNull(err, "There should have been an error with an unreadable directory!");
-                return emptyList();
+                return emptySortedSet();
             }).join().isEmpty(), "Memento list wasn't empty!");
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);

--- a/core/api/build.gradle
+++ b/core/api/build.gradle
@@ -9,7 +9,6 @@ ext {
 
 dependencies {
     api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
-    api("org.apache.commons:commons-lang3:$commonsLangVersion")
     api("javax.enterprise:cdi-api:${cdiApiVersion}")
 
     testImplementation project(':trellis-vocabulary')

--- a/core/api/src/main/java/org/trellisldp/api/MementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MementoService.java
@@ -14,11 +14,10 @@
 package org.trellisldp.api;
 
 import java.time.Instant;
-import java.util.List;
+import java.util.SortedSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
 
@@ -64,11 +63,11 @@ public interface MementoService {
     CompletableFuture<Resource> get(IRI identifier, Instant time);
 
     /**
-     * List all of the Mementos for a resource.
+     * Get the times for all of the Mementos of the given resource.
      * @param identifier the resource identifier
-     * @return the new completion stage containing a list of Memento dateTime ranges
+     * @return the new completion stage containing a collection of Memento dateTimes
      */
-    CompletableFuture<List<Range<Instant>>> list(IRI identifier);
+    CompletableFuture<SortedSet<Instant>> mementos(IRI identifier);
 
     /**
      * Delete a Memento resource.

--- a/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
@@ -13,16 +13,15 @@
  */
 package org.trellisldp.api;
 
-import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySortedSet;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 
 import java.time.Instant;
-import java.util.List;
+import java.util.SortedSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
 
@@ -47,8 +46,8 @@ public class NoopMementoService implements MementoService {
     }
 
     @Override
-    public CompletableFuture<List<Range<Instant>>> list(final IRI identifier) {
-        return completedFuture(emptyList());
+    public CompletableFuture<SortedSet<Instant>> mementos(final IRI identifier) {
+        return completedFuture(emptySortedSet());
     }
 
     @Override

--- a/core/api/src/test/java/org/trellisldp/api/NoopMementoServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopMementoServiceTest.java
@@ -70,7 +70,7 @@ public class NoopMementoServiceTest {
         testService.put(identifier, time, of(quad));
 
         assertEquals(MISSING_RESOURCE, testService.get(identifier, time).join(), "No-op service found a Memento!");
-        assertTrue(testService.list(identifier).join().isEmpty(), "No-op service found a list of Mementos!");
+        assertTrue(testService.mementos(identifier).join().isEmpty(), "No-op service found a list of Mementos!");
         assertNull(testService.delete(identifier, time).join(), "No-op service responded incorrectly to a delete!");
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -315,14 +315,14 @@ public class TrellisHttpResource {
             LOGGER.debug("Getting versioned resource: {}", req.getVersion());
             return trellis.getMementoService().get(identifier, req.getVersion().getInstant())
                 .thenApply(getHandler::initialize).thenApply(getHandler::standardHeaders)
-                .thenCombine(trellis.getMementoService().list(identifier), getHandler::addMementoHeaders)
+                .thenCombine(trellis.getMementoService().mementos(identifier), getHandler::addMementoHeaders)
                 .thenCompose(getHandler::getRepresentation);
 
         // Fetch a timemap
         } else if (TIMEMAP.equals(req.getExt())) {
             LOGGER.debug("Getting timemap resource: {}", req.getPath());
             return trellis.getResourceService().get(identifier)
-                .thenCombine(trellis.getMementoService().list(identifier), (res, mementos) -> {
+                .thenCombine(trellis.getMementoService().mementos(identifier), (res, mementos) -> {
                     if (MISSING_RESOURCE.equals(res)) {
                         throw new NotFoundException();
                     }
@@ -333,7 +333,7 @@ public class TrellisHttpResource {
         } else if (nonNull(req.getDatetime())) {
             LOGGER.debug("Getting timegate resource: {}", req.getDatetime().getInstant());
             return trellis.getMementoService().get(identifier, req.getDatetime().getInstant())
-                .thenCombine(trellis.getMementoService().list(identifier), (res, mementos) -> {
+                .thenCombine(trellis.getMementoService().mementos(identifier), (res, mementos) -> {
                     if (MISSING_RESOURCE.equals(res)) {
                         throw new NotAcceptableException();
                     }
@@ -345,7 +345,7 @@ public class TrellisHttpResource {
         LOGGER.debug("Getting resource at: {}", identifier);
         return trellis.getResourceService().get(identifier).thenApply(getHandler::initialize)
             .thenApply(getHandler::standardHeaders)
-            .thenCombine(trellis.getMementoService().list(identifier), getHandler::addMementoHeaders)
+            .thenCombine(trellis.getMementoService().mementos(identifier), getHandler::addMementoHeaders)
             .thenCompose(getHandler::getRepresentation);
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -80,6 +80,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.SortedSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -91,7 +92,6 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.StreamingOutput;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.Range;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
 import org.apache.commons.rdf.api.RDFSyntax;
@@ -240,7 +240,7 @@ public class GetHandler extends BaseLdpHandler {
      * @param mementos the list of memento ranges
      * @return the response builder
      */
-    public ResponseBuilder addMementoHeaders(final ResponseBuilder builder, final List<Range<Instant>> mementos) {
+    public ResponseBuilder addMementoHeaders(final ResponseBuilder builder, final SortedSet<Instant> mementos) {
         // Only show memento links for the user-managed graph (not ACL)
         if (!ACL.equals(getRequest().getExt())) {
             builder.link(getIdentifier(), "original timegate")

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -55,7 +55,6 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_LOCATION;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.HttpHeaders.VARY;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static org.apache.commons.lang3.Range.between;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -107,6 +106,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -595,10 +595,8 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     @Test
     public void testGetTimeMapLink() throws IOException {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockMementoService.list(eq(identifier))).thenReturn(completedFuture(asList(
-                between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
-                between(ofEpochSecond(timestamp - 1000), time),
-                between(time, ofEpochSecond(timestamp + 1000)))));
+        when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
+                ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
 
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
             .accept(APPLICATION_LINK_FORMAT).get();
@@ -622,10 +620,8 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     public void testGetTimeMapJsonCompact() throws IOException {
-        when(mockMementoService.list(eq(identifier))).thenReturn(completedFuture(asList(
-                between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
-                between(ofEpochSecond(timestamp - 1000), time),
-                between(time, ofEpochSecond(timestamp + 1000)))));
+        when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
+                ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
 
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
             .accept("application/ld+json; profile=\"http://www.w3.org/ns/json-ld#compacted\"").get();
@@ -668,10 +664,8 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     public void testGetTimeMapJson() throws IOException {
-        when(mockMementoService.list(eq(identifier))).thenReturn(completedFuture(asList(
-                between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
-                between(ofEpochSecond(timestamp - 1000), time),
-                between(time, ofEpochSecond(timestamp + 1000)))));
+        when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
+                ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
 
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
             .accept("application/ld+json; profile=\"http://www.w3.org/ns/json-ld#expanded\"").get();
@@ -941,10 +935,8 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     public void testOptionsTimemap() {
-        when(mockMementoService.list(identifier)).thenReturn(completedFuture(asList(
-                between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
-                between(ofEpochSecond(timestamp - 1000), time),
-                between(time, ofEpochSecond(timestamp + 1000)))));
+        when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
+                ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
 
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request().options();
 
@@ -2317,7 +2309,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
                 () -> assertTrue(links.stream().anyMatch(l -> l.getRels().contains("timemap") &&
                     RFC_1123_DATE_TIME.withZone(UTC).format(ofEpochSecond(timestamp - 2000))
                         .equals(l.getParams().get("from")) &&
-                    RFC_1123_DATE_TIME.withZone(UTC).format(ofEpochSecond(timestamp + 1000))
+                    RFC_1123_DATE_TIME.withZone(UTC).format(ofEpochSecond(timestamp))
                         .equals(l.getParams().get("until")) &&
                     APPLICATION_LINK_FORMAT.equals(l.getType()) &&
                     l.getUri().toString().equals(getBaseUrl() + path + "?ext=timemap")), "Missing valid timemap link!"),

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -18,11 +18,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.MAX;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySortedSet;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.apache.commons.lang3.Range.between;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -45,6 +44,7 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.BlankNode;
@@ -254,18 +254,14 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         when(mockMementoService.get(eq(binaryIdentifier), any(Instant.class)))
             .thenReturn(completedFuture(mockBinaryVersionedResource));
 
-        when(mockMementoService.list(any(IRI.class))).thenReturn(completedFuture(emptyList()));
-        when(mockMementoService.list(eq(identifier)))
-                .thenReturn(completedFuture(asList(
-                    between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
-                    between(ofEpochSecond(timestamp - 1000), time),
-                    between(time, ofEpochSecond(timestamp + 1000)))));
-        when(mockMementoService.list(eq(binaryIdentifier))).thenReturn(completedFuture(asList(
-                between(ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000)),
-                between(ofEpochSecond(timestamp - 1000), time),
-                between(time, ofEpochSecond(timestamp + 1000)))));
-        when(mockMementoService.list(eq(deletedIdentifier))).thenReturn(completedFuture(emptyList()));
-        when(mockMementoService.list(eq(userDeletedIdentifier))).thenReturn(completedFuture(emptyList()));
+        when(mockMementoService.mementos(any(IRI.class))).thenReturn(completedFuture(emptySortedSet()));
+        when(mockMementoService.mementos(eq(identifier)))
+                .thenReturn(completedFuture(new TreeSet<>(asList(
+                    ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
+        when(mockMementoService.mementos(eq(binaryIdentifier))).thenReturn(completedFuture(new TreeSet<>(asList(
+                ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
+        when(mockMementoService.mementos(eq(deletedIdentifier))).thenReturn(completedFuture(emptySortedSet()));
+        when(mockMementoService.mementos(eq(userDeletedIdentifier))).thenReturn(completedFuture(emptySortedSet()));
         when(mockMementoService.put(any())).thenReturn(completedFuture(null));
     }
 

--- a/platform/karaf/src/main/resources/features.xml
+++ b/platform/karaf/src/main/resources/features.xml
@@ -7,8 +7,6 @@
     <feature dependency="true">aries-blueprint</feature>
 
     <bundle dependency="true">mvn:org.apache.commons/commons-rdf-api/${commonsRdfVersion}</bundle>
-    <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commonsLangVersion}</bundle>
-
     <bundle dependency="true">mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/${spiflyVersion}</bundle>
     <bundle dependency="true">mvn:org.ow2.asm/asm/${asmVersion}</bundle>
     <bundle dependency="true">mvn:org.ow2.asm/asm-commons/${asmVersion}</bundle>

--- a/platform/webapp/build.gradle
+++ b/platform/webapp/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     compile("javax.ws.rs:javax.ws.rs-api:$jaxrsVersion")
     compile("org.apache.jena:jena-osgi:$jenaVersion")
     compile("org.apache.commons:commons-compress:$commonsCompressVersion")
-    compile("org.apache.commons:commons-lang3:$commonsLangVersion")
     compile("org.apache.tamaya:tamaya-api:$tamayaVersion")
     compile("org.apache.tamaya:tamaya-core:$tamayaVersion")
     compile("org.glassfish.jersey.core:jersey-server:$jerseyVersion")


### PR DESCRIPTION
Resolves #263

This removes the dependency on `commons-lang3` and changes the `MementoService::list` method to `MementoService::mementos`, now returning a `CompletableFuture<SortedSet<Instant>>`