### PR TITLE
Rework ResourceService interfaces

### DIFF
--- a/components/app-triplestore/src/test/resources/logback-test.xml
+++ b/components/app-triplestore/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-  <logger name="org.trellisldp" additivity="false" level="DEBUG">
+  <logger name="org.trellisldp" additivity="false" level="INFO">
     <appender-ref ref="STDOUT"/>
   </logger>
   <root additivity="false" level="WARN">

--- a/components/app-triplestore/src/test/resources/logback-test.xml
+++ b/components/app-triplestore/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-  <logger name="org.trellisldp" additivity="false" level="INFO">
+  <logger name="org.trellisldp" additivity="false" level="DEBUG">
     <appender-ref ref="STDOUT"/>
   </logger>
   <root additivity="false" level="WARN">

--- a/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
@@ -192,7 +192,7 @@ public class FileMementoService implements MementoService {
         quads.add(rdf.createQuad(PreferServerManaged, resource.getIdentifier(), DC.modified,
                     rdf.createLiteral(resource.getModified().toString(), XSD.dateTime)));
 
-        resource.getBinary().ifPresent(b -> {
+        resource.getBinaryMetadata().ifPresent(b -> {
             quads.add(rdf.createQuad(PreferServerManaged, resource.getIdentifier(), DC.hasPart, b.getIdentifier()));
             b.getMimeType().map(mimeType -> rdf.createQuad(PreferServerManaged, b.getIdentifier(), DC.format,
                 rdf.createLiteral(mimeType))).ifPresent(quads::add);

--- a/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
@@ -194,8 +194,6 @@ public class FileMementoService implements MementoService {
 
         resource.getBinary().ifPresent(b -> {
             quads.add(rdf.createQuad(PreferServerManaged, resource.getIdentifier(), DC.hasPart, b.getIdentifier()));
-            quads.add(rdf.createQuad(PreferServerManaged, b.getIdentifier(), DC.modified,
-                        rdf.createLiteral(b.getModified().toString(), XSD.dateTime)));
             b.getMimeType().map(mimeType -> rdf.createQuad(PreferServerManaged, b.getIdentifier(), DC.format,
                 rdf.createLiteral(mimeType))).ifPresent(quads::add);
             b.getSize().map(size -> rdf.createQuad(PreferServerManaged, b.getIdentifier(),

--- a/components/file/src/main/java/org/trellisldp/file/FileResource.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileResource.java
@@ -34,7 +34,7 @@ import org.apache.commons.rdf.api.Quad;
 import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.commons.rdf.api.Triple;
 import org.slf4j.Logger;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.vocabulary.DC;
 import org.trellisldp.vocabulary.LDP;
@@ -84,8 +84,8 @@ public class FileResource implements Resource {
     }
 
     @Override
-    public Optional<Binary> getBinary() {
-        return asIRI(DC.hasPart).map(id -> Binary.builder(id).mimeType(asLiteral(DC.format).orElse(null))
+    public Optional<BinaryMetadata> getBinaryMetadata() {
+        return asIRI(DC.hasPart).map(id -> BinaryMetadata.builder(id).mimeType(asLiteral(DC.format).orElse(null))
                 .size(asLiteral(DC.extent).map(Long::parseLong).orElse(null)).build());
     }
 

--- a/components/file/src/main/java/org/trellisldp/file/FileResource.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileResource.java
@@ -85,9 +85,8 @@ public class FileResource implements Resource {
 
     @Override
     public Optional<Binary> getBinary() {
-        return asIRI(DC.hasPart).flatMap(id -> asLiteral(Time.hasTime).map(Instant::parse).map(time ->
-                    new Binary(id, time, asLiteral(DC.format).orElse(null),
-                               asLiteral(DC.extent).map(Long::parseLong).orElse(null))));
+        return asIRI(DC.hasPart).map(id -> Binary.builder(id).mimeType(asLiteral(DC.format).orElse(null))
+                .size(asLiteral(DC.extent).map(Long::parseLong).orElse(null)).build());
     }
 
     @Override

--- a/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
@@ -41,7 +41,7 @@ import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.jena.JenaRDF;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.vocabulary.DC;
@@ -123,7 +123,8 @@ public class FileMementoServiceTest {
         when(mockResource.stream()).thenAnswer(inv -> Stream.of(
                     rdf.createQuad(Trellis.PreferUserManaged, identifier, DC.title, rdf.createLiteral("Title")),
                     rdf.createQuad(Trellis.PreferServerManaged, identifier, DC.isPartOf, root)));
-        when(mockResource.getBinary()).thenReturn(of(Binary.builder(binaryId).mimeType(mimeType).size(size).build()));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(BinaryMetadata.builder(binaryId).mimeType(mimeType)
+                    .size(size).build()));
         when(mockResource.getMemberOfRelation()).thenReturn(empty());
         when(mockResource.getMemberRelation()).thenReturn(empty());
         when(mockResource.getMembershipResource()).thenReturn(empty());
@@ -136,8 +137,8 @@ public class FileMementoServiceTest {
         assertEquals(time, res.getModified());
         assertEquals(LDP.NonRDFSource, res.getInteractionModel());
         assertEquals(of(root), res.getContainer());
-        assertTrue(res.getBinary().isPresent());
-        res.getBinary().ifPresent(b -> {
+        assertTrue(res.getBinaryMetadata().isPresent());
+        res.getBinaryMetadata().ifPresent(b -> {
             assertEquals(binaryId, b.getIdentifier());
             assertEquals(of(mimeType), b.getMimeType());
             assertEquals(of(size), b.getSize());
@@ -167,7 +168,7 @@ public class FileMementoServiceTest {
         when(mockResource.stream()).thenAnswer(inv -> Stream.of(
                     rdf.createQuad(Trellis.PreferUserManaged, identifier, DC.title, rdf.createLiteral("Title")),
                     rdf.createQuad(Trellis.PreferServerManaged, identifier, DC.isPartOf, root)));
-        when(mockResource.getBinary()).thenReturn(empty());
+        when(mockResource.getBinaryMetadata()).thenReturn(empty());
         when(mockResource.getMemberOfRelation()).thenReturn(of(DC.isPartOf));
         when(mockResource.getMemberRelation()).thenReturn(of(LDP.member));
         when(mockResource.getMembershipResource()).thenReturn(of(member));
@@ -184,7 +185,7 @@ public class FileMementoServiceTest {
         assertEquals(of(member), res.getMembershipResource());
         assertEquals(of(FOAF.primaryTopic), res.getInsertedContentRelation());
         assertEquals(of(root), res.getContainer());
-        assertFalse(res.getBinary().isPresent());
+        assertFalse(res.getBinaryMetadata().isPresent());
         assertEquals(1L, res.stream(Trellis.PreferUserManaged).count());
     }
 

--- a/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
@@ -111,7 +111,6 @@ public class FileMementoServiceTest {
         final IRI binaryId = rdf.createIRI("file:binary");
         final IRI root = rdf.createIRI("trellis:data/");
         final Instant time = now();
-        final Instant binaryTime = now().minusSeconds(10);
         final String mimeType = "text/plain";
         final Long size = 20L;
 
@@ -124,7 +123,7 @@ public class FileMementoServiceTest {
         when(mockResource.stream()).thenAnswer(inv -> Stream.of(
                     rdf.createQuad(Trellis.PreferUserManaged, identifier, DC.title, rdf.createLiteral("Title")),
                     rdf.createQuad(Trellis.PreferServerManaged, identifier, DC.isPartOf, root)));
-        when(mockResource.getBinary()).thenReturn(of(new Binary(binaryId, binaryTime, mimeType, size)));
+        when(mockResource.getBinary()).thenReturn(of(Binary.builder(binaryId).mimeType(mimeType).size(size).build()));
         when(mockResource.getMemberOfRelation()).thenReturn(empty());
         when(mockResource.getMemberRelation()).thenReturn(empty());
         when(mockResource.getMembershipResource()).thenReturn(empty());
@@ -140,7 +139,6 @@ public class FileMementoServiceTest {
         assertTrue(res.getBinary().isPresent());
         res.getBinary().ifPresent(b -> {
             assertEquals(binaryId, b.getIdentifier());
-            assertEquals(binaryTime, b.getModified());
             assertEquals(of(mimeType), b.getMimeType());
             assertEquals(of(size), b.getSize());
         });

--- a/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
@@ -78,7 +78,6 @@ public class FileResourceTest {
         assertFalse(res.getInsertedContentRelation().isPresent(), "Unexpected ldp:insertedContentRelation value!");
         assertTrue(res.getBinary().isPresent(), "Missing binary metadata!");
         res.getBinary().ifPresent(binary -> {
-            assertEquals(parse("2017-02-16T11:17:00Z"), binary.getModified(), "Incorrect binary modification date!");
             assertEquals(of(10L), binary.getSize(), "Incorrect binary size!");
             assertEquals(of("text/plain"), binary.getMimeType(), "Incorrect binary mime type!");
             assertEquals(rdf.createIRI("file:///path/to/binary"), binary.getIdentifier(), "Incorrect binary id!");

--- a/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
@@ -53,7 +53,7 @@ public class FileResourceTest {
         assertFalse(res.getMemberRelation().isPresent(), "Unexpected ldp:memberRelation value!");
         assertFalse(res.getMemberOfRelation().isPresent(), "Unexpected ldp:isMemberOfRelation value!");
         assertFalse(res.getInsertedContentRelation().isPresent(), "Unexpected ldp:insertedContentRelation value!");
-        assertFalse(res.getBinary().isPresent(), "Unexpected binary present!");
+        assertFalse(res.getBinaryMetadata().isPresent(), "Unexpected binary present!");
         assertFalse(res.hasAcl(), "Unexpected ACL present!");
         assertFalse(res.getContainer().isPresent(), "Unexpected parent resource!");
         assertEquals(3L, res.stream(LDP.PreferContainment).count(), "Incorrect containment count!");
@@ -76,8 +76,8 @@ public class FileResourceTest {
         assertFalse(res.getMemberRelation().isPresent(), "Unexpected ldp:memberRelation value!");
         assertFalse(res.getMemberOfRelation().isPresent(), "Unexpected ldp:isMemberOfRelation value!");
         assertFalse(res.getInsertedContentRelation().isPresent(), "Unexpected ldp:insertedContentRelation value!");
-        assertTrue(res.getBinary().isPresent(), "Missing binary metadata!");
-        res.getBinary().ifPresent(binary -> {
+        assertTrue(res.getBinaryMetadata().isPresent(), "Missing binary metadata!");
+        res.getBinaryMetadata().ifPresent(binary -> {
             assertEquals(of(10L), binary.getSize(), "Incorrect binary size!");
             assertEquals(of("text/plain"), binary.getMimeType(), "Incorrect binary mime type!");
             assertEquals(rdf.createIRI("file:///path/to/binary"), binary.getIdentifier(), "Incorrect binary id!");
@@ -121,7 +121,7 @@ public class FileResourceTest {
         res.getInsertedContentRelation().ifPresent(rel ->
                 assertEquals(DC.relation, rel, "Incorrect ldp:insertedContentRelation!"));
         assertFalse(res.getMemberOfRelation().isPresent(), "Unexpected ldp:isMemberOfRelation!");
-        assertFalse(res.getBinary().isPresent(), "Unexpected binary metadata!");
+        assertFalse(res.getBinaryMetadata().isPresent(), "Unexpected binary metadata!");
         assertFalse(res.hasAcl(), "Unexpected ACL!");
         assertEquals(3L, res.stream(LDP.PreferContainment).count(), "Incorrect containment triple count!");
         assertEquals(6L, res.stream(Trellis.PreferUserManaged).count(), "Incorrect user triple count!");
@@ -146,7 +146,7 @@ public class FileResourceTest {
         assertFalse(res.getInsertedContentRelation().isPresent(), "Unexpected ldp:insertedContentRelation!");
         assertTrue(res.getMemberOfRelation().isPresent(), "Missing ldp:isMemberOfRelation!");
         res.getMemberOfRelation().ifPresent(rel -> assertEquals(DC.isPartOf, rel, "Incorrect ldp:isMemberOfRelation!"));
-        assertFalse(res.getBinary().isPresent(), "Unexpected binary metadata!");
+        assertFalse(res.getBinaryMetadata().isPresent(), "Unexpected binary metadata!");
         assertFalse(res.hasAcl(), "Unexpected ACL!");
         assertEquals(3L, res.stream(LDP.PreferContainment).count(), "Incorrect containment triple count!");
         assertEquals(5L, res.stream(Trellis.PreferUserManaged).count(), "Incorrect user triple count!");

--- a/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
@@ -154,7 +154,6 @@ public interface LdpBinaryTests extends CommonTests {
     @DisplayName("Test modifying a binary's description via PATCH")
     default void testPatchBinaryDescription() {
         final RDF rdf = getInstance();
-        final EntityTag binaryETag = getETag(getResourceLocation());
         final EntityTag descriptionETag;
         final Long size;
 

--- a/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
@@ -190,7 +190,6 @@ public interface LdpBinaryTests extends CommonTests {
         try (final Response res = target(getResourceLocation()).request().get()) {
             assertAll("Check the LDP-NR", checkNonRdfResponse(res, TEXT_PLAIN_TYPE));
             assertEquals(CONTENT, readEntityAsString(res.getEntity()), "Check for an expected binary content value");
-            assertEquals(binaryETag, res.getEntityTag(), "Check that the ETag values are the same");
         }
     }
 

--- a/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.function.Executable;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
@@ -243,7 +243,7 @@ public interface ResourceServiceTests {
         final Dataset dataset = buildDataset(identifier, "Create LDP-NR Test", SUBJECT2);
 
         final IRI binaryLocation = rdf.createIRI("binary:location/" + getResourceService().generateIdentifier());
-        final Binary binary = Binary.builder(binaryLocation).mimeType("text/plain").size(150L).build();
+        final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType("text/plain").size(150L).build();
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(), "Check for no pre-existing LDP-NR");
         assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
@@ -252,7 +252,7 @@ public interface ResourceServiceTests {
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check the LDP-NR resource", checkResource(res, identifier, LDP.NonRDFSource, time, dataset));
         assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed count of the LDP-NR");
-        res.getBinary().ifPresent(b -> {
+        res.getBinaryMetadata().ifPresent(b -> {
             assertEquals(binaryLocation, b.getIdentifier(), "Check the binary identifier");
             assertEquals(of("text/plain"), b.getMimeType(), "Check the binary mimeType");
             assertEquals(of(150L), b.getSize(), "Check the binary size");
@@ -486,7 +486,8 @@ public interface ResourceServiceTests {
                 () -> assertFalse(res.getModified().isBefore(time), "Check the modification time (1)"),
                 () -> assertFalse(res.getModified().isAfter(now()), "Check the modification time (2)"),
                 () -> assertFalse(res.hasAcl(), "Check for an ACL"),
-                () -> assertEquals(LDP.NonRDFSource.equals(ldpType), res.getBinary().isPresent(), "Check Binary"),
+                () -> assertEquals(LDP.NonRDFSource.equals(ldpType), res.getBinaryMetadata().isPresent(),
+                                   "Check Binary"),
                 () -> assertEquals(asList(LDP.DirectContainer, LDP.IndirectContainer).contains(ldpType),
                        res.getMembershipResource().isPresent(), "Check ldp:membershipResource"),
                 () -> assertEquals(asList(LDP.DirectContainer, LDP.IndirectContainer).contains(ldpType),

--- a/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
@@ -14,7 +14,6 @@
 package org.trellisldp.test;
 
 import static java.time.Instant.now;
-import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.Arrays.asList;
 import static java.util.Optional.of;
 import static java.util.function.Predicate.isEqual;
@@ -49,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.function.Executable;
 import org.trellisldp.api.Binary;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.vocabulary.AS;
@@ -92,8 +92,9 @@ public interface ResourceServiceTests {
         final Dataset dataset = buildDataset(identifier, "Creation Test", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(), "Check for no pre-existing LDP-RS");
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.RDFSource, dataset,
-                    ROOT_CONTAINER, null).join(), "Check that the resource was successfully created");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset).join(),
+                "Check that the resource was successfully created");
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check resource stream", res.stream(Trellis.PreferUserManaged).map(toQuad(Trellis.PreferUserManaged))
                 .map(q -> () -> assertTrue(dataset.contains(q), "Verify that the quad is from the dataset: " + q)));
@@ -111,16 +112,18 @@ public interface ResourceServiceTests {
         final Dataset dataset = buildDataset(identifier, "Replacement Test", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(), "Check for no pre-existing LDP-RS");
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.RDFSource, dataset,
-                    ROOT_CONTAINER, null).join(), "Check that the LDP-RS was successfully created");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset).join(),
+                    "Check that the LDP-RS was successfully created");
 
         dataset.clear();
         dataset.add(Trellis.PreferUserManaged, identifier, SKOS.prefLabel, rdf.createLiteral("preferred label"));
         dataset.add(Trellis.PreferUserManaged, identifier, SKOS.altLabel, rdf.createLiteral("alternate label"));
         dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
-        assertDoesNotThrow(() -> getResourceService().replace(identifier, LDP.RDFSource, dataset,
-                    ROOT_CONTAINER, null).join(), "Check that the LDP-RS was successfully replaced");
+        assertDoesNotThrow(() -> getResourceService().replace(Metadata.builder(identifier)
+                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset).join(),
+                "Check that the LDP-RS was successfully replaced");
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check the replaced LDP-RS stream", res.stream(Trellis.PreferUserManaged)
                 .map(toQuad(Trellis.PreferUserManaged))
@@ -142,12 +145,14 @@ public interface ResourceServiceTests {
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(),
                 "Check that the resource doesn't exist");
 
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.RDFSource, dataset,
-                    ROOT_CONTAINER, null).join(), "Check that the resource was successfully created");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                            .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset).join(),
+                    "Check that the resource was successfully created");
         assertNotEquals(DELETED_RESOURCE, getResourceService().get(identifier).join(),
                 "Check that the resource isn't currently 'deleted'");
 
-        assertDoesNotThrow(() -> getResourceService().delete(identifier, ROOT_CONTAINER).join(),
+        assertDoesNotThrow(() -> getResourceService().delete(Metadata.builder(identifier)
+                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build()).join(),
                 "Check that the delete operation succeeded");
         assertEquals(DELETED_RESOURCE, getResourceService().get(identifier).join(),
                 "Verify that the resource is marked as deleted");
@@ -164,8 +169,9 @@ public interface ResourceServiceTests {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
         final Dataset dataset0 = buildDataset(identifier, "Immutable Resource Test", SUBJECT2);
 
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.RDFSource, dataset0,
-                    ROOT_CONTAINER, null).join(), "Check the successful creation of an LDP-RS");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset0).join(),
+                    "Check the successful creation of an LDP-RS");
 
         final IRI audit1 = rdf.createIRI(TRELLIS_BNODE_PREFIX + getResourceService().generateIdentifier());
         final Dataset dataset1 = rdf.createDataset();
@@ -216,8 +222,9 @@ public interface ResourceServiceTests {
         final Dataset dataset = buildDataset(identifier, "Create LDP-RS Test", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(), "Check for no pre-existing LDP-RS");
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.RDFSource, dataset,
-                    ROOT_CONTAINER, null).join(), "Check the creation of an LDP-RS");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset).join(),
+                "Check the creation of an LDP-RS");
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check the LDP-RS resource", checkResource(res, identifier, LDP.RDFSource, time, dataset));
         assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user triple count");
@@ -235,20 +242,18 @@ public interface ResourceServiceTests {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
         final Dataset dataset = buildDataset(identifier, "Create LDP-NR Test", SUBJECT2);
 
-        final Instant binaryTime = now();
         final IRI binaryLocation = rdf.createIRI("binary:location/" + getResourceService().generateIdentifier());
-        final Binary binary = new Binary(binaryLocation, binaryTime, "text/plain", 150L);
+        final Binary binary = Binary.builder(binaryLocation).mimeType("text/plain").size(150L).build();
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(), "Check for no pre-existing LDP-NR");
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.NonRDFSource, dataset,
-                    ROOT_CONTAINER, binary).join(), "Check the creation of an LDP-NR");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .interactionModel(LDP.NonRDFSource).container(ROOT_CONTAINER).binary(binary).build(), dataset)
+                .join(), "Check the creation of an LDP-NR");
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check the LDP-NR resource", checkResource(res, identifier, LDP.NonRDFSource, time, dataset));
         assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed count of the LDP-NR");
         res.getBinary().ifPresent(b -> {
             assertEquals(binaryLocation, b.getIdentifier(), "Check the binary identifier");
-            assertFalse(b.getModified().isBefore(binaryTime.truncatedTo(MILLIS)), "Check an early time boundary");
-            assertFalse(b.getModified().isAfter(now()), "Check an outer time boundary");
             assertEquals(of("text/plain"), b.getMimeType(), "Check the binary mimeType");
             assertEquals(of(150L), b.getSize(), "Check the binary size");
         });
@@ -268,22 +273,25 @@ public interface ResourceServiceTests {
         final Dataset dataset0 = buildDataset(identifier, "Container Test", SUBJECT0);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(), "Check for no pre-existing LDP-C");
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.Container, dataset0,
-                    ROOT_CONTAINER, null).join(), "Check that the LDP-C is created successfully");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .interactionModel(LDP.Container).container(ROOT_CONTAINER).build(), dataset0).join(),
+                "Check that the LDP-C is created successfully");
 
         final IRI child1 = rdf.createIRI(base + "/child01");
         final Dataset dataset1 = buildDataset(child1, "Contained Child 1", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child1).join(), "Check for no child1 resource");
-        assertDoesNotThrow(() -> getResourceService().create(child1, LDP.RDFSource, dataset1, identifier,
-                    null).join(), "Check that the first child was successfully created in the LDP-C");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1).interactionModel(LDP.RDFSource)
+                    .container(identifier).build(), dataset1).join(),
+                "Check that the first child was successfully created in the LDP-C");
 
         final IRI child2 = rdf.createIRI(base + "/child02");
         final Dataset dataset2 = buildDataset(child2, "Contained Child2", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child2).join(), "Check for no child2 resource");
-        assertDoesNotThrow(() -> getResourceService().create(child2, LDP.RDFSource, dataset2, identifier,
-                    null).join(), "Check that the second child was successfully created in the LDP-C");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2).interactionModel(LDP.RDFSource)
+                    .container(identifier).build(), dataset2).join(),
+                "Check that the second child was successfully created in the LDP-C");
 
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check the LDP-C resource", checkResource(res, identifier, LDP.Container, time, dataset0));
@@ -309,22 +317,23 @@ public interface ResourceServiceTests {
         final Dataset dataset0 = buildDataset(identifier, "Basic Container Test", SUBJECT0);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(), "Check for a pre-existing LDP-BC");
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.BasicContainer, dataset0,
-                    ROOT_CONTAINER, null).join(), "Check that creating an LDP-BC succeeds");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .interactionModel(LDP.BasicContainer).container(ROOT_CONTAINER).build(), dataset0).join(),
+                "Check that creating an LDP-BC succeeds");
 
         final IRI child1 = rdf.createIRI(base + "/child11");
         final Dataset dataset1 = buildDataset(child1, "Contained Child 1", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child1).join(), "Check for no child1 resource");
-        assertDoesNotThrow(() -> getResourceService().create(child1, LDP.RDFSource, dataset1, identifier,
-                    null).join(), "Check that child1 is created");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1).interactionModel(LDP.RDFSource)
+                    .container(identifier).build(), dataset1).join(), "Check that child1 is created");
 
         final IRI child2 = rdf.createIRI(base + "/child12");
         final Dataset dataset2 = buildDataset(child2, "Contained Child2", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child2).join(), "Check for no child2 resource");
-        assertDoesNotThrow(() -> getResourceService().create(child2, LDP.RDFSource, dataset2, identifier,
-                    null).join(), "Check that child2 is created");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2).interactionModel(LDP.RDFSource)
+                    .container(identifier).build(), dataset2).join(), "Check that child2 is created");
 
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check the LDP-BC resource", checkResource(res, identifier, LDP.BasicContainer, time, dataset0));
@@ -356,22 +365,26 @@ public interface ResourceServiceTests {
         dataset0.add(Trellis.PreferUserManaged, identifier, LDP.isMemberOfRelation, DC.isPartOf);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(), "Check that the DC doesn't exist");
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.DirectContainer, dataset0,
-                    ROOT_CONTAINER, null).join(), "Check that creating the LDP-DC succeeds");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .membershipResource(member).memberOfRelation(DC.isPartOf)
+                    .interactionModel(LDP.DirectContainer).container(ROOT_CONTAINER).build(), dataset0).join(),
+                "Check that creating the LDP-DC succeeds");
 
         final IRI child1 = rdf.createIRI(base + "/child1");
         final Dataset dataset1 = buildDataset(child1, "Child 1", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child1).join(), "Check that no child resource exists");
-        assertDoesNotThrow(() -> getResourceService().create(child1, LDP.RDFSource, dataset1, identifier,
-                    null).join(), "Check that the child resource is successfully created");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1).interactionModel(LDP.RDFSource)
+                    .container(identifier).build(), dataset1).join(),
+                "Check that the child resource is successfully created");
 
         final IRI child2 = rdf.createIRI(base + "/child2");
         final Dataset dataset2 = buildDataset(child2, "Child 2", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child2).join(), "Check that no child2 resource exists");
-        assertDoesNotThrow(() -> getResourceService().create(child2, LDP.RDFSource, dataset2, identifier,
-                    null).join(), "Check that the child2 resource is successfully created");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2).interactionModel(LDP.RDFSource)
+                    .container(identifier).build(), dataset2).join(),
+                "Check that the child2 resource is successfully created");
 
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check the resource", checkResource(res, identifier, LDP.DirectContainer, time, dataset0));
@@ -410,24 +423,28 @@ public interface ResourceServiceTests {
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).join(),
                 "Check for a missing resource");
-        assertDoesNotThrow(() -> getResourceService().create(identifier, LDP.IndirectContainer, dataset0,
-                    ROOT_CONTAINER, null).join(), "Check that creating a resource succeeds");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                    .membershipResource(member).memberRelation(DC.relation).insertedContentRelation(FOAF.primaryTopic)
+                    .interactionModel(LDP.IndirectContainer).container(ROOT_CONTAINER).build(), dataset0).join(),
+                "Check that creating a resource succeeds");
 
         final IRI child1 = rdf.createIRI(base + "/child1");
         final Dataset dataset1 = buildDataset(child1, "Indirect Container Child 1", SUBJECT1);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child1).join(),
                 "Check that the child resource doesn't exist");
-        assertDoesNotThrow(() -> getResourceService().create(child1, LDP.RDFSource, dataset1, identifier,
-                    null).join(), "Check that creating a child resource succeeds");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1).interactionModel(LDP.RDFSource)
+                    .container(identifier).build(), dataset1).join(),
+                "Check that creating a child resource succeeds");
 
         final IRI child2 = rdf.createIRI(base + "/child2");
         final Dataset dataset2 = buildDataset(child2, "Indirect Container Child 2", SUBJECT2);
 
         assertEquals(MISSING_RESOURCE, getResourceService().get(child2).join(),
                 "Check that the child resource doesn't exist");
-        assertDoesNotThrow(() -> getResourceService().create(child2, LDP.RDFSource, dataset2, identifier,
-                    null).join(), "Check that creating the child resource succeeds");
+        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2).interactionModel(LDP.RDFSource)
+                    .container(identifier).build(), dataset2).join(),
+                "Check that creating the child resource succeeds");
 
         final Resource res = getResourceService().get(identifier).join();
         assertAll("Check the resource", checkResource(res, identifier, LDP.IndirectContainer, time, dataset0));

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
@@ -57,7 +57,7 @@ import org.apache.jena.sparql.syntax.ElementNamedGraph;
 import org.apache.jena.sparql.syntax.ElementOptional;
 import org.apache.jena.sparql.syntax.ElementPathBlock;
 import org.slf4j.Logger;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.vocabulary.DC;
 import org.trellisldp.vocabulary.LDP;
@@ -230,8 +230,8 @@ public class TriplestoreResource implements Resource {
     }
 
     @Override
-    public Optional<Binary> getBinary() {
-        return asIRI(DC.hasPart).map(id -> Binary.builder(id).mimeType(asLiteral(DC.format).orElse(null))
+    public Optional<BinaryMetadata> getBinaryMetadata() {
+        return asIRI(DC.hasPart).map(id -> BinaryMetadata.builder(id).mimeType(asLiteral(DC.format).orElse(null))
                     .size(asLiteral(DC.extent).map(Long::parseLong).orElse(null)).build());
     }
 

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
@@ -62,7 +62,6 @@ import org.trellisldp.api.Resource;
 import org.trellisldp.vocabulary.DC;
 import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.RDF;
-import org.trellisldp.vocabulary.Time;
 import org.trellisldp.vocabulary.Trellis;
 
 /**
@@ -177,8 +176,7 @@ public class TriplestoreResource implements Resource {
             final RDFNode s = qs.get("binarySubject");
             final RDFNode p = qs.get("binaryPredicate");
             final RDFNode o = qs.get("binaryObject");
-            nodesToTriple(s, p, o).ifPresent(t ->
-                data.put(DC.modified.equals(t.getPredicate()) ? Time.hasTime : t.getPredicate(), t.getObject()));
+            nodesToTriple(s, p, o).ifPresent(t -> data.put(t.getPredicate(), t.getObject()));
             data.put(getPredicate(qs), getObject(qs));
         });
     }

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
@@ -231,9 +231,8 @@ public class TriplestoreResource implements Resource {
 
     @Override
     public Optional<Binary> getBinary() {
-        return asIRI(DC.hasPart).flatMap(id -> asLiteral(Time.hasTime).map(Instant::parse).map(time ->
-                    new Binary(id, time, asLiteral(DC.format).orElse(null),
-                        asLiteral(DC.extent).map(Long::parseLong).orElse(null))));
+        return asIRI(DC.hasPart).map(id -> Binary.builder(id).mimeType(asLiteral(DC.format).orElse(null))
+                    .size(asLiteral(DC.extent).map(Long::parseLong).orElse(null)).build());
     }
 
     @Override

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -59,7 +59,6 @@ import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Literal;
 import org.apache.commons.rdf.api.RDFTerm;
-import org.apache.commons.rdf.api.Triple;
 import org.apache.commons.rdf.jena.JenaRDF;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Query;
@@ -76,9 +75,9 @@ import org.apache.jena.sparql.syntax.ElementNamedGraph;
 import org.apache.jena.sparql.syntax.ElementPathBlock;
 import org.apache.jena.update.UpdateRequest;
 import org.slf4j.Logger;
-import org.trellisldp.api.Binary;
 import org.trellisldp.api.DefaultIdentifierService;
 import org.trellisldp.api.IdentifierService;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
@@ -139,14 +138,14 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public CompletableFuture<Void> delete(final IRI identifier, final IRI container) {
-        LOGGER.debug("Deleting: {}", identifier);
+    public CompletableFuture<Void> delete(final Metadata metadata) {
+        LOGGER.debug("Deleting: {}", metadata.getIdentifier());
         return runAsync(() -> {
             try (final Dataset dataset = rdf.createDataset()) {
                 final Instant eventTime = now();
-                dataset.add(PreferServerManaged, identifier, DC.type, DeletedResource);
-                dataset.add(PreferServerManaged, identifier, RDF.type, LDP.Resource);
-                storeResource(identifier, dataset, eventTime, OperationType.DELETE);
+                dataset.add(PreferServerManaged, metadata.getIdentifier(), DC.type, DeletedResource);
+                dataset.add(PreferServerManaged, metadata.getIdentifier(), RDF.type, LDP.Resource);
+                storeResource(metadata.getIdentifier(), dataset, eventTime, OperationType.DELETE);
             } catch (final Exception ex) {
                 LOGGER.error("Error deleting resource: {}", ex.getMessage());
                 throw new RuntimeTrellisException(ex);
@@ -155,54 +154,51 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public CompletableFuture<Void> replace(final IRI id, final IRI ixnModel, final Dataset dataset, final IRI container,
-            final Binary binary) {
-        LOGGER.debug("Persisting: {}", id);
+    public CompletableFuture<Void> replace(final Metadata metadata, final Dataset dataset) {
+        LOGGER.debug("Persisting: {}", metadata.getIdentifier());
         return runAsync(() ->
-                createOrReplace(id, ixnModel, dataset, OperationType.REPLACE, container, binary));
+                createOrReplace(metadata, dataset, OperationType.REPLACE));
     }
 
-    private void createOrReplace(final IRI identifier, final IRI ixnModel,
-                    final Dataset dataset, final OperationType type, final IRI container, final Binary binary) {
+    private void createOrReplace(final Metadata metadata, final Dataset dataset, final OperationType type) {
         final Instant eventTime = now();
 
         // Set the LDP type
-        dataset.add(PreferServerManaged, identifier, RDF.type, ixnModel);
+        dataset.add(PreferServerManaged, metadata.getIdentifier(), RDF.type, metadata.getInteractionModel());
 
         // Relocate some user-managed triples into the server-managed graph
-        if (LDP.DirectContainer.equals(ixnModel) || LDP.IndirectContainer.equals(ixnModel)) {
-            dataset.getGraph(PreferUserManaged).ifPresent(g -> {
-                g.stream(identifier, LDP.membershipResource, null).findFirst().ifPresent(t -> {
-                    // This allows for HTTP resource URL-based queries
-                    dataset.add(PreferServerManaged, identifier, LDP.member, getBaseIRI(t.getObject()));
-                    dataset.add(PreferServerManaged, identifier, LDP.membershipResource, t.getObject());
-                });
-                g.stream(identifier, LDP.hasMemberRelation, null).findFirst().ifPresent(t -> dataset
-                                .add(PreferServerManaged, identifier, LDP.hasMemberRelation, t.getObject()));
-                g.stream(identifier, LDP.isMemberOfRelation, null).findFirst().ifPresent(t -> dataset
-                                .add(PreferServerManaged, identifier, LDP.isMemberOfRelation, t.getObject()));
-                dataset.add(PreferServerManaged, identifier, LDP.insertedContentRelation,
-                                g.stream(identifier, LDP.insertedContentRelation, null).map(Triple::getObject)
-                                                .findFirst().orElse(LDP.MemberSubject));
-            });
+        metadata.getMembershipResource().ifPresent(member -> {
+            dataset.add(PreferServerManaged, metadata.getIdentifier(), LDP.member, getBaseIRI(member));
+            dataset.add(PreferServerManaged, metadata.getIdentifier(), LDP.membershipResource, member);
+        });
+
+        metadata.getMemberRelation().ifPresent(relation ->
+                dataset.add(PreferServerManaged, metadata.getIdentifier(), LDP.hasMemberRelation, relation));
+
+        metadata.getMemberOfRelation().ifPresent(relation ->
+                dataset.add(PreferServerManaged, metadata.getIdentifier(), LDP.isMemberOfRelation, relation));
+
+        if (asList(LDP.IndirectContainer, LDP.DirectContainer).contains(metadata.getInteractionModel())) {
+            dataset.add(PreferServerManaged, metadata.getIdentifier(), LDP.insertedContentRelation,
+                    metadata.getInsertedContentRelation().orElse(LDP.MemberSubject));
         }
 
         // Set the parent relationship
-        if (nonNull(container)) {
-            dataset.add(PreferServerManaged, identifier, DC.isPartOf, container);
-        }
+        metadata.getContainer().ifPresent(parent ->
+                dataset.add(PreferServerManaged, metadata.getIdentifier(), DC.isPartOf, parent));
 
-        if (nonNull(binary)) {
-            dataset.add(PreferServerManaged, identifier, DC.hasPart, binary.getIdentifier());
-            dataset.add(PreferServerManaged, binary.getIdentifier(), DC.modified,
-                    rdf.createLiteral(binary.getModified().toString(), XSD.dateTime));
+        metadata.getBinary().ifPresent(binary -> {
+            dataset.add(PreferServerManaged, metadata.getIdentifier(), DC.hasPart, binary.getIdentifier());
             binary.getMimeType().map(rdf::createLiteral).ifPresent(mimeType ->
                     dataset.add(PreferServerManaged, binary.getIdentifier(), DC.format, mimeType));
             binary.getSize().map(size -> rdf.createLiteral(size.toString(), XSD.long_)).ifPresent(size ->
                     dataset.add(PreferServerManaged, binary.getIdentifier(), DC.extent, size));
-        }
+        });
 
-        storeResource(identifier, dataset, eventTime, type);
+        dataset.getGraph(PreferServerManaged).ifPresent(g ->
+                g.stream().forEach(t -> System.out.println("Triple: " + t)));
+
+        storeResource(metadata.getIdentifier(), dataset, eventTime, type);
     }
 
     private void storeResource(final IRI identifier, final Dataset dataset,

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -195,9 +195,6 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
                     dataset.add(PreferServerManaged, binary.getIdentifier(), DC.extent, size));
         });
 
-        dataset.getGraph(PreferServerManaged).ifPresent(g ->
-                g.stream().forEach(t -> System.out.println("Triple: " + t)));
-
         storeResource(metadata.getIdentifier(), dataset, eventTime, type);
     }
 

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.trellisldp.api.Metadata.builder;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
@@ -165,7 +166,7 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() -> svc.replace(root, LDP.BasicContainer, data, null, null).join(),
+        assertDoesNotThrow(() -> svc.replace(builder(root).interactionModel(LDP.BasicContainer).build(), data).join(),
                 "Unsuccessful replace operation!");
         final Resource res2 = svc.get(root).join();
         assertAll("Check resource", checkResource(res2, root, LDP.BasicContainer, later));
@@ -181,11 +182,13 @@ public class TriplestoreResourceServiceTest {
             .loadDataset(any(org.apache.jena.query.Dataset.class));
 
         assertThrows(ExecutionException.class, () ->
-                svc.create(resource, LDP.RDFSource, rdf.createDataset(), root, null).get(),
+                svc.create(builder(resource).interactionModel(LDP.RDFSource).container(root).build(),
+                    rdf.createDataset()).get(),
                 "No (create) exception with dropped backend connection!");
         assertThrows(ExecutionException.class, () -> svc.add(resource, rdf.createDataset()).get(),
                 "No (add) exception with dropped backend connection!");
-        assertThrows(ExecutionException.class, () -> svc.delete(resource, root).get(),
+        assertThrows(ExecutionException.class, () ->
+                svc.delete(builder(resource).interactionModel(LDP.RDFSource).container(root).build()).get(),
                 "No (delete) exception with dropped backend connection!");
         assertThrows(ExecutionException.class, () -> svc.touch(resource).get(),
                 "No (touch) exception with dropped backend connection!");
@@ -206,9 +209,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.RDFSource, dataset, root, null),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+            svc.create(builder(resource).interactionModel(LDP.RDFSource).container(root).build(), dataset),
+            svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.RDFSource, 1L, 3L, 0L)),
@@ -227,9 +230,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.RDFSource, dataset, root, null),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+            svc.create(builder(resource).interactionModel(LDP.RDFSource).container(root).build(), dataset),
+            svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.RDFSource, 1L, 1L, 0L)),
@@ -243,22 +246,22 @@ public class TriplestoreResourceServiceTest {
         svc.initialize();
 
         final IRI binaryIdentifier = rdf.createIRI("foo:binary");
-        final Instant binaryTime = now();
         final Dataset dataset = rdf.createDataset();
-        final Binary binary = new Binary(binaryIdentifier, binaryTime, "text/plain", 10L);
+        final Binary binary = Binary.builder(binaryIdentifier).mimeType("text/plain").size(10L).build();
         dataset.add(Trellis.PreferUserManaged, resource, DC.title, rdf.createLiteral("title"));
         dataset.add(Trellis.PreferAudit, rdf.createBlankNode(), RDF.type, AS.Create);
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.NonRDFSource, dataset, root, binary),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+              svc.create(builder(resource).interactionModel(LDP.NonRDFSource).container(root).binary(binary).build(),
+                  dataset),
+              svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.NonRDFSource, 1L, 1L, 0L)),
             svc.get(resource).thenAccept(res ->
-                assertAll("Check binary", checkBinary(res, binaryIdentifier, binaryTime, "text/plain", 10L))),
+                assertAll("Check binary", checkBinary(res, binaryIdentifier, "text/plain", 10L))),
             svc.get(root).thenAccept(checkRoot(later, 1L))).join();
 
         final IRI resource3 = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource/notachild");
@@ -269,7 +272,8 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                svc.create(resource3, LDP.RDFSource, dataset, null, null).join(), "Unsuccessful create operation!");
+                svc.create(builder(resource3).interactionModel(LDP.RDFSource).build(), dataset).join(),
+                "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource3).thenAccept(res -> {
@@ -302,9 +306,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.Container, dataset, root, null),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+                svc.create(builder(resource).interactionModel(LDP.Container).container(root).build(), dataset),
+                svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 3L, 3L, 0L)),
@@ -317,9 +321,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
-                      svc.touch(resource)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+            svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
+            svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 1L, 1L)),
@@ -336,7 +340,8 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.replace(child, LDP.RDFSource, dataset, resource, null).join(),
+        assertDoesNotThrow(() -> svc.replace(builder(child).interactionModel(LDP.RDFSource).container(resource).build(),
+                    dataset).join(),
                 "Unsuccessful create operation!");
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater2, 3L, 2L)),
@@ -362,10 +367,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.Container, dataset1, root, null),
-                      svc.add(resource, dataset2),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+              svc.create(builder(resource).interactionModel(LDP.Container).container(root).build(), dataset1),
+              svc.add(resource, dataset2),
+              svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 2L, 2L, 0L)),
@@ -385,9 +390,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.Container, dataset, root, null),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+              svc.create(builder(resource).interactionModel(LDP.Container).container(root).build(), dataset),
+              svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.Container, 2L, 1L, 0L)),
@@ -401,9 +406,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
-                      svc.touch(resource)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+              svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
+              svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(child).thenAccept(checkChild(evenLater, 2L, 1L)),
@@ -421,7 +426,7 @@ public class TriplestoreResourceServiceTest {
         final Instant preDelete = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.delete(child, resource),
+                allOf(svc.delete(builder(child).interactionModel(LDP.RDFSource).container(resource).build()),
                       svc.touch(resource)).join(), "Unsuccessful delete operation!");
 
         allOf(
@@ -444,8 +449,8 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.BasicContainer, dataset, root, null),
+        assertDoesNotThrow(() -> allOf(
+              svc.create(builder(resource).interactionModel(LDP.BasicContainer).container(root).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -461,7 +466,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -478,7 +483,8 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> svc.replace(child, LDP.RDFSource, dataset, resource, null).join(),
+        assertDoesNotThrow(() -> svc.replace(builder(child).interactionModel(LDP.RDFSource).container(resource).build(),
+                    dataset).join(),
                 "Unsuccessful create operation!");
 
         allOf(
@@ -505,7 +511,8 @@ public class TriplestoreResourceServiceTest {
         final Instant later = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.DirectContainer, dataset, root, null),
+                allOf(svc.create(builder(resource).interactionModel(LDP.DirectContainer).membershipResource(resource)
+                        .memberRelation(DC.relation).container(root).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -519,7 +526,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -550,9 +557,10 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.DirectContainer, dataset, root, null),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+                svc.create(builder(resource).interactionModel(LDP.DirectContainer).container(root)
+                    .memberRelation(DC.relation).membershipResource(members).build(), dataset),
+                svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 4L, 0L, 0L)),
@@ -565,7 +573,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                allOf(svc.create(builder(members).interactionModel(LDP.RDFSource).container(root).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -582,7 +590,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater2 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -613,7 +621,8 @@ public class TriplestoreResourceServiceTest {
         final Instant later = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.DirectContainer, dataset, root, null),
+                allOf(svc.create(builder(resource).interactionModel(LDP.DirectContainer).container(root)
+                        .membershipResource(members).memberRelation(DC.relation).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -632,7 +641,8 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(resource2, LDP.DirectContainer, dataset, root, null),
+                allOf(svc.create(builder(resource2).interactionModel(LDP.DirectContainer).container(root)
+                        .membershipResource(members).memberRelation(DC.subject).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -651,7 +661,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater2 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                allOf(svc.create(builder(members).interactionModel(LDP.RDFSource).container(root).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -671,7 +681,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater3 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(resource), svc.touch(members)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -693,7 +703,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater4 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child2, LDP.RDFSource, dataset, resource2, null),
+                allOf(svc.create(builder(child2).interactionModel(LDP.RDFSource).container(resource2).build(), dataset),
                       svc.touch(members), svc.touch(resource2)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -731,7 +741,8 @@ public class TriplestoreResourceServiceTest {
         final Instant later = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.DirectContainer, dataset, root, null),
+                allOf(svc.create(builder(resource).interactionModel(LDP.DirectContainer).container(root)
+                        .membershipResource(members).memberOfRelation(DC.relation).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -747,7 +758,8 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(resource2, LDP.DirectContainer, dataset, root, null),
+                allOf(svc.create(builder(resource2).interactionModel(LDP.DirectContainer).container(root)
+                        .membershipResource(members).memberOfRelation(DC.subject).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -764,8 +776,9 @@ public class TriplestoreResourceServiceTest {
 
         final Instant evenLater2 = meanwhile();
 
-        assertDoesNotThrow(() -> allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
-                      svc.touch(root)).join(), "Unsuccessful membership resource create operation!");
+        assertDoesNotThrow(() -> allOf(
+                    svc.create(builder(members).interactionModel(LDP.RDFSource).container(root).build(), dataset),
+                    svc.touch(root)).join(), "Unsuccessful membership resource create operation!");
 
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater2, 1L, 1L, 0L)),
@@ -784,7 +797,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater3 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -808,7 +821,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater4 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child2, LDP.RDFSource, dataset, resource2, null),
+                allOf(svc.create(builder(child2).interactionModel(LDP.RDFSource).container(resource2).build(), dataset),
                       svc.touch(resource2)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -850,9 +863,11 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.IndirectContainer, dataset, root, null),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+            svc.create(builder(resource).interactionModel(LDP.IndirectContainer).container(root)
+                .membershipResource(members).memberRelation(RDFS.label)
+                .insertedContentRelation(SKOS.prefLabel).build(), dataset),
+            svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 7L, 4L, 0L)),
@@ -870,7 +885,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                allOf(svc.create(builder(members).interactionModel(LDP.RDFSource).container(root).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -891,7 +906,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater2 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -924,7 +939,9 @@ public class TriplestoreResourceServiceTest {
         final Instant later = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.IndirectContainer, dataset, root, null),
+                allOf(svc.create(builder(resource).interactionModel(LDP.IndirectContainer).container(root)
+                        .membershipResource(members).memberRelation(RDFS.label)
+                        .insertedContentRelation(LDP.MemberSubject).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -941,7 +958,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                allOf(svc.create(builder(members).interactionModel(LDP.RDFSource).container(root).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -959,7 +976,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater2 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -991,9 +1008,11 @@ public class TriplestoreResourceServiceTest {
 
         final Instant later = meanwhile();
 
-        assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.IndirectContainer, dataset, root, null),
-                      svc.touch(root)).join(), "Unsuccessful create operation!");
+        assertDoesNotThrow(() -> allOf(
+                svc.create(builder(resource).interactionModel(LDP.IndirectContainer).container(root)
+                    .membershipResource(members).memberRelation(RDFS.label)
+                    .insertedContentRelation(SKOS.prefLabel).build(), dataset),
+                svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
             svc.get(resource).thenAccept(checkResource(later, LDP.IndirectContainer, 4L, 2L, 0L)),
@@ -1010,7 +1029,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                allOf(svc.create(builder(members).interactionModel(LDP.RDFSource).container(root).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -1030,7 +1049,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater2 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(members), svc.touch(resource)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -1069,7 +1088,9 @@ public class TriplestoreResourceServiceTest {
         final Instant later = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(resource, LDP.IndirectContainer, dataset, root, null),
+                allOf(svc.create(builder(resource).interactionModel(LDP.IndirectContainer).container(root)
+                        .membershipResource(members).memberRelation(RDFS.label)
+                        .insertedContentRelation(SKOS.prefLabel).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -1086,7 +1107,9 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(resource2, LDP.IndirectContainer, dataset, root, null),
+                allOf(svc.create(builder(resource2).interactionModel(LDP.IndirectContainer).container(root)
+                        .membershipResource(members).memberRelation(RDFS.label)
+                        .insertedContentRelation(SKOS.prefLabel).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -1104,7 +1127,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater2 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(members, LDP.RDFSource, dataset, root, null),
+                allOf(svc.create(builder(members).interactionModel(LDP.RDFSource).container(root).build(), dataset),
                       svc.touch(root)).join(), "Unsuccessful member resource creation operation!");
 
         allOf(
@@ -1125,7 +1148,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater3 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child, LDP.RDFSource, dataset, resource, null),
+                allOf(svc.create(builder(child).interactionModel(LDP.RDFSource).container(resource).build(), dataset),
                       svc.touch(members), svc.touch(resource)).join(), "Unsuccessful child creation operation!");
 
         allOf(
@@ -1151,7 +1174,7 @@ public class TriplestoreResourceServiceTest {
         final Instant evenLater4 = meanwhile();
 
         assertDoesNotThrow(() ->
-                allOf(svc.create(child2, LDP.RDFSource, dataset, resource2, null),
+                allOf(svc.create(builder(child2).interactionModel(LDP.RDFSource).container(resource2).build(), dataset),
                       svc.touch(members), svc.touch(resource2)).join(), "Unsuccessful create operation!");
 
         allOf(
@@ -1259,8 +1282,8 @@ public class TriplestoreResourceServiceTest {
                 () -> assertFalse(res.getModified().isAfter(now().plusMillis(5L)), "modification date in the future!"));
     }
 
-    private static Stream<Executable> checkBinary(final Resource res, final IRI identifier, final Instant time,
-            final String mimeType, final Long size) {
+    private static Stream<Executable> checkBinary(final Resource res, final IRI identifier, final String mimeType,
+            final Long size) {
         return Stream.of(
                 () -> assertNotNull(res, "Missing resource!"),
                 () -> assertTrue(res.getBinary().isPresent(), "missing binary metadata!"),
@@ -1268,8 +1291,7 @@ public class TriplestoreResourceServiceTest {
                 () -> assertEquals(mimeType, res.getBinary().flatMap(Binary::getMimeType).orElse(null),
                                    "Incorrect binary mimetype!"),
                 () -> assertEquals(size, res.getBinary().flatMap(Binary::getSize).orElse(null),
-                                   "Incorrect binary size!"),
-                () -> assertEquals(time, res.getBinary().get().getModified(), "Incorrect binary modification date!"));
+                                   "Incorrect binary size!"));
     }
 
     private static Stream<Executable> checkResourceStream(final Resource res, final long userManaged,

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.vocabulary.AS;
@@ -247,7 +247,7 @@ public class TriplestoreResourceServiceTest {
 
         final IRI binaryIdentifier = rdf.createIRI("foo:binary");
         final Dataset dataset = rdf.createDataset();
-        final Binary binary = Binary.builder(binaryIdentifier).mimeType("text/plain").size(10L).build();
+        final BinaryMetadata binary = BinaryMetadata.builder(binaryIdentifier).mimeType("text/plain").size(10L).build();
         dataset.add(Trellis.PreferUserManaged, resource, DC.title, rdf.createLiteral("title"));
         dataset.add(Trellis.PreferAudit, rdf.createBlankNode(), RDF.type, AS.Create);
 
@@ -279,12 +279,12 @@ public class TriplestoreResourceServiceTest {
             svc.get(resource3).thenAccept(res -> {
                 assertAll("Check resource", checkResource(res, resource3, LDP.RDFSource, evenLater));
                 assertAll("Check resource stream", checkResourceStream(res, 1L, 0L, 1L, 0L, 0L));
-                assertFalse(res.getBinary().isPresent(), "Unexpected binary metadata!");
+                assertFalse(res.getBinaryMetadata().isPresent(), "Unexpected binary metadata!");
             }),
             svc.get(root).thenAccept(checkRoot(later, 1L)),
             svc.get(root).thenAccept(checkPredates(evenLater)),
             svc.get(root).thenAccept(res ->
-                assertFalse(res.getBinary().isPresent(), "unexpected binary metadata!")),
+                assertFalse(res.getBinaryMetadata().isPresent(), "unexpected binary metadata!")),
             svc.get(resource).thenAccept(checkResource(later, LDP.NonRDFSource, 1L, 1L, 0L)),
             svc.get(resource).thenAccept(checkPredates(evenLater))).join();
     }
@@ -578,7 +578,8 @@ public class TriplestoreResourceServiceTest {
 
         allOf(
             svc.get(members).thenAccept(checkMember(evenLater, 1L, 0L, 0L)),
-            svc.get(members).thenAccept(res -> assertFalse(res.getBinary().isPresent(), "Unexpected binary metadata!")),
+            svc.get(members).thenAccept(res -> assertFalse(res.getBinaryMetadata().isPresent(),
+                    "Unexpected binary metadata!")),
             svc.get(resource).thenAccept(checkResource(later, LDP.DirectContainer, 4L, 0L, 0L)),
             svc.get(resource).thenAccept(checkPredates(evenLater)),
             svc.get(root).thenAccept(checkRoot(evenLater, 2L))).join();
@@ -1286,11 +1287,12 @@ public class TriplestoreResourceServiceTest {
             final Long size) {
         return Stream.of(
                 () -> assertNotNull(res, "Missing resource!"),
-                () -> assertTrue(res.getBinary().isPresent(), "missing binary metadata!"),
-                () -> assertEquals(identifier, res.getBinary().get().getIdentifier(), "Incorrect binary identifier!"),
-                () -> assertEquals(mimeType, res.getBinary().flatMap(Binary::getMimeType).orElse(null),
+                () -> assertTrue(res.getBinaryMetadata().isPresent(), "missing binary metadata!"),
+                () -> assertEquals(identifier, res.getBinaryMetadata().get().getIdentifier(),
+                                   "Incorrect binary identifier!"),
+                () -> assertEquals(mimeType, res.getBinaryMetadata().flatMap(BinaryMetadata::getMimeType).orElse(null),
                                    "Incorrect binary mimetype!"),
-                () -> assertEquals(size, res.getBinary().flatMap(Binary::getSize).orElse(null),
+                () -> assertEquals(size, res.getBinaryMetadata().flatMap(BinaryMetadata::getSize).orElse(null),
                                    "Incorrect binary size!"));
     }
 

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
@@ -170,7 +170,7 @@ public class TriplestoreResourceTest {
 
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
-        res.getBinary().ifPresent(b -> {
+        res.getBinaryMetadata().ifPresent(b -> {
             assertEquals(binaryIdentifier, b.getIdentifier(), "Incorrect binary identifier!");
             assertEquals(of(Long.parseLong(size)), b.getSize(), "Incorrect binary size!");
             assertEquals(of(mimeType), b.getMimeType(), "Incorrect binary mime type!");
@@ -297,7 +297,7 @@ public class TriplestoreResourceTest {
                 () -> assertEquals(identifier, res.getIdentifier(), "Incorrect identifier!"),
                 () -> assertEquals(ldpType, res.getInteractionModel(), "Incorrect interaction model!"),
                 () -> assertEquals(parse(time), res.getModified(), "Incorrect modified date!"),
-                () -> assertEquals(hasBinary, res.getBinary().isPresent(), "Unexpected binary presence!"),
+                () -> assertEquals(hasBinary, res.getBinaryMetadata().isPresent(), "Unexpected binary presence!"),
                 () -> assertEquals(hasParent, res.getContainer().isPresent(), "Unexpected parent resource!"),
                 () -> assertEquals(hasAcl, res.hasAcl(), "Unexpected ACL presence!"));
     }

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
@@ -155,7 +155,6 @@ public class TriplestoreResourceTest {
 
     @Test
     public void testBinaryResource() {
-        final String binaryTime = "2018-01-10T14:02:00Z";
         final String size = "2560";
         final String mimeType = "image/jpeg";
         final IRI binaryIdentifier = rdf.createIRI("file:///binary");
@@ -163,8 +162,6 @@ public class TriplestoreResourceTest {
         dataset.add(Trellis.PreferServerManaged, identifier, DC.hasPart, binaryIdentifier);
         dataset.add(Trellis.PreferServerManaged, binaryIdentifier, DC.extent, rdf.createLiteral(size, XSD.long_));
         dataset.add(Trellis.PreferServerManaged, binaryIdentifier, DC.format, rdf.createLiteral(mimeType));
-        dataset.add(Trellis.PreferServerManaged, binaryIdentifier, DC.modified,
-                rdf.createLiteral(binaryTime, XSD.dateTime));
         auditService.creation(identifier, mockSession).forEach(q ->
                 dataset.add(auditId, q.getSubject(), q.getPredicate(), q.getObject()));
 
@@ -175,7 +172,6 @@ public class TriplestoreResourceTest {
         assertTrue(res.exists(), "Missing resource!");
         res.getBinary().ifPresent(b -> {
             assertEquals(binaryIdentifier, b.getIdentifier(), "Incorrect binary identifier!");
-            assertEquals(parse(binaryTime), b.getModified(), "Incorrect binary modified date!");
             assertEquals(of(Long.parseLong(size)), b.getSize(), "Incorrect binary size!");
             assertEquals(of(mimeType), b.getMimeType(), "Incorrect binary mime type!");
         });

--- a/core/api/src/main/java/org/trellisldp/api/Binary.java
+++ b/core/api/src/main/java/org/trellisldp/api/Binary.java
@@ -16,7 +16,6 @@ package org.trellisldp.api;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
-import java.time.Instant;
 import java.util.Optional;
 
 import org.apache.commons.rdf.api.IRI;
@@ -36,27 +35,21 @@ import org.apache.commons.rdf.api.IRI;
  *
  * @author acoburn
  */
-public class Binary {
+public final class Binary {
 
     private final IRI identifier;
     private final String mimeType;
     private final Long size;
-    private final Instant modified;
 
     /**
      * A simple Binary object.
      *
      * @param identifier the identifier
-     * @param modified the modified date
      * @param mimeType the mimeType, may be {@code null}
      * @param size the size, may be {@code null}
      */
-    public Binary(final IRI identifier, final Instant modified, final String mimeType, final Long size) {
-        requireNonNull(identifier);
-        requireNonNull(modified);
-
-        this.identifier = identifier;
-        this.modified = modified;
+    private Binary(final IRI identifier, final String mimeType, final Long size) {
+        this.identifier = requireNonNull(identifier, "identifier may not be null!");
         this.mimeType = mimeType;
         this.size = size;
     }
@@ -89,11 +82,56 @@ public class Binary {
     }
 
     /**
-     * Retrieve the last-modified date of the binary.
-     *
-     * @return the last-modified date
+     * Get a mutable builder for a {@link Binary}.
+     * @param identifier the identifier
+     * @return a builder for a {@link Binary}
      */
-    public Instant getModified() {
-        return modified;
+    public static Builder builder(final IRI identifier) {
+        return new Builder(identifier);
+    }
+
+    /**
+     * A mutable buillder for a {@link Binary}.
+     */
+    public static final class Builder {
+        private final IRI identifier;
+        private String mimeType;
+        private Long size;
+
+        /**
+         * Create a Binary builder with the provided identifier.
+         * @param identifier the identifier
+         */
+        private Builder(final IRI identifier) {
+            this.identifier = requireNonNull(identifier, "Identifier cannot be null!");
+        }
+
+        /**
+         * Set the binary MIME type.
+         * @param mimeType the MIME type
+         * @return this builder
+         */
+        public Builder mimeType(final String mimeType) {
+            this.mimeType = mimeType;
+            return this;
+        }
+
+        /**
+         * Set the binary size.
+         * @param size the binary size
+         * @return this builder
+         */
+        public Builder size(final Long size) {
+            this.size = size;
+            return this;
+        }
+
+        /**
+         * Build the Binary object, transitioning this builder to the built state.
+         * @return the built Binary
+         */
+        public Binary build() {
+            return new Binary(identifier, mimeType, size);
+        }
     }
 }

--- a/core/api/src/main/java/org/trellisldp/api/BinaryMetadata.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryMetadata.java
@@ -26,29 +26,29 @@ import org.apache.commons.rdf.api.IRI;
  * These interfaces assume it is the case that Non-RDF resources have an RDF description.
  *
  * <p>For those resources that are non-RDF resources (LDP-NR), the base {@link Resource} interface
- * will make a {@link Binary} object available. The binary content is not accessed directly
- * through the {@link Binary} class, but rather an identifier is returned, which may
+ * will make a {@link BinaryMetadata} object available. The binary content is not accessed directly
+ * through the {@link BinaryMetadata} class, but rather an identifier is returned, which may
  * be resolved by an external system.
  *
- * <p>The {@link Binary} class also provides access methods for the MIME Type and size of the
+ * <p>The {@link BinaryMetadata} class also provides access methods for the MIME Type and size of the
  * resource.
  *
  * @author acoburn
  */
-public final class Binary {
+public final class BinaryMetadata {
 
     private final IRI identifier;
     private final String mimeType;
     private final Long size;
 
     /**
-     * A simple Binary object.
+     * A simple BinaryMetadata object.
      *
      * @param identifier the identifier
      * @param mimeType the mimeType, may be {@code null}
      * @param size the size, may be {@code null}
      */
-    private Binary(final IRI identifier, final String mimeType, final Long size) {
+    private BinaryMetadata(final IRI identifier, final String mimeType, final Long size) {
         this.identifier = requireNonNull(identifier, "identifier may not be null!");
         this.mimeType = mimeType;
         this.size = size;
@@ -82,16 +82,16 @@ public final class Binary {
     }
 
     /**
-     * Get a mutable builder for a {@link Binary}.
+     * Get a mutable builder for a {@link BinaryMetadata}.
      * @param identifier the identifier
-     * @return a builder for a {@link Binary}
+     * @return a builder for a {@link BinaryMetadata}
      */
     public static Builder builder(final IRI identifier) {
         return new Builder(identifier);
     }
 
     /**
-     * A mutable buillder for a {@link Binary}.
+     * A mutable buillder for a {@link BinaryMetadata}.
      */
     public static final class Builder {
         private final IRI identifier;
@@ -99,7 +99,7 @@ public final class Binary {
         private Long size;
 
         /**
-         * Create a Binary builder with the provided identifier.
+         * Create a BinaryMetadata builder with the provided identifier.
          * @param identifier the identifier
          */
         private Builder(final IRI identifier) {
@@ -127,11 +127,11 @@ public final class Binary {
         }
 
         /**
-         * Build the Binary object, transitioning this builder to the built state.
-         * @return the built Binary
+         * Build the BinaryMetadata object, transitioning this builder to the built state.
+         * @return the built BinaryMetadata
          */
-        public Binary build() {
-            return new Binary(identifier, mimeType, size);
+        public BinaryMetadata build() {
+            return new BinaryMetadata(identifier, mimeType, size);
         }
     }
 }

--- a/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -72,20 +72,18 @@ public abstract class JoiningResourceService implements ResourceService {
     }
 
     @Override
-    public CompletableFuture<Void> create(final IRI id, final IRI ixnModel,
-            final Dataset dataset, final IRI container, final Binary binary) {
-        return mutableData.create(id, ixnModel, dataset, container, binary);
+    public CompletableFuture<Void> create(final Metadata metadata, final Dataset dataset) {
+        return mutableData.create(metadata, dataset);
     }
 
     @Override
-    public CompletableFuture<Void> replace(final IRI id, final IRI ixnModel,
-            final Dataset dataset, final IRI container, final Binary binary) {
-        return mutableData.replace(id, ixnModel, dataset, container, binary);
+    public CompletableFuture<Void> replace(final Metadata metadata, final Dataset dataset) {
+        return mutableData.replace(metadata, dataset);
     }
 
     @Override
-    public CompletableFuture<Void> delete(final IRI id, final IRI container) {
-        return mutableData.delete(id, container);
+    public CompletableFuture<Void> delete(final Metadata metadata) {
+        return mutableData.delete(metadata);
     }
 
     /**

--- a/core/api/src/main/java/org/trellisldp/api/MementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MementoService.java
@@ -23,8 +23,8 @@ import org.apache.commons.rdf.api.IRI;
  * An interface for a Memento subsystem. Mementos of {@link Resource}s may be made and retrieved using this service.
  * Mementos may also be recorded by other means, including by the persistence layer independently of Trellis, but unless
  * they are retrieved via this service, Trellis will not publish them as HTTP resources. Mementos of NonRDFSources (like
- * any other {@code Resource}) may also be made and retrieved here, but the associated {@link Binary}s are made (like
- * all {@code Binary}s) via a {@link BinaryService} implementation.
+ * any other {@link Resource}) may also be made and retrieved here, but the associated {@link java.io.InputStream}s are
+ * made (like all binary {@link java.io.InputStream}s) via a {@link BinaryService} implementation.
  */
 public interface MementoService {
 

--- a/core/api/src/main/java/org/trellisldp/api/Metadata.java
+++ b/core/api/src/main/java/org/trellisldp/api/Metadata.java
@@ -23,7 +23,7 @@ import org.apache.commons.rdf.api.IRI;
 /**
  * Metadata values used for resource composition.
  */
-public class Metadata {
+public final class Metadata {
 
     private final IRI identifier;
     private final IRI ixnModel;
@@ -60,18 +60,6 @@ public class Metadata {
     }
 
     /**
-     * A Metadata-bearing data structure for use with resource manipulation.
-     *
-     * @param r a resource
-     */
-    public Metadata(final Resource r) {
-        this(r.getIdentifier(), r.getInteractionModel(), r.getContainer().orElse(null),
-                        r.getMemberRelation().orElse(null), r.getMembershipResource().orElse(null),
-                        r.getMemberOfRelation().orElse(null), r.getInsertedContentRelation().orElse(null),
-                        r.getBinary().orElse(null));
-    }
-
-    /**
      * A mutable builder for a {@link Metadata} object.
      *
      * @param identifier the resource identifier
@@ -89,7 +77,8 @@ public class Metadata {
      */
     public static Builder builder(final Resource r) {
         return builder(r.getIdentifier()).interactionModel(r.getInteractionModel())
-                        .container(r.getContainer().orElse(null)).memberRelation(r.getMemberRelation().orElse(null))
+                        .container(r.getContainer().orElse(null))
+                        .memberRelation(r.getMemberRelation().orElse(null))
                         .membershipResource(r.getMembershipResource().orElse(null))
                         .memberOfRelation(r.getMemberOfRelation().orElse(null))
                         .insertedContentRelation(r.getInsertedContentRelation().orElse(null));
@@ -177,7 +166,7 @@ public class Metadata {
     /**
      * A mutable builder for a {@link Metadata} object.
      */
-    public static class Builder {
+    public static final class Builder {
         private final IRI identifier;
         private IRI ixnModel;
         private IRI container;
@@ -191,7 +180,7 @@ public class Metadata {
          * Create a Metadata builder with the provided identifier.
          * @param identifier the identifier
          */
-        public Builder(final IRI identifier) {
+        private Builder(final IRI identifier) {
             this.identifier = requireNonNull(identifier, "Identifier cannot be null!");
         }
 
@@ -267,10 +256,10 @@ public class Metadata {
 
         /**
          * Build the Metadata object, transitioning this builder to the built state.
-         * @return the built stream
+         * @return the built Metadata
          */
         public Metadata build() {
-            return new Metadata(identifier, ixnModel, container, memberRelation, membershipResource, memberOfRelation,
+            return new Metadata(identifier, ixnModel, container, membershipResource, memberRelation, memberOfRelation,
                             insertedContentRelation, binary);
         }
     }

--- a/core/api/src/main/java/org/trellisldp/api/Metadata.java
+++ b/core/api/src/main/java/org/trellisldp/api/Metadata.java
@@ -32,7 +32,7 @@ public final class Metadata {
     private final IRI membershipResource;
     private final IRI memberOfRelation;
     private final IRI insertedContentRelation;
-    private final Binary binary;
+    private final BinaryMetadata binary;
 
     /**
      * A Metadata-bearing data structure for use with resource manipulation.
@@ -44,11 +44,11 @@ public final class Metadata {
      * @param memberRelation an LDP hasMemberRelation predicate, may be {@code null}
      * @param memberOfRelation an LDP isMemberOfRelation predicate, may be {@code null}
      * @param insertedContentRelation an LDP insertedContentRelation, may be {@code null}
-     * @param binary metadata about a Binary, may be {@code null}
+     * @param binary metadata about a BinaryMetadata, may be {@code null}
      */
     private Metadata(final IRI identifier, final IRI ixnModel, final IRI container, final IRI membershipResource,
             final IRI memberRelation, final IRI memberOfRelation, final IRI insertedContentRelation,
-            final Binary binary) {
+            final BinaryMetadata binary) {
         this.identifier = requireNonNull(identifier, "Identifier cannot be null!");
         this.ixnModel = requireNonNull(ixnModel, "Interaction model cannot be null!");
         this.container = container;
@@ -159,7 +159,7 @@ public final class Metadata {
      * @implSpec Otheer LDP resource types will always return an empty {@link Optional} value
      * @return the binary metadata
      */
-    public Optional<Binary> getBinary() {
+    public Optional<BinaryMetadata> getBinary() {
         return ofNullable(binary);
     }
 
@@ -174,7 +174,7 @@ public final class Metadata {
         private IRI membershipResource;
         private IRI memberOfRelation;
         private IRI insertedContentRelation;
-        private Binary binary;
+        private BinaryMetadata binary;
 
         /**
          * Create a Metadata builder with the provided identifier.
@@ -249,7 +249,7 @@ public final class Metadata {
          * @param binary the binary metadata
          * @return this builder
          */
-        public Builder binary(final Binary binary) {
+        public Builder binary(final BinaryMetadata binary) {
             this.binary = binary;
             return this;
         }

--- a/core/api/src/main/java/org/trellisldp/api/Metadata.java
+++ b/core/api/src/main/java/org/trellisldp/api/Metadata.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.api;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+
+import java.util.Optional;
+
+import org.apache.commons.rdf.api.IRI;
+
+/**
+ * Metadata values used for resource composition.
+ */
+public class Metadata {
+
+    private final IRI identifier;
+    private final IRI ixnModel;
+    private final IRI container;
+    private final IRI memberRelation;
+    private final IRI membershipResource;
+    private final IRI memberOfRelation;
+    private final IRI insertedContentRelation;
+    private final Binary binary;
+
+    /**
+     * A Metadata-bearing data structure for use with resource manipulation.
+     *
+     * @param identifier the identifier
+     * @param ixnModel the interaction model
+     * @param container a container identifier, may be {@code null}
+     * @param membershipResource an LDP membershipResource, may be {@code null}
+     * @param memberRelation an LDP hasMemberRelation predicate, may be {@code null}
+     * @param memberOfRelation an LDP isMemberOfRelation predicate, may be {@code null}
+     * @param insertedContentRelation an LDP insertedContentRelation, may be {@code null}
+     * @param binary metadata about a Binary, may be {@code null}
+     */
+    private Metadata(final IRI identifier, final IRI ixnModel, final IRI container, final IRI membershipResource,
+            final IRI memberRelation, final IRI memberOfRelation, final IRI insertedContentRelation,
+            final Binary binary) {
+        this.identifier = requireNonNull(identifier, "Identifier cannot be null!");
+        this.ixnModel = requireNonNull(ixnModel, "Interaction model cannot be null!");
+        this.container = container;
+        this.membershipResource = membershipResource;
+        this.memberRelation = memberRelation;
+        this.memberOfRelation = memberOfRelation;
+        this.insertedContentRelation = insertedContentRelation;
+        this.binary = binary;
+    }
+
+    /**
+     * A Metadata-bearing data structure for use with resource manipulation.
+     *
+     * @param r a resource
+     */
+    public Metadata(final Resource r) {
+        this(r.getIdentifier(), r.getInteractionModel(), r.getContainer().orElse(null),
+                        r.getMemberRelation().orElse(null), r.getMembershipResource().orElse(null),
+                        r.getMemberOfRelation().orElse(null), r.getInsertedContentRelation().orElse(null),
+                        r.getBinary().orElse(null));
+    }
+
+    /**
+     * A mutable builder for a {@link Metadata} object.
+     *
+     * @param identifier the resource identifier
+     * @return a builder for a {@link Metadata} object
+     */
+    public static Builder builder(final IRI identifier) {
+        return new Builder(identifier);
+    }
+
+    /**
+     * A mutable builder for a {@link Metadata} object.
+     *
+     * @param r the resource
+     * @return a builder for a {@link Metadata} object
+     */
+    public static Builder builder(final Resource r) {
+        return builder(r.getIdentifier()).interactionModel(r.getInteractionModel())
+                        .container(r.getContainer().orElse(null)).memberRelation(r.getMemberRelation().orElse(null))
+                        .membershipResource(r.getMembershipResource().orElse(null))
+                        .memberOfRelation(r.getMemberOfRelation().orElse(null))
+                        .insertedContentRelation(r.getInsertedContentRelation().orElse(null));
+    }
+
+    /**
+     * Get an identifier for this metadata.
+     *
+     * @return the identifier
+     */
+    public IRI getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * Get the LDP interaction model for this metadata.
+     *
+     * @return the interaction model
+     */
+    public IRI getInteractionModel() {
+        return ixnModel;
+    }
+
+    /**
+     * Get the container for this resource.
+     *
+     * @apiNote returning an empty Optional should indicate here that the resource is not contained by any parent
+     *          resource. This may be because it is a root resource and therefore not contained by any other resource.
+     *          Alternatively, it could mean that a PUT operation was used to create the resource.
+     * @return the identifier for a container, if one exists.
+     */
+    public Optional<IRI> getContainer() {
+        return ofNullable(container);
+    }
+
+    /**
+     * Retrieve the membership resource if this is an LDP Direct or Indirect container.
+     *
+     * @implSpec Other LDP resource types will always return an empty {@link Optional} value
+     * @return the membership resource
+     */
+    public Optional<IRI> getMembershipResource() {
+        return ofNullable(membershipResource);
+    }
+
+    /**
+     * Retrieve the member relation if this is an LDP Direct or Indirect container.
+     *
+     * @implSpec Other LDP resource types will always return an empty {@link Optional} value
+     * @return the ldp:hasMemberRelation IRI
+     */
+    public Optional<IRI> getMemberRelation() {
+        return ofNullable(memberRelation);
+    }
+
+    /**
+     * Retrieve the member of relation IRI.
+     *
+     * @implSpec Other LDP resource types will always return an empty {@link Optional} value
+     * @return the ldp:isMemberOfRelation IRI
+     */
+    public Optional<IRI> getMemberOfRelation() {
+        return ofNullable(memberOfRelation);
+    }
+
+    /**
+     * Retrieve the inserted content relation if this is an LDP Indirect container.
+     *
+     * @implSpec Other LDP resource types will always return an empty {@link Optional} value
+     * @return the inserted content relation
+     */
+    public Optional<IRI> getInsertedContentRelation() {
+        return ofNullable(insertedContentRelation);
+    }
+
+    /**
+     * Retrieve the binary metadata if this is an LDP NonRDFSource.
+     * @implSpec Otheer LDP resource types will always return an empty {@link Optional} value
+     * @return the binary metadata
+     */
+    public Optional<Binary> getBinary() {
+        return ofNullable(binary);
+    }
+
+    /**
+     * A mutable builder for a {@link Metadata} object.
+     */
+    public static class Builder {
+        private final IRI identifier;
+        private IRI ixnModel;
+        private IRI container;
+        private IRI memberRelation;
+        private IRI membershipResource;
+        private IRI memberOfRelation;
+        private IRI insertedContentRelation;
+        private Binary binary;
+
+        /**
+         * Create a Metadata builder with the provided identifier.
+         * @param identifier the identifier
+         */
+        public Builder(final IRI identifier) {
+            this.identifier = requireNonNull(identifier, "Identifier cannot be null!");
+        }
+
+        /**
+         * Set the LDP interaction model.
+         * @param ixnModel the interaction model
+         * @return this builder
+         */
+        public Builder interactionModel(final IRI ixnModel) {
+            this.ixnModel = ixnModel;
+            return this;
+        }
+
+        /**
+         * Set the container value.
+         * @param container the container identifier
+         * @return this builder
+         */
+        public Builder container(final IRI container) {
+            this.container = container;
+            return this;
+        }
+
+        /**
+         * Set the member relation value.
+         * @param memberRelation the member relation predicate
+         * @return this builder
+         */
+        public Builder memberRelation(final IRI memberRelation) {
+            this.memberRelation = memberRelation;
+            return this;
+        }
+
+        /**
+         * Set the membership resource value.
+         * @param membershipResource the member resource identifier
+         * @return this builder
+         */
+        public Builder membershipResource(final IRI membershipResource) {
+            this.membershipResource = membershipResource;
+            return this;
+        }
+
+        /**
+         * Set the member of relation value.
+         * @param memberOfRelation the member of relation predicate
+         * @return this builder
+         */
+        public Builder memberOfRelation(final IRI memberOfRelation) {
+            this.memberOfRelation = memberOfRelation;
+            return this;
+        }
+
+        /**
+         * Set the inserted content relation value.
+         * @param insertedContentRelation the inserted content relation predicate
+         * @return this builder
+         */
+        public Builder insertedContentRelation(final IRI insertedContentRelation) {
+            this.insertedContentRelation = insertedContentRelation;
+            return this;
+        }
+
+        /**
+         * Set the binary metadata.
+         * @param binary the binary metadata
+         * @return this builder
+         */
+        public Builder binary(final Binary binary) {
+            this.binary = binary;
+            return this;
+        }
+
+        /**
+         * Build the Metadata object, transitioning this builder to the built state.
+         * @return the built stream
+         */
+        public Metadata build() {
+            return new Metadata(identifier, ixnModel, container, memberRelation, membershipResource, memberOfRelation,
+                            insertedContentRelation, binary);
+        }
+    }
+}

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -17,7 +17,6 @@ package org.trellisldp.api;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.rdf.api.Dataset;
-import org.apache.commons.rdf.api.IRI;
 
 /**
  * A service that persists resources by <i>replacing</i> their records.
@@ -31,46 +30,38 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * Create a resource in the server.
      *
      * @implSpec the default implementation of this method is to proxy create requests to the {@link #replace} method.
-     * @param identifier the identifier for the new resource
-     * @param ixnModel the LDP interaction model for this resource
+     * @param metadata metadata for the new resource
      * @param dataset the dataset to be persisted
-     * @param container an LDP container for this resource, {@code null} for none
-     * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
      * @return a new completion stage that, when the stage completes normally, indicates that the supplied data were
      * successfully created in the corresponding persistence layer. In the case of an unsuccessful write operation,
      * the {@link CompletableFuture} will complete exceptionally and can be handled with
      * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
-    default CompletableFuture<Void> create(IRI identifier, IRI ixnModel, Dataset dataset, IRI container,
-                Binary binary) {
-        return replace(identifier, ixnModel, dataset, container, binary);
+    default CompletableFuture<Void> create(Metadata metadata, Dataset dataset) {
+        return replace(metadata, dataset);
     }
 
     /**
      * Replace a resource in the server.
      *
-     * @param identifier the identifier for the new resource
-     * @param ixnModel the LDP interaction model for this resource
+     * @param metadata metadata for the resource
      * @param dataset the dataset to be persisted
-     * @param container an LDP container for this resource, {@code null} for none
-     * @param binary a binary resource, relevant only for ldp:NonRDFSource items: {@code null} for none
      * @return a new completion stage that, when the stage completes normally, indicates that the supplied data
      * were successfully stored in the corresponding persistence layer. In the case of an unsuccessful write operation,
      * the {@link CompletableFuture} will complete exceptionally and can be handled with
      * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> replace(IRI identifier, IRI ixnModel, Dataset dataset, IRI container, Binary binary);
+    CompletableFuture<Void> replace(Metadata metadata, Dataset dataset);
 
     /**
      * Delete a resource from the server.
      *
-     * @param identifier the identifier for the new resource
-     * @param container an LDP container for this resource, {@code null} for none
+     * @param metadata metadata for the resource
      * @return a new completion stage that, when the stage completes normally, indicates that the resource
      * was successfully deleted from the corresponding persistence layer. In the case of an unsuccessful delete
      * operation, the {@link CompletableFuture} will complete exceptionally and can be handled with
      * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> delete(IRI identifier, IRI container);
+    CompletableFuture<Void> delete(Metadata metadata);
 
 }

--- a/core/api/src/main/java/org/trellisldp/api/Resource.java
+++ b/core/api/src/main/java/org/trellisldp/api/Resource.java
@@ -225,12 +225,12 @@ public interface Resource {
     }
 
     /**
-     * Retrieve a Binary for this resouce, if it is a LDP-NR.
+     * Retrieve a BinaryMetadata for this resouce, if it is a LDP-NR.
      *
      * @implSpec Other LDP resource types will always return an empty {@link Optional} value
-     * @return the binary object
+     * @return the binary metadata
      */
-    default Optional<Binary> getBinary() {
+    default Optional<BinaryMetadata> getBinaryMetadata() {
         return empty();
     }
 

--- a/core/api/src/test/java/org/trellisldp/api/BinaryMetadataTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryMetadataTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class BinaryTest {
+public class BinaryMetadataTest {
 
     private static final RDF rdf = new SimpleRDF();
 
@@ -34,16 +34,16 @@ public class BinaryTest {
     private final IRI identifier = rdf.createIRI("trellis:data/resource");
 
     @Test
-    public void testBinary() {
-        final Binary binary = Binary.builder(identifier).mimeType(mimeType).size(size).build();
+    public void testBinaryMetadata() {
+        final BinaryMetadata binary = BinaryMetadata.builder(identifier).mimeType(mimeType).size(size).build();
         assertEquals(identifier, binary.getIdentifier(), "Identifier did not match");
         assertEquals(of(mimeType), binary.getMimeType(), "MimeType did not match");
         assertEquals(of(size), binary.getSize(), "Size did not match");
     }
 
     @Test
-    public void testBinaryWithOptionalArgs() {
-        final Binary binary = Binary.builder(identifier).build();
+    public void testBinaryMetadataWithOptionalArgs() {
+        final BinaryMetadata binary = BinaryMetadata.builder(identifier).build();
         assertEquals(identifier, binary.getIdentifier(), "Identifier did not match");
         assertFalse(binary.getMimeType().isPresent(), "MimeType was not absent");
         assertFalse(binary.getSize().isPresent(), "Size was not absent");

--- a/core/api/src/test/java/org/trellisldp/api/BinaryTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryTest.java
@@ -13,12 +13,9 @@
  */
 package org.trellisldp.api;
 
-import static java.time.Instant.parse;
 import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.time.Instant;
 
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
@@ -34,25 +31,22 @@ public class BinaryTest {
 
     private final Long size = 10L;
     private final String mimeType = "text/plain";
-    private final Instant modified = parse("2015-09-15T06:14:00.00Z");
     private final IRI identifier = rdf.createIRI("trellis:data/resource");
 
     @Test
     public void testBinary() {
-        final Binary binary = new Binary(identifier, modified, mimeType, size);
+        final Binary binary = Binary.builder(identifier).mimeType(mimeType).size(size).build();
         assertEquals(identifier, binary.getIdentifier(), "Identifier did not match");
         assertEquals(of(mimeType), binary.getMimeType(), "MimeType did not match");
         assertEquals(of(size), binary.getSize(), "Size did not match");
-        assertEquals(modified, binary.getModified(), "Modification date did not match");
     }
 
     @Test
     public void testBinaryWithOptionalArgs() {
-        final Binary binary = new Binary(identifier, modified, null, null);
+        final Binary binary = Binary.builder(identifier).build();
         assertEquals(identifier, binary.getIdentifier(), "Identifier did not match");
         assertFalse(binary.getMimeType().isPresent(), "MimeType was not absent");
         assertFalse(binary.getSize().isPresent(), "Size was not absent");
-        assertEquals(modified, binary.getModified(), "Modification date did not match");
     }
 
 }

--- a/core/api/src/test/java/org/trellisldp/api/MetadataTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/MetadataTest.java
@@ -68,7 +68,7 @@ public class MetadataTest {
 
     @Test
     public void testMetadataBinary() {
-        final Binary binary = Binary.builder(rdf.createIRI("http://example.com/binary")).build();
+        final BinaryMetadata binary = BinaryMetadata.builder(rdf.createIRI("http://example.com/binary")).build();
         final Metadata metadata = Metadata.builder(identifier)
                 .interactionModel(LDP.NonRDFSource)
                 .container(root).binary(binary).build();

--- a/core/api/src/test/java/org/trellisldp/api/MetadataTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/MetadataTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.api;
+
+import static java.util.Optional.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+import org.junit.jupiter.api.Test;
+import org.trellisldp.vocabulary.DC;
+import org.trellisldp.vocabulary.FOAF;
+import org.trellisldp.vocabulary.LDP;
+
+public class MetadataTest {
+
+    private static final RDF rdf = TrellisUtils.getInstance();
+    private static final IRI identifier = rdf.createIRI("trellis:data/resource");
+    private static final IRI member = rdf.createIRI("trellis:data/member");
+    private static final IRI root = rdf.createIRI("trellis:data/");
+
+    @Test
+    public void testMetadataIndirectContainer() {
+        final Metadata metadata = Metadata.builder(identifier)
+                .interactionModel(LDP.IndirectContainer)
+                .container(root).memberRelation(LDP.member)
+                .membershipResource(member)
+                .insertedContentRelation(FOAF.primaryTopic).build();
+        assertEquals(identifier, metadata.getIdentifier());
+        assertEquals(LDP.IndirectContainer, metadata.getInteractionModel());
+        assertEquals(of(root), metadata.getContainer());
+        assertEquals(of(member), metadata.getMembershipResource());
+        assertEquals(of(LDP.member), metadata.getMemberRelation());
+        assertEquals(of(FOAF.primaryTopic), metadata.getInsertedContentRelation());
+        assertFalse(metadata.getMemberOfRelation().isPresent());
+        assertFalse(metadata.getBinary().isPresent());
+    }
+
+    @Test
+    public void testMetadataDirectContainer() {
+        final Metadata metadata = Metadata.builder(identifier)
+                .interactionModel(LDP.DirectContainer)
+                .container(root).memberOfRelation(DC.isPartOf)
+                .membershipResource(member).build();
+        assertEquals(identifier, metadata.getIdentifier());
+        assertEquals(LDP.DirectContainer, metadata.getInteractionModel());
+        assertEquals(of(root), metadata.getContainer());
+        assertEquals(of(member), metadata.getMembershipResource());
+        assertEquals(of(DC.isPartOf), metadata.getMemberOfRelation());
+        assertFalse(metadata.getInsertedContentRelation().isPresent());
+        assertFalse(metadata.getMemberRelation().isPresent());
+        assertFalse(metadata.getBinary().isPresent());
+    }
+
+    @Test
+    public void testMetadataBinary() {
+        final Binary binary = Binary.builder(rdf.createIRI("http://example.com/binary")).build();
+        final Metadata metadata = Metadata.builder(identifier)
+                .interactionModel(LDP.NonRDFSource)
+                .container(root).binary(binary).build();
+        assertEquals(identifier, metadata.getIdentifier());
+        assertEquals(LDP.NonRDFSource, metadata.getInteractionModel());
+        assertEquals(of(root), metadata.getContainer());
+        assertEquals(of(binary), metadata.getBinary());
+        assertFalse(metadata.getMembershipResource().isPresent());
+        assertFalse(metadata.getMemberOfRelation().isPresent());
+        assertFalse(metadata.getInsertedContentRelation().isPresent());
+        assertFalse(metadata.getMemberRelation().isPresent());
+    }
+
+    @Test
+    public void testMetadataResource() {
+        final Resource mockResource = mock(Resource.class);
+        when(mockResource.getContainer()).thenReturn(of(root));
+        when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
+        when(mockResource.getIdentifier()).thenReturn(identifier);
+
+        final Metadata metadata = Metadata.builder(mockResource).build();
+        assertEquals(identifier, metadata.getIdentifier());
+        assertEquals(LDP.RDFSource, metadata.getInteractionModel());
+        assertEquals(of(root), metadata.getContainer());
+        assertFalse(metadata.getBinary().isPresent());
+        assertFalse(metadata.getMembershipResource().isPresent());
+        assertFalse(metadata.getMemberOfRelation().isPresent());
+        assertFalse(metadata.getInsertedContentRelation().isPresent());
+        assertFalse(metadata.getMemberRelation().isPresent());
+    }
+}

--- a/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -69,7 +69,7 @@ public class ResourceServiceTest {
         doCallRealMethod().when(mockResourceService).unskolemize(any());
         doCallRealMethod().when(mockResourceService).toInternal(any(), any());
         doCallRealMethod().when(mockResourceService).toExternal(any(), any());
-        doCallRealMethod().when(mockResourceService).create(any(), any(), any(), any(), any());
+        doCallRealMethod().when(mockResourceService).create(any(), any());
 
         when(mockRetrievalService.get(eq(existing))).thenAnswer(inv -> completedFuture(mockResource));
     }
@@ -90,13 +90,12 @@ public class ResourceServiceTest {
     public void testDefaultCreate() {
         final IRI root = rdf.createIRI("trellis:data/");
         final Dataset dataset = rdf.createDataset();
+        final Metadata metadata = Metadata.builder(existing).container(root).interactionModel(LDP.RDFSource).build();
 
-        when(mockResourceService.replace(eq(existing), eq(LDP.RDFSource), eq(dataset), eq(root), any()))
-            .thenReturn(completedFuture(null));
+        when(mockResourceService.replace(eq(metadata), eq(dataset))).thenReturn(completedFuture(null));
 
-        assertDoesNotThrow(() -> mockResourceService.create(existing, LDP.RDFSource, dataset, root, null).join());
-        verify(mockResourceService).replace(eq(existing), eq(LDP.RDFSource),
-                eq(dataset), eq(root), any());
+        assertDoesNotThrow(() -> mockResourceService.create(metadata, dataset).join());
+        verify(mockResourceService).replace(eq(metadata), eq(dataset));
     }
 
     @Test

--- a/core/api/src/test/java/org/trellisldp/api/ResourceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceTest.java
@@ -58,7 +58,7 @@ public class ResourceTest {
         doCallRealMethod().when(mockResource).getInsertedContentRelation();
         doCallRealMethod().when(mockResource).stream(any(IRI.class));
         doCallRealMethod().when(mockResource).stream(anyCollection());
-        doCallRealMethod().when(mockResource).getBinary();
+        doCallRealMethod().when(mockResource).getBinaryMetadata();
         doCallRealMethod().when(mockResource).hasAcl();
         doCallRealMethod().when(mockResource).getExtraLinkRelations();
 
@@ -73,7 +73,7 @@ public class ResourceTest {
         assertFalse(mockResource.getMemberRelation().isPresent(), "Member relation unexpectedly present!");
         assertFalse(mockResource.getMemberOfRelation().isPresent(), "Member of relation unexpectedly present!");
         assertFalse(mockResource.getInsertedContentRelation().isPresent(), "Inserted content relation is present!");
-        assertFalse(mockResource.getBinary().isPresent(), "Binary is unexpectedly present!");
+        assertFalse(mockResource.getBinaryMetadata().isPresent(), "Binary is unexpectedly present!");
         assertFalse(mockResource.getExtraLinkRelations().findFirst().isPresent(), "Extra links unexpectedly present!");
         assertFalse(mockResource.hasAcl(), "ACL unexpectedly present!");
     }

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -59,6 +59,7 @@ import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.api.Triple;
 import org.apache.tamaya.ConfigurationProvider;
 import org.slf4j.Logger;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ServiceBundler;
 import org.trellisldp.http.core.PATCH;
@@ -148,14 +149,14 @@ public class TrellisHttpResource {
     private CompletableFuture<Void> initialize(final IRI id, final Resource res, final TrellisDataset dataset) {
         if (MISSING_RESOURCE.equals(res) || DELETED_RESOURCE.equals(res)) {
             LOGGER.info("Initializing root container: {}", id);
-            return trellis.getResourceService().create(id, LDP.BasicContainer, dataset.asDataset(), null, null);
+            return trellis.getResourceService().create(Metadata.builder(id).interactionModel(LDP.BasicContainer)
+                    .build(), dataset.asDataset());
         } else if (!res.hasAcl()) {
             LOGGER.info("Initializeing root ACL: {}", id);
             try (final Stream<? extends Triple> triples = res.stream(Trellis.PreferUserManaged)) {
                 triples.map(toQuad(Trellis.PreferUserManaged)).forEach(dataset::add);
             }
-            return trellis.getResourceService().replace(res.getIdentifier(), res.getInteractionModel(),
-                    dataset.asDataset(), null, null);
+            return trellis.getResourceService().replace(Metadata.builder(res).build(), dataset.asDataset());
         }
         return completedFuture(null);
     }

--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 
 import org.apache.commons.rdf.api.Triple;
 import org.slf4j.Logger;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ServiceBundler;
 import org.trellisldp.http.core.TrellisRequest;
@@ -154,8 +155,7 @@ public class DeleteHandler extends MutatingLdpHandler {
 
         // delete the resource
         return allOf(
-                getServices().getResourceService().delete(getResource().getIdentifier(),
-                    getResource().getContainer().orElse(null)),
+                getServices().getResourceService().delete(Metadata.builder(getResource()).build()),
                 getServices().getResourceService().add(getResource().getIdentifier(), immutable.asDataset()));
     }
 }

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -357,10 +357,6 @@ public class GetHandler extends BaseLdpHandler {
         builder.lastModified(from(mod));
 
         final IRI dsid = getResource().getBinaryMetadata().map(BinaryMetadata::getIdentifier).orElse(null);
-        if (isNull(dsid)) {
-            LOGGER.error("Could not access binary metadata for {}", getResource().getIdentifier());
-            throw new WebApplicationException("Could not access binary metadata");
-        }
 
         // Add standard headers
         builder.header(VARY, RANGE).header(VARY, WANT_DIGEST).header(ACCEPT_RANGES, "bytes").tag(etag)

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -349,12 +349,7 @@ public class GetHandler extends BaseLdpHandler {
 
     private CompletableFuture<ResponseBuilder> getLdpNr(final ResponseBuilder builder) {
 
-        final Instant mod = getResource().getBinary().map(Binary::getModified).orElse(null);
-        if (isNull(mod)) {
-            LOGGER.error("Could not access binary metadata for {}", getResource().getIdentifier());
-            throw new WebApplicationException("Could not access binary metadata");
-        }
-
+        final Instant mod = getResource().getModified();
         final EntityTag etag = new EntityTag(buildEtagHash(getIdentifier() + "BINARY", mod, null));
         checkCache(mod, etag);
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -300,7 +300,7 @@ class MutatingLdpHandler extends BaseLdpHandler {
         final Metadata.Builder metadata = metadataBuilder(getResource().getIdentifier(),
                 getResource().getInteractionModel(), mutable);
         getResource().getContainer().ifPresent(metadata::container);
-        getResource().getBinary().ifPresent(metadata::binary);
+        getResource().getBinaryMetadata().ifPresent(metadata::binary);
         // update the resource
         return allOf(
             getServices().getResourceService().replace(metadata.build(), mutable.asDataset()),

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -61,7 +61,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFSyntax;
 import org.slf4j.Logger;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ServiceBundler;
@@ -183,7 +183,7 @@ public class PostHandler extends MutatingLdpHandler {
                 LOGGER.debug("Successfully persisted bitstream with content type {} to {}", mimeType, binaryLocation));
 
             metadata = metadataBuilder(internalId, ldpType, mutable).container(parentIdentifier)
-                .binary(Binary.builder(binaryLocation).mimeType(mimeType).size(getEntityLength()).build());
+                .binary(BinaryMetadata.builder(binaryLocation).mimeType(mimeType).size(getEntityLength()).build());
             builder.link(getIdentifier() + "?ext=description", "describedby");
         } else {
             readEntityIntoDataset(PreferUserManaged, ofNullable(rdfSyntax).orElse(TURTLE), mutable);

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -14,7 +14,6 @@
 package org.trellisldp.http.impl;
 
 import static java.net.URI.create;
-import static java.time.Instant.now;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -47,7 +46,6 @@ import java.io.File;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -65,6 +63,7 @@ import org.apache.commons.rdf.api.RDFSyntax;
 import org.apache.commons.rdf.api.Triple;
 import org.slf4j.Logger;
 import org.trellisldp.api.Binary;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ServiceBundler;
 import org.trellisldp.http.core.TrellisRequest;
@@ -117,17 +116,13 @@ public class PutHandler extends MutatingLdpHandler {
 
         // Check the cache
         if (nonNull(getResource())) {
+            final Instant modified = getResource().getModified();
             final EntityTag etag;
-            final Instant modified;
-            final Optional<Instant> binaryModification = getResource().getBinary().map(Binary::getModified);
 
-            if (binaryModification.isPresent() &&
+            if (getResource().getBinary().isPresent() &&
                     !ofNullable(getRequest().getContentType()).flatMap(RDFSyntax::byMediaType).isPresent()) {
-                modified = binaryModification.get();
-                etag = new EntityTag(buildEtagHash(getIdentifier() + "BINARY",
-                            modified, null));
+                etag = new EntityTag(buildEtagHash(getIdentifier() + "BINARY", modified, null));
             } else {
-                modified = getResource().getModified();
                 etag = new EntityTag(buildEtagHash(getIdentifier(), modified, getRequest().getPrefer()));
             }
             // Check the cache
@@ -193,7 +188,8 @@ public class PutHandler extends MutatingLdpHandler {
 
     private CompletableFuture<ResponseBuilder> handleResourceUpdate(final TrellisDataset mutable,
             final TrellisDataset immutable, final ResponseBuilder builder, final IRI ldpType) {
-        final Binary binary;
+
+        final Metadata.Builder metadata;
         final CompletableFuture<Void> persistPromise;
 
         // Add user-supplied data
@@ -208,7 +204,8 @@ public class PutHandler extends MutatingLdpHandler {
             persistPromise = persistContent(binaryLocation, singletonMap(CONTENT_TYPE, mimeType)).thenAccept(future ->
                 LOGGER.debug("Successfully persisted bitstream with content type {} to {}", mimeType, binaryLocation));
 
-            binary = new Binary(binaryLocation, now(), mimeType, getEntityLength());
+            metadata = metadataBuilder(internalId, ldpType, mutable)
+                .binary(Binary.builder(binaryLocation).mimeType(mimeType).size(getEntityLength()).build());
             builder.link(getIdentifier() + "?ext=description", "describedby");
         } else {
             readEntityIntoDataset(graphName, ofNullable(rdfSyntax).orElse(TURTLE), mutable);
@@ -222,11 +219,13 @@ public class PutHandler extends MutatingLdpHandler {
                         ofNullable(rdfSyntax).orElse(TURTLE));
             }
             LOGGER.trace("Successfully checked for constraint violations");
-            binary = ofNullable(getResource()).flatMap(Resource::getBinary).orElse(null);
+            metadata = metadataBuilder(internalId, ldpType, mutable);
+            ofNullable(getResource()).flatMap(Resource::getBinary).ifPresent(metadata::binary);
             persistPromise = completedFuture(null);
         }
 
         if (nonNull(getResource())) {
+            getResource().getContainer().ifPresent(metadata::container);
             LOGGER.debug("Resource {} found in persistence", getIdentifier());
             try (final Stream<? extends Triple> remaining = getResource().stream(otherGraph)) {
                 remaining.map(toQuad(otherGraph)).forEachOrdered(mutable::add);
@@ -238,13 +237,13 @@ public class PutHandler extends MutatingLdpHandler {
         LOGGER.trace("Successfully calculated and skolemized immutable data");
 
         ldpResourceTypes(effectiveLdpType(ldpType)).map(IRI::getIRIString)
-            .peek(type -> LOGGER.debug("Adding link for type {}", type))
+            .peek(type -> LOGGER.info("Adding link for type {}", type))
             .forEach(type -> builder.link(type, "type"));
         LOGGER.debug("Persisting mutable data for {} with data: {}", internalId, mutable);
 
         return allOf(
                 persistPromise,
-                createOrReplace(ldpType, mutable, binary),
+                createOrReplace(metadata.build(), mutable),
                 getServices().getResourceService().add(internalId, immutable.asDataset()))
             .thenCompose(future -> handleUpdateEvent(ldpType))
             .thenApply(future -> decorateResponse(builder));
@@ -270,15 +269,13 @@ public class PutHandler extends MutatingLdpHandler {
             || (LDP.NonRDFSource.equals(ldpType) && isBinaryDescription()) ? LDP.RDFSource : ldpType;
     }
 
-    private CompletableFuture<Void> createOrReplace(final IRI ldpType, final TrellisDataset ds, final Binary b) {
-        final Resource resource = getResource();
-        if (isNull(resource)) {
+    private CompletableFuture<Void> createOrReplace(final Metadata metadata, final TrellisDataset ds) {
+        if (isNull(getResource())) {
             LOGGER.debug("Creating new resource {}", internalId);
-            return getServices().getResourceService().create(internalId, ldpType, ds.asDataset(), null, b);
+            return getServices().getResourceService().create(metadata, ds.asDataset());
         } else {
             LOGGER.debug("Replacing old resource {}", internalId);
-            return getServices().getResourceService().replace(internalId, ldpType, ds.asDataset(),
-                    resource.getContainer().orElse(null), b);
+            return getServices().getResourceService().replace(metadata, ds.asDataset());
         }
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -297,22 +297,6 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinaryMetadataError1() {
-        when(mockBinary.getModified()).thenReturn(null);
-        final Response res = target(BINARY_PATH).request().get();
-
-        assertEquals(SC_INTERNAL_SERVER_ERROR, res.getStatus(), "Unexpected response code!");
-    }
-
-    @Test
-    public void testGetBinaryMetadataError2() {
-        when(mockBinary.getIdentifier()).thenReturn(null);
-        final Response res = target(BINARY_PATH).request().get();
-
-        assertEquals(SC_INTERNAL_SERVER_ERROR, res.getStatus(), "Unexpected response code!");
-    }
-
-    @Test
     public void testGetBinaryDigestInvalid() throws IOException {
         final Response res = target(BINARY_PATH).request().header(WANT_DIGEST, "FOO").get();
 

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -63,7 +63,7 @@ import org.mockito.Mock;
 import org.trellisldp.api.AccessControlService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
@@ -130,8 +130,8 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
 
     protected static final Set<IRI> allModes = newHashSet(ACL.Append, ACL.Control, ACL.Read, ACL.Write);
 
-    protected static final Binary testBinary = Binary.builder(binaryInternalIdentifier).mimeType(BINARY_MIME_TYPE)
-        .size(BINARY_SIZE).build();
+    protected static final BinaryMetadata testBinary = BinaryMetadata.builder(binaryInternalIdentifier)
+        .mimeType(BINARY_MIME_TYPE).size(BINARY_SIZE).build();
 
     @Mock
     protected ServiceBundler mockBundler;
@@ -281,32 +281,32 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     private void setUpResources() {
         when(mockVersionedResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockVersionedResource.getModified()).thenReturn(time);
-        when(mockVersionedResource.getBinary()).thenReturn(empty());
+        when(mockVersionedResource.getBinaryMetadata()).thenReturn(empty());
         when(mockVersionedResource.getIdentifier()).thenReturn(identifier);
         when(mockVersionedResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockBinaryVersionedResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockBinaryVersionedResource.getModified()).thenReturn(time);
-        when(mockBinaryVersionedResource.getBinary()).thenReturn(of(testBinary));
+        when(mockBinaryVersionedResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockBinaryVersionedResource.getIdentifier()).thenReturn(binaryIdentifier);
         when(mockBinaryVersionedResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockBinaryResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockBinaryResource.getModified()).thenReturn(time);
-        when(mockBinaryResource.getBinary()).thenReturn(of(testBinary));
+        when(mockBinaryResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockBinaryResource.getIdentifier()).thenReturn(binaryIdentifier);
         when(mockBinaryResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockResource.getContainer()).thenReturn(of(root));
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockResource.getModified()).thenReturn(time);
-        when(mockResource.getBinary()).thenReturn(empty());
+        when(mockResource.getBinaryMetadata()).thenReturn(empty());
         when(mockResource.getIdentifier()).thenReturn(identifier);
         when(mockResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockRootResource.getModified()).thenReturn(time);
-        when(mockRootResource.getBinary()).thenReturn(empty());
+        when(mockRootResource.getBinaryMetadata()).thenReturn(empty());
         when(mockRootResource.getIdentifier()).thenReturn(root);
         when(mockRootResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
         when(mockRootResource.hasAcl()).thenReturn(true);

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -68,6 +68,7 @@ import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.MementoService;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.NoopAuditService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
@@ -129,6 +130,9 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
 
     protected static final Set<IRI> allModes = newHashSet(ACL.Append, ACL.Control, ACL.Read, ACL.Write);
 
+    protected static final Binary testBinary = Binary.builder(binaryInternalIdentifier).mimeType(BINARY_MIME_TYPE)
+        .size(BINARY_SIZE).build();
+
     @Mock
     protected ServiceBundler mockBundler;
 
@@ -153,9 +157,6 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     @Mock
     protected Resource mockResource, mockVersionedResource, mockBinaryResource, mockBinaryVersionedResource,
               mockRootResource;
-
-    @Mock
-    protected Binary mockBinary;
 
     @Mock
     protected InputStream mockInputStream;
@@ -218,11 +219,9 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         when(mockResourceService.toInternal(any(RDFTerm.class), any())).thenCallRealMethod();
         when(mockResourceService.toExternal(any(RDFTerm.class), any())).thenCallRealMethod();
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(null));
-        when(mockResourceService.delete(any(IRI.class), any(IRI.class))).thenReturn(completedFuture(null));
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class),
-                        any(), any())).thenReturn(completedFuture(null));
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class),
-                        any(), any())).thenReturn(completedFuture(null));
+        when(mockResourceService.delete(any(Metadata.class))).thenReturn(completedFuture(null));
+        when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
+        when(mockResourceService.create(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
         when(mockResourceService.unskolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());
@@ -288,20 +287,15 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
 
         when(mockBinaryVersionedResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockBinaryVersionedResource.getModified()).thenReturn(time);
-        when(mockBinaryVersionedResource.getBinary()).thenReturn(of(mockBinary));
+        when(mockBinaryVersionedResource.getBinary()).thenReturn(of(testBinary));
         when(mockBinaryVersionedResource.getIdentifier()).thenReturn(binaryIdentifier);
         when(mockBinaryVersionedResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 
         when(mockBinaryResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockBinaryResource.getModified()).thenReturn(time);
-        when(mockBinaryResource.getBinary()).thenReturn(of(mockBinary));
+        when(mockBinaryResource.getBinary()).thenReturn(of(testBinary));
         when(mockBinaryResource.getIdentifier()).thenReturn(binaryIdentifier);
         when(mockBinaryResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
-
-        when(mockBinary.getModified()).thenReturn(time);
-        when(mockBinary.getIdentifier()).thenReturn(binaryInternalIdentifier);
-        when(mockBinary.getMimeType()).thenReturn(of(BINARY_MIME_TYPE));
-        when(mockBinary.getSize()).thenReturn(of(BINARY_SIZE));
 
         when(mockResource.getContainer()).thenReturn(of(root));
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -40,13 +40,13 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.rdf.api.Dataset;
-import org.apache.commons.rdf.api.IRI;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.http.core.TrellisRequest;
@@ -146,16 +146,15 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(mockRootResource));
         when(mockRootResource.hasAcl()).thenReturn(false);
-        when(mockService.replace(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
 
         final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler);
         matcher.initialize();
 
         verify(mockService, never().description("When re-initializing the root ACL, create should not be called"))
-            .create(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .create(any(Metadata.class), any(Dataset.class));
         verify(mockService, description("Use replace when re-initializing the root ACL"))
-            .replace(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .replace(any(Metadata.class), any(Dataset.class));
         verify(mockService, description("Verify that the root resource is fetched only once")).get(root);
     }
 
@@ -164,16 +163,15 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
-        when(mockService.create(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockService.create(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
 
         final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler);
         matcher.initialize();
 
         verify(mockService, description("Re-create a missing root resource on initialization"))
-            .create(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .create(any(Metadata.class), any(Dataset.class));
         verify(mockService, never().description("Don't try to replace a non-existent root on initialization"))
-            .replace(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .replace(any(Metadata.class), any(Dataset.class));
         verify(mockService, description("Verify that the root resource is fetched only once")).get(root);
     }
 
@@ -182,25 +180,24 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
-        when(mockService.create(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockService.create(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
 
         final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler);
         matcher.initialize();
 
         verify(mockService, description("A previously deleted root resource should be re-created upon initialization"))
-            .create(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .create(any(Metadata.class), any(Dataset.class));
         verify(mockService, never().description("replace shouldn't be called when re-initializing a deleted root"))
-            .replace(eq(root), any(IRI.class), any(Dataset.class), any(), any());
+            .replace(any(Metadata.class), any(Dataset.class));
         verify(mockService, description("Verify that the root resource is fetched only once")).get(root);
     }
 
     private Stream<Executable> verifyInteractions(final ResourceService svc) {
         return of(
                 () -> verify(svc, never().description("Don't re-initialize the root if it already exists"))
-                        .create(eq(root), any(IRI.class), any(Dataset.class), any(), any()),
+                        .create(any(Metadata.class), any(Dataset.class)),
                 () -> verify(svc, never().description("Don't re-initialize the root if it already exists"))
-                        .replace(eq(root), any(IRI.class), any(Dataset.class), any(), any()),
+                        .replace(any(Metadata.class), any(Dataset.class)),
                 () -> verify(svc, description("Verify that the root resource is fetched only once")).get(root));
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -271,7 +271,7 @@ abstract class BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockResource.getContainer()).thenReturn(Optional.of(root));
         when(mockResource.getIdentifier()).thenReturn(identifier);
-        when(mockResource.getBinary()).thenReturn(empty());
+        when(mockResource.getBinaryMetadata()).thenReturn(empty());
         when(mockResource.getModified()).thenReturn(time);
         when(mockResource.getExtraLinkRelations()).thenAnswer(inv -> Stream.empty());
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -88,6 +88,7 @@ import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.MementoService;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.NoopAuditService;
 import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
@@ -222,11 +223,9 @@ abstract class BaseTestHandler {
     private void setUpResourceService() {
         when(mockResourceService.supportedInteractionModels()).thenReturn(allInteractionModels);
         when(mockResourceService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockResource));
-        when(mockResourceService.create(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
-        when(mockResourceService.delete(any(IRI.class), any(IRI.class))).thenReturn(completedFuture(null));
+        when(mockResourceService.create(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
+        when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
+        when(mockResourceService.delete(any(Metadata.class))).thenReturn(completedFuture(null));
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(completedFuture(null));
         when(mockResourceService.skolemize(any(Literal.class))).then(returnsFirstArg());
         when(mockResourceService.skolemize(any(IRI.class))).then(returnsFirstArg());

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -41,6 +41,7 @@ import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.junit.jupiter.api.Test;
 import org.trellisldp.api.AuditService;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.vocabulary.LDP;
 
@@ -73,7 +74,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
 
     @Test
     public void testDeleteError() {
-        when(mockResourceService.delete(any(IRI.class), any(IRI.class))).thenReturn(asyncException());
+        when(mockResourceService.delete(any(Metadata.class))).thenReturn(asyncException());
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
         assertThrows(CompletionException.class, () ->
                 unwrapAsyncError(handler.deleteResource(handler.initialize(mockParent, mockResource))),
@@ -94,8 +95,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
 
     @Test
     public void testDeleteACLError() {
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(asyncException());
+        when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getExt()).thenReturn(ACL);
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
         assertThrows(CompletionException.class, () ->
@@ -105,8 +105,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
 
     @Test
     public void testDeleteACLAuditError() {
-        when(mockResourceService.replace(any(IRI.class), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(completedFuture(null));
+        when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getExt()).thenReturn(ACL);
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -87,7 +87,7 @@ import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.http.core.Prefer;
 import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.OA;
@@ -98,8 +98,8 @@ import org.trellisldp.vocabulary.SKOS;
  */
 public class GetHandlerTest extends BaseTestHandler {
 
-    private Binary testBinary = Binary.builder(rdf.createIRI("file:///testResource.txt")).mimeType("text/plain")
-        .size(100L).build();
+    private BinaryMetadata testBinary = BinaryMetadata.builder(rdf.createIRI("file:///testResource.txt"))
+        .mimeType("text/plain").size(100L).build();
 
     @Test
     public void testGetLdprs() {
@@ -198,7 +198,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
     @Test
     public void testCacheLdpNr() {
-        when(mockResource.getBinary()).thenReturn(of(testBinary));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockHttpHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(WILDCARD_TYPE));
         when(mockRequest.evaluatePreconditions(eq(from(time)), any(EntityTag.class)))
@@ -342,7 +342,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
     @Test
     public void testGetBinaryDescription() {
-        when(mockResource.getBinary()).thenReturn(of(testBinary));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, null);
@@ -354,7 +354,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
     @Test
     public void testGetBinaryDescription2() {
-        when(mockResource.getBinary()).thenReturn(of(testBinary));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getExt()).thenReturn(DESCRIPTION);
 
@@ -382,7 +382,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
     @Test
     public void testGetBinary() throws IOException {
-        when(mockResource.getBinary()).thenReturn(of(testBinary));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockHttpHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(WILDCARD_TYPE));
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.http.impl;
 
-import static java.time.Instant.ofEpochSecond;
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.ofInstant;
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
@@ -74,7 +73,6 @@ import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE_TYPE;
 import static org.trellisldp.vocabulary.JSONLD.compacted;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,9 +98,8 @@ import org.trellisldp.vocabulary.SKOS;
  */
 public class GetHandlerTest extends BaseTestHandler {
 
-    private static final Instant binaryTime = ofEpochSecond(1496262750);
-
-    private Binary testBinary = new Binary(rdf.createIRI("file:///testResource.txt"), binaryTime, "text/plain", 100L);
+    private Binary testBinary = Binary.builder(rdf.createIRI("file:///testResource.txt")).mimeType("text/plain")
+        .size(100L).build();
 
     @Test
     public void testGetLdprs() {
@@ -204,7 +201,7 @@ public class GetHandlerTest extends BaseTestHandler {
         when(mockResource.getBinary()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockHttpHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(WILDCARD_TYPE));
-        when(mockRequest.evaluatePreconditions(eq(from(binaryTime)), any(EntityTag.class)))
+        when(mockRequest.evaluatePreconditions(eq(from(time)), any(EntityTag.class)))
                 .thenReturn(notModified());
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, baseUrl);
@@ -395,7 +392,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(-1, res.getLength(), "Incorrect response length!");
-        assertEquals(from(binaryTime), res.getLastModified(), "Incorrect content-type header!");
+        assertEquals(from(time), res.getLastModified(), "Incorrect content-type header!");
         assertTrue(res.getMediaType().isCompatible(TEXT_PLAIN_TYPE), "Incorrect content-type header!");
         assertTrue(res.getLinks().stream()
                 .anyMatch(link -> link.getRel().equals("describedby") &&

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -57,6 +57,7 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Triple;
 import org.junit.jupiter.api.Test;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.http.core.Prefer;
@@ -122,7 +123,7 @@ public class PatchHandlerTest extends BaseTestHandler {
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
 
         verify(mockIoService).update(any(Graph.class), eq(insert), eq(SPARQL_UPDATE), eq(identifier.getIRIString()));
-        verify(mockResourceService).replace(eq(identifier), eq(LDP.RDFSource), any(Dataset.class), any(), any());
+        verify(mockResourceService).replace(any(Metadata.class), any(Dataset.class));
     }
 
     @Test
@@ -183,8 +184,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     public void testError() {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
-        when(mockResourceService.replace(eq(identifier), any(IRI.class), any(Dataset.class), any(), any()))
-            .thenReturn(asyncException());
+        when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(asyncException());
 
         final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null);
         assertThrows(CompletionException.class, () ->

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -55,6 +55,7 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Triple;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.http.core.Digest;
 import org.trellisldp.vocabulary.DC;
@@ -187,7 +188,7 @@ public class PostHandlerTest extends BaseTestHandler {
 
         verify(mockBinaryService, never()).setContent(any(IRI.class), any(InputStream.class));
         verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + path));
-        verify(mockResourceService).create(eq(identifier), eq(LDP.RDFSource), any(Dataset.class), any(), any());
+        verify(mockResourceService).create(any(Metadata.class), any(Dataset.class));
     }
 
     @Test
@@ -275,8 +276,7 @@ public class PostHandlerTest extends BaseTestHandler {
 
     @Test
     public void testError() throws IOException {
-        when(mockResourceService.create(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + "newresource")),
-                    any(IRI.class), any(Dataset.class), any(), any())).thenReturn(asyncException());
+        when(mockResourceService.create(any(Metadata.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getContentType()).thenReturn("text/turtle");
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", baseUrl);
@@ -294,7 +294,7 @@ public class PostHandlerTest extends BaseTestHandler {
     private Stream<Executable> checkBinaryEntityResponse(final IRI identifier) {
         return Stream.of(
                 () -> verify(mockResourceService, description("ResourceService::create not called!"))
-                            .create(eq(identifier), eq(LDP.NonRDFSource), any(Dataset.class), any(), any()),
+                            .create(any(Metadata.class), any(Dataset.class)),
                 () -> verify(mockIoService, never().description("entity shouldn't be read!")).read(any(), any(), any()),
                 () -> verify(mockBinaryService, description("content not set on binary service!"))
                             .setContent(iriArgument.capture(), any(InputStream.class), metadataArgument.capture()),

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
-import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE;
 import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 
@@ -171,7 +170,6 @@ public class PostHandlerTest extends BaseTestHandler {
     @Test
     public void testRdfEntity() throws IOException {
         final String path = "newresource";
-        final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + path);
         final Triple triple = rdf.createTriple(rdf.createIRI(baseUrl + path), DC.title,
                         rdf.createLiteral("A title"));
 
@@ -195,14 +193,13 @@ public class PostHandlerTest extends BaseTestHandler {
     public void testBinaryEntity() throws IOException {
         when(mockTrellisRequest.getContentType()).thenReturn("text/plain");
 
-        final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "new-resource");
         final PostHandler handler = buildPostHandler("/simpleData.txt", "new-resource", null);
         final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "new-resource"), res.getLocation(), "Incorrect Location header!");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.NonRDFSource));
-        assertAll("Check Binary response", checkBinaryEntityResponse(identifier));
+        assertAll("Check Binary response", checkBinaryEntityResponse());
     }
 
     @Test
@@ -210,14 +207,13 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getContentType()).thenReturn("text/plain");
         when(mockTrellisRequest.getDigest()).thenReturn(new Digest("md5", "1VOyRwUXW1CPdC5nelt7GQ=="));
 
-        final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource-with-entity");
         final PostHandler handler = buildPostHandler("/simpleData.txt", "resource-with-entity", null);
         final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "resource-with-entity"), res.getLocation(), "Incorrect Location hearder!");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.NonRDFSource));
-        assertAll("Check Binary response", checkBinaryEntityResponse(identifier));
+        assertAll("Check Binary response", checkBinaryEntityResponse());
     }
 
     @Test
@@ -291,7 +287,7 @@ public class PostHandlerTest extends BaseTestHandler {
         return new PostHandler(mockTrellisRequest, root, id, entity, mockBundler, baseUrl);
     }
 
-    private Stream<Executable> checkBinaryEntityResponse(final IRI identifier) {
+    private Stream<Executable> checkBinaryEntityResponse() {
         return Stream.of(
                 () -> verify(mockResourceService, description("ResourceService::create not called!"))
                             .create(any(Metadata.class), any(Dataset.class)),

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -56,7 +56,7 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFSyntax;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
-import org.trellisldp.api.Binary;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Metadata;
 import org.trellisldp.api.RuntimeTrellisException;
@@ -68,8 +68,8 @@ import org.trellisldp.vocabulary.LDP;
  */
 public class PutHandlerTest extends BaseTestHandler {
 
-    private final Binary testBinary = Binary.builder(rdf.createIRI("file:///binary.txt")).mimeType("text/plain")
-        .build();
+    private final BinaryMetadata testBinary = BinaryMetadata.builder(rdf.createIRI("file:///binary.txt"))
+        .mimeType("text/plain").build();
 
     @Test
     public void testPutConflict() {
@@ -164,7 +164,7 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
-        when(mockResource.getBinary()).thenReturn(of(testBinary));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
 
         final PutHandler handler = buildPutHandler("/simpleData.txt", null);
         final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
@@ -176,7 +176,7 @@ public class PutHandlerTest extends BaseTestHandler {
     @Test
     public void testPutLdpNRDescription() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
-        when(mockResource.getBinary()).thenReturn(of(testBinary));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.RDFSource.getIRIString()).rel("type").build());
 
@@ -190,7 +190,7 @@ public class PutHandlerTest extends BaseTestHandler {
     @Test
     public void testPutLdpNRDescription2() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
-        when(mockResource.getBinary()).thenReturn(of(testBinary));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
 
         final PutHandler handler = buildPutHandler("/simpleLiteral.ttl", null);
@@ -211,7 +211,7 @@ public class PutHandlerTest extends BaseTestHandler {
 
     @Test
     public void testCache() {
-        when(mockResource.getBinary()).thenReturn(of(testBinary));
+        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockRequest.evaluatePreconditions(eq(from(time)), any(EntityTag.class)))
                 .thenReturn(status(PRECONDITION_FAILED));
 


### PR DESCRIPTION
Related to #292 
Resolves #288

This adds the `Metadata` class and applies it to the various methods in `MutableDataService`.

The `Binary` class is renamed to `BinaryMetadata`

The third commit renames `Resource::getBinary` to `Resource::getBinaryMetadata`, which I can remove if necessary, but that change provides better symmetry, as the method now returns an `Optional<BinaryMetadata>` object.