### PR TITLE
Use template interface with ResourceService

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/SimpleResourceTemplate.java
+++ b/components/test/src/main/java/org/trellisldp/test/SimpleResourceTemplate.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.test;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Quad;
+import org.trellisldp.api.BinaryTemplate;
+import org.trellisldp.api.ResourceTemplate;
+import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.OA;
+import org.trellisldp.vocabulary.Trellis;
+
+/**
+ * A template for generating a {@link org.trellisldp.api.Resource} in a persistence layer.
+ */
+public class SimpleResourceTemplate implements ResourceTemplate {
+
+    private final IRI identifier;
+    private final IRI interactionModel;
+    private final IRI container;
+    private final Dataset dataset;
+    private final BinaryTemplate binary;
+
+    /**
+     * Create a template for generating a Trellis Resource.
+     * @param identifier the identifier
+     * @param interactionModel the LDP interaction model
+     * @param dataset the dataset
+     * @param container the container, may be {@code null}
+     * @param binary the binary template, may be {@code null}
+     */
+    public SimpleResourceTemplate(final IRI identifier, final IRI interactionModel, final Dataset dataset,
+            final IRI container, final BinaryTemplate binary) {
+        requireNonNull(identifier, "identifier may not be null!");
+        requireNonNull(interactionModel, "interactionModel may not be null!");
+        this.identifier = identifier;
+        this.interactionModel = interactionModel;
+        this.container = container;
+        this.dataset = dataset;
+        this.binary = binary;
+    }
+
+    @Override
+    public IRI getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public IRI getInteractionModel() {
+        return interactionModel;
+    }
+
+    @Override
+    public Optional<IRI> getMembershipResource() {
+        return firstValue(LDP.membershipResource);
+    }
+
+    @Override
+    public Optional<IRI> getMemberOfRelation() {
+        return firstValue(LDP.isMemberOfRelation);
+    }
+
+    @Override
+    public Optional<IRI> getMemberRelation() {
+        return firstValue(LDP.hasMemberRelation);
+    }
+
+    @Override
+    public Optional<IRI> getInsertedContentRelation() {
+        return firstValue(LDP.insertedContentRelation);
+    }
+
+    @Override
+    public Optional<IRI> getContainer() {
+        return ofNullable(container);
+    }
+
+    @Override
+    public Optional<BinaryTemplate> getBinaryTemplate() {
+        return ofNullable(binary);
+    }
+
+    @Override
+    public Dataset dataset() {
+        return dataset;
+    }
+
+    @Override
+    public Stream<? extends Quad> stream() {
+        return dataset.stream();
+    }
+
+    @Override
+    public Stream<Entry<String, String>> getExtraLinkRelations() {
+        final Stream.Builder<Entry<String, String>> builder = Stream.builder();
+        firstValue(OA.annotationService).map(IRI::getIRIString)
+            .map(x -> new SimpleImmutableEntry<>(x, OA.annotationService.getIRIString())).ifPresent(builder::accept);
+        firstValue(LDP.inbox).map(IRI::getIRIString)
+            .map(x -> new SimpleImmutableEntry<>(x, LDP.inbox.getIRIString())).ifPresent(builder::accept);
+        return builder.build();
+    }
+
+    private Optional<IRI> firstValue(final IRI predicate) {
+        return dataset.stream(of(Trellis.PreferUserManaged), identifier, predicate, null)
+            .map(Quad::getObject).filter(IRI.class::isInstance).map(IRI.class::cast).findFirst();
+    }
+}

--- a/core/api/src/main/java/org/trellisldp/api/BinaryTemplate.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryTemplate.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.api;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.apache.commons.rdf.api.IRI;
+
+/**
+ * A template for generating a {@link Binary} in a persistence layer.
+ */
+public class BinaryTemplate {
+
+    private final IRI identifier;
+    private final String mimeType;
+    private final Long size;
+    private final Instant modified;
+
+    /**
+     * Create a new BinaryTemplate object.
+     * @param identifier the identifier
+     * @param mimeType the mime type, may be {@code null}
+     * @param size the size, may be {@code null}
+     */
+    public BinaryTemplate(final IRI identifier, final String mimeType, final Long size) {
+        this(identifier, mimeType, size, null);
+    }
+
+    /**
+     * Create a new BinaryTemplate object.
+     *
+     * @apiNote the modified parameter can be used with an existing binary resource if an earlier modification
+     *          date it to be used. This may be useful in cases where a LDP-NR description is being updated
+     *          and the corresponding binary is not changed.
+     * @param identifier the identifier
+     * @param mimeType the mime type, may be {@code null}
+     * @param size the size, may be {@code null}
+     * @param modified a provisional modification date, may be {@code null}
+     */
+    public BinaryTemplate(final IRI identifier, final String mimeType, final Long size, final Instant modified) {
+        requireNonNull(identifier, "Identifier may not be null!");
+        this.identifier = identifier;
+        this.mimeType = mimeType;
+        this.size = size;
+        this.modified = modified;
+    }
+
+    /**
+     * Get the identifier for the binary.
+     * @return the identifier
+     */
+    public IRI getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * Get the size of the binary in bytes, if available.
+     * @return the size in bytes of the binary.
+     */
+    public Optional<Long> getSize() {
+        return ofNullable(size);
+    }
+
+    /**
+     * Get the MIME Type of the binary, if available.
+     * @return a MIME Type of the binary
+     */
+    public Optional<String> getMimeType() {
+        return ofNullable(mimeType);
+    }
+
+    /**
+     * Get the modification date of the binary, if available.
+     * @return the modification date of the binary
+     */
+    public Optional<Instant> getModified() {
+        return ofNullable(modified);
+    }
+
+    /**
+     * Create a Binary template from existing binary metadata.
+     *
+     * @param binary the binary metadata
+     * @return a new binary template containing the original Binary modification date
+     */
+    public static BinaryTemplate fromBinary(final Binary binary) {
+        return new BinaryTemplate(binary.getIdentifier(), binary.getMimeType().orElse(null),
+                binary.getSize().orElse(null), binary.getModified());
+    }
+}

--- a/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -72,15 +72,13 @@ public abstract class JoiningResourceService implements ResourceService {
     }
 
     @Override
-    public CompletableFuture<Void> create(final IRI id, final IRI ixnModel,
-            final Dataset dataset, final IRI container, final Binary binary) {
-        return mutableData.create(id, ixnModel, dataset, container, binary);
+    public CompletableFuture<Void> create(final ResourceTemplate template) {
+        return mutableData.create(template);
     }
 
     @Override
-    public CompletableFuture<Void> replace(final IRI id, final IRI ixnModel,
-            final Dataset dataset, final IRI container, final Binary binary) {
-        return mutableData.replace(id, ixnModel, dataset, container, binary);
+    public CompletableFuture<Void> replace(final ResourceTemplate template) {
+        return mutableData.replace(template);
     }
 
     @Override

--- a/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -39,13 +39,13 @@ public abstract class JoiningResourceService implements ResourceService {
 
     private final ImmutableDataService<Resource> immutableData;
 
-    private final MutableDataService<Resource> mutableData;
+    private final MutableDataService<Resource, ResourceTemplate> mutableData;
 
     /**
      * @param mutableData service in which to persist mutable data
      * @param immutableData service in which to persist immutable data
      */
-    public JoiningResourceService(final MutableDataService<Resource> mutableData,
+    public JoiningResourceService(final MutableDataService<Resource, ResourceTemplate> mutableData,
                     final ImmutableDataService<Resource> immutableData) {
         this.immutableData = immutableData;
         this.mutableData = mutableData;

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -16,7 +16,6 @@ package org.trellisldp.api;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 
 /**
@@ -31,35 +30,26 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * Create a resource in the server.
      *
      * @implSpec the default implementation of this method is to proxy create requests to the {@link #replace} method.
-     * @param identifier the identifier for the new resource
-     * @param ixnModel the LDP interaction model for this resource
-     * @param dataset the dataset to be persisted
-     * @param container an LDP container for this resource, {@code null} for none
-     * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
+     * @param template the resource template
      * @return a new completion stage that, when the stage completes normally, indicates that the supplied data were
      * successfully created in the corresponding persistence layer. In the case of an unsuccessful write operation,
      * the {@link CompletableFuture} will complete exceptionally and can be handled with
      * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
-    default CompletableFuture<Void> create(IRI identifier, IRI ixnModel, Dataset dataset, IRI container,
-                Binary binary) {
-        return replace(identifier, ixnModel, dataset, container, binary);
+    default CompletableFuture<Void> create(ResourceTemplate template) {
+        return replace(template);
     }
 
     /**
      * Replace a resource in the server.
      *
-     * @param identifier the identifier for the new resource
-     * @param ixnModel the LDP interaction model for this resource
-     * @param dataset the dataset to be persisted
-     * @param container an LDP container for this resource, {@code null} for none
-     * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
+     * @param template the resource template
      * @return a new completion stage that, when the stage completes normally, indicates that the supplied data
      * were successfully stored in the corresponding persistence layer. In the case of an unsuccessful write operation,
      * the {@link CompletableFuture} will complete exceptionally and can be handled with
      * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> replace(IRI identifier, IRI ixnModel, Dataset dataset, IRI container, Binary binary);
+    CompletableFuture<Void> replace(ResourceTemplate template);
 
     /**
      * Delete a resource from the server.

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -23,8 +23,9 @@ import org.apache.commons.rdf.api.IRI;
  *
  * @author ajs6f
  * @param <U> the type of resource that can be persisted by this service
+ * @param <V> the type of data used as a template for generating a resource
  */
-public interface MutableDataService<U> extends RetrievalService<U> {
+public interface MutableDataService<U, V> extends RetrievalService<U> {
 
     /**
      * Create a resource in the server.
@@ -36,7 +37,7 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * the {@link CompletableFuture} will complete exceptionally and can be handled with
      * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
-    default CompletableFuture<Void> create(ResourceTemplate template) {
+    default CompletableFuture<Void> create(V template) {
         return replace(template);
     }
 
@@ -49,7 +50,7 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * the {@link CompletableFuture} will complete exceptionally and can be handled with
      * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> replace(ResourceTemplate template);
+    CompletableFuture<Void> replace(V template);
 
     /**
      * Delete a resource from the server.

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -31,7 +31,8 @@ import org.apache.commons.rdf.api.RDFTerm;
  *           managed by an external framework (e.g. using {@code PostConstruct}). This may or may not include
  *           actions in external systems like databases, which may be better managed elsewhere.
  */
-public interface ResourceService extends MutableDataService<Resource>, ImmutableDataService<Resource> {
+public interface ResourceService extends MutableDataService<Resource, ResourceTemplate>,
+       ImmutableDataService<Resource> {
 
     /**
      * Skolemize a blank node.

--- a/core/api/src/main/java/org/trellisldp/api/ResourceTemplate.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceTemplate.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.api;
+
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Quad;
+
+/**
+ * A template for generating a {@link Resource} in a persistence layer.
+ */
+public interface ResourceTemplate {
+
+    /**
+     * Get the identifier for the resource.
+     * @return an identifier
+     */
+    IRI getIdentifier();
+
+    /**
+     * Get the interaction model for the resource.
+     * @return the LDP interaction model
+     */
+    IRI getInteractionModel();
+
+    /**
+     * Get the container for this resource, if one exists.
+     * @return the parent container, if present
+     */
+    Optional<IRI> getContainer();
+
+    /**
+     * Get the LDP membership resource, if present.
+     * @return the ldp:membershipResource value, if present
+     */
+    Optional<IRI> getMembershipResource();
+
+    /**
+     * Get the LDP member relation, if present.
+     * @return the ldp:hasMemberRelation value, if present
+     */
+    Optional<IRI> getMemberRelation();
+
+    /**
+     * Get the LDP member of relation, if present.
+     * @return the ldp:isMemberOfRelation value, if present
+     */
+    Optional<IRI> getMemberOfRelation();
+
+    /**
+     * Get the LDP inserted content relation, if present.
+     * @return the ldp:insertedContentRelation value, if present
+     */
+    Optional<IRI> getInsertedContentRelation();
+
+    /**
+     * Get the supplied RDF data as a stream.
+     *
+     * @apiNote the data available through this method will only include user-managed and ACL quads.
+     *          It will not include containment, membership or audit quads.
+     * @return a stream of user-supplied RDF quads
+     */
+    Stream<? extends Quad> stream();
+
+    /**
+     * Get the supplied RDF data as a {@link Dataset}.
+     *
+     * @apiNote the data available through this method will only include user-managed and ACL quads.
+     *          It will not include containment, membership or audit quads.
+     * @return a dataset containing user-supplied RDF quads
+     */
+    Dataset dataset();
+
+    /**
+     * Get the BinaryTemplate, if one is present.
+     *
+     * @return the binary template
+     */
+    Optional<BinaryTemplate> getBinaryTemplate();
+
+    /**
+     * Get any extra data for link relations.
+     * @apiNote Each entry can be used to create a link header, such that the key refers
+     *          to the URI and the value is the "rel" portion. For example, an item with
+     *          {@code key="http://example.com/author001"} and {@code value="author"} will result
+     *          in the header {@code Link: <http://example.com/author001>; rel="author"}.
+     *          An implementation may choose not to store these values.
+     * @return a stream of relation types
+     */
+    Stream<Entry<String, String>> getExtraLinkRelations();
+}

--- a/core/api/src/test/java/org/trellisldp/api/BinaryTemplateTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryTemplateTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.api;
+
+import static java.time.Instant.now;
+import static java.util.Optional.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author acoburn
+ */
+public class BinaryTemplateTest {
+
+    private static final RDF rdf = new SimpleRDF();
+
+    private final Long size = 10L;
+    private final String mimeType = "text/plain";
+    private final IRI identifier = rdf.createIRI("trellis:data/resource");
+
+    @Test
+    public void testBinaryTemplate() {
+        final BinaryTemplate binary = new BinaryTemplate(identifier, mimeType, size);
+        assertEquals(identifier, binary.getIdentifier(), "Identifier did not match");
+        assertEquals(of(mimeType), binary.getMimeType(), "MimeType did not match");
+        assertEquals(of(size), binary.getSize(), "Size did not match");
+        assertFalse(binary.getModified().isPresent(), "Unexpected modification date");
+    }
+
+    @Test
+    public void testBinaryTemplateWithOptionalArgs() {
+        final BinaryTemplate binary = new BinaryTemplate(identifier, null, null, null);
+        assertEquals(identifier, binary.getIdentifier(), "Identifier did not match");
+        assertFalse(binary.getMimeType().isPresent(), "MimeType was not absent");
+        assertFalse(binary.getSize().isPresent(), "Size was not absent");
+        assertFalse(binary.getModified().isPresent(), "Modification was not absent");
+    }
+
+    @Test
+    public void testFromBinary() {
+        final Binary binary = new Binary(identifier, now(), mimeType, size);
+        final BinaryTemplate template = BinaryTemplate.fromBinary(binary);
+        assertEquals(binary.getIdentifier(), template.getIdentifier());
+        assertEquals(of(binary.getModified()), template.getModified());
+        assertTrue(template.getSize().isPresent());
+        assertEquals(binary.getSize(), template.getSize());
+        assertTrue(template.getMimeType().isPresent());
+        assertEquals(binary.getMimeType(), template.getMimeType());
+    }
+}

--- a/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/JoiningResourceServiceTest.java
@@ -57,7 +57,7 @@ public class JoiningResourceServiceTest {
 
     private final ImmutableDataService<Resource> testImmutableService = new TestableImmutableService();
 
-    private final MutableDataService<Resource> testMutableService = new TestableMutableDataService();
+    private final MutableDataService<Resource, ResourceTemplate> testMutableService = new TestableMutableDataService();
 
     private final ResourceService testable = new TestableJoiningResourceService(testImmutableService,
                     testMutableService);
@@ -95,7 +95,7 @@ public class JoiningResourceServiceTest {
     }
 
     private static class TestableMutableDataService extends TestableRetrievalService
-                    implements MutableDataService<Resource> {
+                    implements MutableDataService<Resource, ResourceTemplate> {
 
         @Override
         public CompletableFuture<Void> create(final ResourceTemplate template) {
@@ -119,7 +119,7 @@ public class JoiningResourceServiceTest {
     private static class TestableJoiningResourceService extends JoiningResourceService {
 
         public TestableJoiningResourceService(final ImmutableDataService<Resource> immutableData,
-                        final MutableDataService<Resource> mutableData) {
+                        final MutableDataService<Resource, ResourceTemplate> mutableData) {
             super(mutableData, immutableData);
         }
 

--- a/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -36,7 +36,6 @@ import org.apache.commons.rdf.jena.JenaRDF;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.trellisldp.vocabulary.LDP;
 
 /**
  * @author acoburn
@@ -51,6 +50,9 @@ public class ResourceServiceTest {
 
     @Mock
     private static Resource mockResource;
+
+    @Mock
+    private static ResourceTemplate mockResourceTemplate;
 
     @Mock
     private RetrievalService<Resource> mockRetrievalService;
@@ -69,7 +71,7 @@ public class ResourceServiceTest {
         doCallRealMethod().when(mockResourceService).unskolemize(any());
         doCallRealMethod().when(mockResourceService).toInternal(any(), any());
         doCallRealMethod().when(mockResourceService).toExternal(any(), any());
-        doCallRealMethod().when(mockResourceService).create(any(), any(), any(), any(), any());
+        doCallRealMethod().when(mockResourceService).create(any());
 
         when(mockRetrievalService.get(eq(existing))).thenAnswer(inv -> completedFuture(mockResource));
     }
@@ -91,12 +93,10 @@ public class ResourceServiceTest {
         final IRI root = rdf.createIRI("trellis:data/");
         final Dataset dataset = rdf.createDataset();
 
-        when(mockResourceService.replace(eq(existing), eq(LDP.RDFSource), eq(dataset), eq(root), any()))
-            .thenReturn(completedFuture(null));
+        when(mockResourceService.replace(mockResourceTemplate)).thenReturn(completedFuture(null));
 
-        assertDoesNotThrow(() -> mockResourceService.create(existing, LDP.RDFSource, dataset, root, null).join());
-        verify(mockResourceService).replace(eq(existing), eq(LDP.RDFSource),
-                eq(dataset), eq(root), any());
+        assertDoesNotThrow(() -> mockResourceService.create(mockResourceTemplate).join());
+        verify(mockResourceService).replace(eq(mockResourceTemplate));
     }
 
     @Test

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -72,6 +72,7 @@ import org.trellisldp.http.impl.PatchHandler;
 import org.trellisldp.http.impl.PostHandler;
 import org.trellisldp.http.impl.PutHandler;
 import org.trellisldp.http.impl.TrellisDataset;
+import org.trellisldp.http.impl.TrellisResourceTemplate;
 import org.trellisldp.vocabulary.ACL;
 import org.trellisldp.vocabulary.FOAF;
 import org.trellisldp.vocabulary.LDP;
@@ -148,14 +149,15 @@ public class TrellisHttpResource {
     private CompletableFuture<Void> initialize(final IRI id, final Resource res, final TrellisDataset dataset) {
         if (MISSING_RESOURCE.equals(res) || DELETED_RESOURCE.equals(res)) {
             LOGGER.info("Initializing root container: {}", id);
-            return trellis.getResourceService().create(id, LDP.BasicContainer, dataset.asDataset(), null, null);
+            return trellis.getResourceService().create(new TrellisResourceTemplate(id, LDP.BasicContainer,
+                        dataset.asDataset(), null, null));
         } else if (!res.hasAcl()) {
             LOGGER.info("Initializeing root ACL: {}", id);
             try (final Stream<? extends Triple> triples = res.stream(Trellis.PreferUserManaged)) {
                 triples.map(toQuad(Trellis.PreferUserManaged)).forEach(dataset::add);
             }
-            return trellis.getResourceService().replace(res.getIdentifier(), res.getInteractionModel(),
-                    dataset.asDataset(), null, null);
+            return trellis.getResourceService().replace(new TrellisResourceTemplate(res.getIdentifier(),
+                        res.getInteractionModel(), dataset.asDataset(), null, null));
         }
         return completedFuture(null);
     }

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -50,6 +50,7 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
 import org.apache.commons.rdf.api.RDFSyntax;
 import org.slf4j.Logger;
+import org.trellisldp.api.BinaryTemplate;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.api.ServiceBundler;
@@ -282,9 +283,10 @@ class MutatingLdpHandler extends BaseLdpHandler {
         // update the resource
         return allOf(
                 getServices().getResourceService()
-                    .replace(getResource().getIdentifier(), getResource().getInteractionModel(),
-                        mutable.asDataset(), getResource().getContainer().orElse(null),
-                        getResource().getBinary().orElse(null)),
+                    .replace(new TrellisResourceTemplate(getResource().getIdentifier(),
+                        getResource().getInteractionModel(), mutable.asDataset(),
+                        getResource().getContainer().orElse(null),
+                        getResource().getBinary().map(BinaryTemplate::fromBinary).orElse(null))),
                 getServices().getResourceService().add(getResource().getIdentifier(), immutable.asDataset()));
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/TrellisResourceTemplate.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/TrellisResourceTemplate.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http.impl;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Quad;
+import org.trellisldp.api.BinaryTemplate;
+import org.trellisldp.api.ResourceTemplate;
+import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.OA;
+import org.trellisldp.vocabulary.Trellis;
+
+/**
+ * A template for generating a {@link org.trellisldp.api.Resource} in a persistence layer.
+ */
+public class TrellisResourceTemplate implements ResourceTemplate {
+
+    private final IRI identifier;
+    private final IRI interactionModel;
+    private final IRI container;
+    private final BinaryTemplate binary;
+    private final Dataset dataset;
+
+    /**
+     * Create a template for generating a Trellis Resource.
+     * @param identifier the identifier
+     * @param interactionModel the LDP interaction model
+     * @param dataset the dataset
+     * @param container the container, may be {@code null}
+     * @param binary the binary template, may be {@code null}
+     */
+    public TrellisResourceTemplate(final IRI identifier, final IRI interactionModel, final Dataset dataset,
+            final IRI container, final BinaryTemplate binary) {
+        requireNonNull(identifier, "identifier may not be null!");
+        requireNonNull(interactionModel, "interactionModel may not be null!");
+        this.identifier = identifier;
+        this.interactionModel = interactionModel;
+        this.dataset = dataset;
+        this.container = container;
+        this.binary = binary;
+    }
+
+    @Override
+    public IRI getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public IRI getInteractionModel() {
+        return interactionModel;
+    }
+
+    @Override
+    public Optional<IRI> getContainer() {
+        return ofNullable(container);
+    }
+
+    @Override
+    public Optional<IRI> getMembershipResource() {
+        return firstIRI(LDP.membershipResource);
+    }
+
+    @Override
+    public Optional<IRI> getMemberRelation() {
+        return firstIRI(LDP.hasMemberRelation);
+    }
+
+    @Override
+    public Optional<IRI> getMemberOfRelation() {
+        return firstIRI(LDP.isMemberOfRelation);
+    }
+
+    @Override
+    public Optional<IRI> getInsertedContentRelation() {
+        return firstIRI(LDP.insertedContentRelation);
+    }
+
+    @Override
+    public Stream<? extends Quad> stream() {
+        return dataset.stream();
+    }
+
+    @Override
+    public Dataset dataset() {
+        return dataset;
+    }
+
+    @Override
+    public Optional<BinaryTemplate> getBinaryTemplate() {
+        return ofNullable(binary);
+    }
+
+    @Override
+    public Stream<Entry<String, String>> getExtraLinkRelations() {
+        final Stream.Builder<Entry<String, String>> builder = Stream.builder();
+        dataset.stream(of(Trellis.PreferUserManaged), identifier, OA.annotationService, null)
+            .map(Quad::getObject).filter(IRI.class::isInstance).map(IRI.class::cast).map(IRI::getIRIString)
+            .map(x -> new SimpleImmutableEntry<>(x, OA.annotationService.getIRIString())).forEach(builder::accept);
+        dataset.stream(of(Trellis.PreferUserManaged), identifier, LDP.inbox, null)
+            .map(Quad::getObject).filter(IRI.class::isInstance).map(IRI.class::cast).map(IRI::getIRIString)
+            .map(x -> new SimpleImmutableEntry<>(x, LDP.inbox.getIRIString())).forEach(builder::accept);
+        return builder.build();
+    }
+
+    private Optional<IRI> firstIRI(final IRI predicate) {
+        return dataset.stream(of(Trellis.PreferUserManaged), identifier, predicate, null)
+            .map(Quad::getObject).filter(IRI.class::isInstance).map(IRI.class::cast).findFirst();
+    }
+}

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -71,6 +71,7 @@ import org.trellisldp.api.MementoService;
 import org.trellisldp.api.NoopAuditService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.api.ResourceTemplate;
 import org.trellisldp.api.ServiceBundler;
 import org.trellisldp.api.Session;
 import org.trellisldp.io.JenaIOService;
@@ -219,10 +220,8 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         when(mockResourceService.toExternal(any(RDFTerm.class), any())).thenCallRealMethod();
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(null));
         when(mockResourceService.delete(any(IRI.class), any(IRI.class))).thenReturn(completedFuture(null));
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class),
-                        any(), any())).thenReturn(completedFuture(null));
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class),
-                        any(), any())).thenReturn(completedFuture(null));
+        when(mockResourceService.replace(any(ResourceTemplate.class))).thenReturn(completedFuture(null));
+        when(mockResourceService.create(any(ResourceTemplate.class))).thenReturn(completedFuture(null));
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -39,8 +39,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.rdf.api.Dataset;
-import org.apache.commons.rdf.api.IRI;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -48,6 +46,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.api.ResourceTemplate;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.http.core.TrellisRequest;
 
@@ -146,16 +145,15 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(mockRootResource));
         when(mockRootResource.hasAcl()).thenReturn(false);
-        when(mockService.replace(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockService.replace(any(ResourceTemplate.class))).thenReturn(completedFuture(null));
 
         final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler);
         matcher.initialize();
 
         verify(mockService, never().description("When re-initializing the root ACL, create should not be called"))
-            .create(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .create(any(ResourceTemplate.class));
         verify(mockService, description("Use replace when re-initializing the root ACL"))
-            .replace(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .replace(any(ResourceTemplate.class));
         verify(mockService, description("Verify that the root resource is fetched only once")).get(root);
     }
 
@@ -164,16 +162,15 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
-        when(mockService.create(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockService.create(any(ResourceTemplate.class))).thenReturn(completedFuture(null));
 
         final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler);
         matcher.initialize();
 
         verify(mockService, description("Re-create a missing root resource on initialization"))
-            .create(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .create(any(ResourceTemplate.class));
         verify(mockService, never().description("Don't try to replace a non-existent root on initialization"))
-            .replace(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .replace(any(ResourceTemplate.class));
         verify(mockService, description("Verify that the root resource is fetched only once")).get(root);
     }
 
@@ -182,25 +179,24 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
-        when(mockService.create(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockService.create(any(ResourceTemplate.class))).thenReturn(completedFuture(null));
 
         final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler);
         matcher.initialize();
 
         verify(mockService, description("A previously deleted root resource should be re-created upon initialization"))
-            .create(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .create(any(ResourceTemplate.class));
         verify(mockService, never().description("replace shouldn't be called when re-initializing a deleted root"))
-            .replace(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .replace(any(ResourceTemplate.class));
         verify(mockService, description("Verify that the root resource is fetched only once")).get(root);
     }
 
     private Stream<Executable> verifyInteractions(final ResourceService svc) {
         return of(
                 () -> verify(svc, never().description("Don't re-initialize the root if it already exists"))
-                        .create(eq(root), any(IRI.class), any(Dataset.class), any(), any()),
+                        .create(any(ResourceTemplate.class)),
                 () -> verify(svc, never().description("Don't re-initialize the root if it already exists"))
-                        .replace(eq(root), any(IRI.class), any(Dataset.class), any(), any()),
+                        .replace(any(ResourceTemplate.class)),
                 () -> verify(svc, description("Verify that the root resource is fetched only once")).get(root));
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -92,6 +92,7 @@ import org.trellisldp.api.NoopAuditService;
 import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.api.ResourceTemplate;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.api.ServiceBundler;
 import org.trellisldp.http.core.TrellisRequest;
@@ -222,10 +223,8 @@ abstract class BaseTestHandler {
     private void setUpResourceService() {
         when(mockResourceService.supportedInteractionModels()).thenReturn(allInteractionModels);
         when(mockResourceService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockResource));
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockResourceService.create(any(ResourceTemplate.class))).thenReturn(completedFuture(null));
+        when(mockResourceService.replace(any(ResourceTemplate.class))).thenReturn(completedFuture(null));
         when(mockResourceService.delete(any(IRI.class), any(IRI.class))).thenReturn(completedFuture(null));
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(null));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -41,6 +41,7 @@ import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.junit.jupiter.api.Test;
 import org.trellisldp.api.AuditService;
+import org.trellisldp.api.ResourceTemplate;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.vocabulary.LDP;
 
@@ -94,8 +95,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
 
     @Test
     public void testDeleteACLError() {
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(asyncException());
+        when(mockResourceService.replace(any(ResourceTemplate.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getExt()).thenReturn(ACL);
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
         assertThrows(CompletionException.class, () ->
@@ -105,8 +105,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
 
     @Test
     public void testDeleteACLAuditError() {
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockResourceService.replace(any(ResourceTemplate.class))).thenReturn(completedFuture(null));
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getExt()).thenReturn(ACL);
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -57,6 +57,7 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Triple;
 import org.junit.jupiter.api.Test;
+import org.trellisldp.api.ResourceTemplate;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.http.core.Prefer;
@@ -122,7 +123,7 @@ public class PatchHandlerTest extends BaseTestHandler {
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
 
         verify(mockIoService).update(any(Graph.class), eq(insert), eq(SPARQL_UPDATE), eq(identifier.getIRIString()));
-        verify(mockResourceService).replace(eq(identifier), eq(LDP.RDFSource), any(Dataset.class), any(), any());
+        verify(mockResourceService).replace(any(ResourceTemplate.class));
     }
 
     @Test
@@ -183,8 +184,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     public void testError() {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
-        when(mockResourceService.replace(eq(identifier), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(asyncException());
+        when(mockResourceService.replace(any(ResourceTemplate.class))).thenReturn(asyncException());
 
         final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null);
         assertThrows(CompletionException.class, () ->

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -55,6 +55,7 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Triple;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.trellisldp.api.ResourceTemplate;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.http.core.Digest;
 import org.trellisldp.vocabulary.DC;
@@ -187,7 +188,7 @@ public class PostHandlerTest extends BaseTestHandler {
 
         verify(mockBinaryService, never()).setContent(any(IRI.class), any(InputStream.class));
         verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + path));
-        verify(mockResourceService).create(eq(identifier), eq(LDP.RDFSource), any(Dataset.class), any(), any());
+        verify(mockResourceService).create(any(ResourceTemplate.class));
     }
 
     @Test
@@ -275,8 +276,7 @@ public class PostHandlerTest extends BaseTestHandler {
 
     @Test
     public void testError() throws IOException {
-        when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "newresource")),
-                    any(IRI.class), any(Dataset.class), any(), any())).thenReturn(asyncException());
+        when(mockResourceService.create(any(ResourceTemplate.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getContentType()).thenReturn("text/turtle");
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", baseUrl);
@@ -294,7 +294,7 @@ public class PostHandlerTest extends BaseTestHandler {
     private Stream<Executable> checkBinaryEntityResponse(final IRI identifier) {
         return Stream.of(
                 () -> verify(mockResourceService, description("ResourceService::create not called!"))
-                            .create(eq(identifier), eq(LDP.NonRDFSource), any(Dataset.class), any(), any()),
+                            .create(any(ResourceTemplate.class)),
                 () -> verify(mockIoService, never().description("entity shouldn't be read!")).read(any(), any(), any()),
                 () -> verify(mockBinaryService, description("content not set on binary service!"))
                             .setContent(iriArgument.capture(), any(InputStream.class), metadataArgument.capture()),

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE;
 import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 
@@ -61,6 +60,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.MementoService;
+import org.trellisldp.api.ResourceTemplate;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.vocabulary.LDP;
@@ -262,8 +262,7 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
-        when(mockResourceService.replace(eq(identifier), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(asyncException());
+        when(mockResourceService.replace(any(ResourceTemplate.class))).thenReturn(asyncException());
 
         final PutHandler handler = buildPutHandler("/simpleData.txt", null);
 
@@ -292,8 +291,7 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
-        when(mockResourceService.replace(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")), any(IRI.class),
-                    any(Dataset.class), any(), any())).thenReturn(asyncException());
+        when(mockResourceService.replace(any(ResourceTemplate.class))).thenReturn(asyncException());
 
         final File entity = new File(getClass().getResource("/simpleData.txt").getFile() + ".non-existent-suffix");
         final PutHandler handler = new PutHandler(mockTrellisRequest, entity, mockBundler, null);

--- a/core/http/src/test/java/org/trellisldp/http/impl/TrellisResourceTemplateTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/TrellisResourceTemplateTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http.impl;
+
+import static java.util.Optional.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
+import static org.trellisldp.api.TrellisUtils.getInstance;
+
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+import org.junit.jupiter.api.Test;
+import org.trellisldp.api.ResourceTemplate;
+import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.OA;
+import org.trellisldp.vocabulary.Trellis;
+
+public class TrellisResourceTemplateTest {
+
+    private static final RDF rdf = getInstance();
+
+    @Test
+    public void testResourceTemplate() {
+        final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
+        final IRI id = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
+        final IRI member = rdf.createIRI(TRELLIS_DATA_PREFIX + "member");
+        final IRI inbox = rdf.createIRI("http://www.example.com/inbox");
+        final IRI annotations = rdf.createIRI("http://www.example.com/annotations");
+        final IRI annotations2 = rdf.createIRI("http://www.example.com/annotations2");
+        final Dataset dataset = rdf.createDataset();
+        dataset.add(Trellis.PreferUserManaged, id, LDP.membershipResource, member);
+        dataset.add(Trellis.PreferUserManaged, id, LDP.insertedContentRelation, rdf.createBlankNode());
+        dataset.add(Trellis.PreferUserManaged, id, LDP.inbox, inbox);
+        dataset.add(Trellis.PreferUserManaged, id, OA.annotationService, annotations);
+        dataset.add(Trellis.PreferUserManaged, id, OA.annotationService, annotations2);
+
+        final ResourceTemplate tpl = new TrellisResourceTemplate(id, LDP.RDFSource, dataset, root, null);
+
+        assertEquals(id, tpl.getIdentifier());
+        assertEquals(LDP.RDFSource, tpl.getInteractionModel());
+        assertEquals(dataset, tpl.dataset());
+        assertEquals(dataset.size(), tpl.stream().count());
+        assertEquals(of(root), tpl.getContainer());
+        assertFalse(tpl.getBinaryTemplate().isPresent());
+        assertEquals(of(member), tpl.getMembershipResource());
+        assertFalse(tpl.getMemberRelation().isPresent());
+        assertFalse(tpl.getMemberOfRelation().isPresent());
+        assertFalse(tpl.getInsertedContentRelation().isPresent());
+        assertTrue(tpl.getExtraLinkRelations().anyMatch(pair -> inbox.getIRIString().equals(pair.getKey())
+                    && LDP.inbox.getIRIString().equals(pair.getValue())));
+        assertEquals(2L, tpl.getExtraLinkRelations()
+                .filter(pair -> OA.annotationService.getIRIString().equals(pair.getValue())).count());
+    }
+
+}


### PR DESCRIPTION
Resovles #288

This introduces the `BinaryTemplate` class and the `ResourceTemplate` interface, which are used for resource creation and replacement.

An implementation of the `ResourceTemplate` interface is available in the `org.trellisldp.http.impl` package and also (for testing) in the `org.trellisldp.test` package.

Most of the changes here are in test code, which is a result of changing the `ResourceService::create` and `::replace` signatures.

The `ResourceTemplate` interface is very similar to the `Resource` interface with two differences:

1. The `ResourceTemplate` does not contain the `::hasAcl` method.
2. The `ResourceTemplate` does not contain the alternate `::stream` methods (i.e. those that accept one or more named graphs and respond with `Triple`s -- just the `Stream<Quad> stream()` method is present, and it should be understood that that method only returns the user-provided quads: no containment, membership or audit quads).

The `BinaryTemplate` is similar to the `Binary` class, except that the `BinaryTemplate` includes `Optional<Instant> getModified()` and a helper method for converting an existing `Binary` object into a `BinaryTemplate`. The reason for the `::getModified` method here is that in the case of a binary description being modified, the metadata for the original binary needs to stay the same, and this allows the HTTP layer to pass along that information to the `::replace` method.

A persistence implementation should take care (in a `::replace` method) to [check for the presence of a modified date](https://github.com/trellis-ldp/trellis/pull/290/files#diff-0f7a35d0461f47ab4b396fe19347264cR192) on the binary and keep it unchanged, if it is available. The HTTP layer will _not_ pass in a datetime value on `::create` operations, and so a persistence implementation should use whatever value is determined appropriate for the resource as a whole.