### PR TITLE
Fetch LDP-NR descriptions for tests

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/CommonTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/CommonTests.java
@@ -23,11 +23,13 @@ import static org.trellisldp.api.TrellisUtils.getInstance;
 import static org.trellisldp.test.TestUtils.getLinks;
 import static org.trellisldp.test.TestUtils.hasType;
 
+import java.net.URI;
 import java.util.stream.Stream;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -74,6 +76,18 @@ public interface CommonTests {
      */
     default WebTarget target(final String url) {
         return getClient().target(url);
+    }
+
+    /**
+     * Get the describedby Link value, if one exists.
+     * @param url the URL
+     * @return the location of a description resource, or null if none is available
+     */
+    default String getDescription(final String url) {
+        try (final Response res = target(url).request().head()) {
+            return getLinks(res).stream().filter(link -> "describedby".equals(link.getRel()))
+                .map(Link::getUri).map(URI::toString).findFirst().orElse(null);
+        }
     }
 
     /**

--- a/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
@@ -19,6 +19,7 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.Duration.TWO_SECONDS;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -173,7 +174,8 @@ public interface LdpBinaryTests extends CommonTests {
             descriptionETag = res.getEntityTag();
             assertTrue(descriptionETag.isWeak(), "Check for a weak ETag");
         }
-
+        // wait for enough time so that the ETags will surely be different
+        await().pollDelay(TWO_SECONDS).until(() -> true);
         // Patch the description
         try (final Response res = target(descriptionLocation).request().method("PATCH",
                     entity("INSERT { <> <http://purl.org/dc/terms/title> \"Title\" } WHERE {}",

--- a/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
@@ -13,6 +13,7 @@
  */
 package org.trellisldp.test;
 
+import static java.util.Objects.isNull;
 import static javax.ws.rs.client.Entity.entity;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
@@ -24,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.trellisldp.api.TrellisUtils.getInstance;
 import static org.trellisldp.http.core.HttpConstants.DIGEST;
@@ -157,8 +159,14 @@ public interface LdpBinaryTests extends CommonTests {
         final EntityTag descriptionETag;
         final Long size;
 
+        // Discover the location of the description
+        final String descriptionLocation = getDescription(getResourceLocation());
+        if (isNull(descriptionLocation)) {
+            fail("No describedby Link header!");
+        }
+
         // Fetch the description
-        try (final Response res = target(getResourceLocation()).request().accept("text/turtle").get()) {
+        try (final Response res = target(descriptionLocation).request().accept("text/turtle").get()) {
             assertAll("Check an LDP-NR description", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             size = g.size();
@@ -167,16 +175,16 @@ public interface LdpBinaryTests extends CommonTests {
         }
 
         // Patch the description
-        try (final Response res = target(getResourceLocation()).request().method("PATCH",
+        try (final Response res = target(descriptionLocation).request().method("PATCH",
                     entity("INSERT { <> <http://purl.org/dc/terms/title> \"Title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE))) {
             assertAll("Check PATCHing LDP-NR description", checkRdfResponse(res, LDP.RDFSource, null));
         }
 
-        await().until(() -> !descriptionETag.equals(getETag(getResourceLocation())));
+        await().until(() -> !descriptionETag.equals(getETag(descriptionLocation)));
 
         // Fetch the new description
-        try (final Response res = target(getResourceLocation()).request().accept("text/turtle").get()) {
+        try (final Response res = target(descriptionLocation).request().accept("text/turtle").get()) {
             assertAll("Check the new LDP-NR description", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             assertTrue(g.size() > size, "Check the graph size is greater than " + size);

--- a/components/test/src/main/java/org/trellisldp/test/MementoBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoBinaryTests.java
@@ -13,10 +13,12 @@
  */
 package org.trellisldp.test;
 
+import static java.util.Objects.isNull;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.trellisldp.test.TestUtils.getLinks;
 import static org.trellisldp.test.TestUtils.readEntityAsString;
@@ -60,7 +62,7 @@ public interface MementoBinaryTests extends MementoResourceTests {
     @DisplayName("Test the link canonical header")
     default void testCanonicalHeader() {
         getMementos().forEach((memento, date) -> {
-            try (final Response res = target(memento).request().get()) {
+            try (final Response res = target(memento).request().head()) {
                 assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a valid response");
                 assertTrue(getLinks(res).stream().filter(link -> link.getRel().equals("canonical"))
                         .anyMatch(link -> link.getUri().toString().equals(memento)),
@@ -79,7 +81,11 @@ public interface MementoBinaryTests extends MementoResourceTests {
     @DisplayName("Test the link canonical header")
     default void testCanonicalHeaderDescriptions() {
         getMementos().forEach((memento, date) -> {
-            try (final Response res = target(memento).request().accept("text/turtle").get()) {
+            final String description = getDescription(memento);
+            if (isNull(description)) {
+                fail("Could not find description link header!");
+            }
+            try (final Response res = target(description).request().accept("text/turtle").head()) {
                 assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a valid response");
                 assertTrue(getLinks(res).stream().filter(link -> link.getRel().equals("canonical"))
                         .anyMatch(link -> link.getUri().toString().equals(memento + "&ext=description")),

--- a/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
@@ -101,16 +101,21 @@ public interface MementoResourceTests extends MementoCommonTests {
     @DisplayName("Test the presence of a datetime header for each memento")
     default void testMementoAcceptDateTimeHeader() {
         getMementos().forEach((memento, date) -> {
-            try (final Response res1 = target(getResourceLocation()).request().header(ACCEPT_DATETIME, date).head()) {
-                assertEquals(REDIRECTION, res1.getStatusInfo().getFamily(), "Check for a redirection to the memento");
-                final String location = res1.getLocation().toString();
-                try (final Response res2 = target(location).request().header(ACCEPT_DATETIME, date).head()) {
-                    assertEquals(SUCCESSFUL, res2.getStatusInfo().getFamily(),
-                                    "Check for a successful memento request");
-                    final ZonedDateTime zdt = ZonedDateTime.parse(date, RFC_1123_DATE_TIME);
-                    assertEquals(zdt, ZonedDateTime.parse(res2.getHeaderString(MEMENTO_DATETIME), RFC_1123_DATE_TIME),
-                                    "Check that the memento-datetime header is correct");
+            final String location;
+            try (final Response res = target(getResourceLocation()).request().header(ACCEPT_DATETIME, date).head()) {
+                if (REDIRECTION.equals(res.getStatusInfo().getFamily())) {
+                    location = res.getLocation().toString();
+                } else {
+                    location = getResourceLocation();
                 }
+            }
+
+            try (final Response res = target(location).request().header(ACCEPT_DATETIME, date).head()) {
+                assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(),
+                                "Check for a successful memento request");
+                final ZonedDateTime zdt = ZonedDateTime.parse(date, RFC_1123_DATE_TIME);
+                assertEquals(zdt, ZonedDateTime.parse(res.getHeaderString(MEMENTO_DATETIME), RFC_1123_DATE_TIME),
+                                "Check that the memento-datetime header is correct");
             }
         });
     }

--- a/components/test/src/main/java/org/trellisldp/test/MementoTimeGateTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoTimeGateTests.java
@@ -106,9 +106,17 @@ public interface MementoTimeGateTests extends MementoCommonTests {
     @Test
     @DisplayName("Test normal redirection of a timegate request")
     default void testTimeGateRedirected() {
-        final Instant time = now();
-        try (final Response res = target(getResourceLocation()).request()
-                .header(ACCEPT_DATETIME, RFC_1123_DATE_TIME.withZone(UTC).format(time)).get()) {
+        final String date = RFC_1123_DATE_TIME.withZone(UTC).format(now());
+        final String location;
+        try (final Response res = target(getResourceLocation()).request().header(ACCEPT_DATETIME, date).head()) {
+            if (REDIRECTION.equals(res.getStatusInfo().getFamily())) {
+                location = res.getLocation().toString();
+            } else {
+                location = getResourceLocation();
+            }
+        }
+
+        try (final Response res = target(location).request().header(ACCEPT_DATETIME, date).head()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a valid response");
             assertNotNull(res.getHeaderString(MEMENTO_DATETIME), "Check for a Memento-Datetime header");
         }

--- a/platform/webapp/src/test/java/org/trellisldp/webapp/TrellisApplicationTest.java
+++ b/platform/webapp/src/test/java/org/trellisldp/webapp/TrellisApplicationTest.java
@@ -14,6 +14,8 @@
 package org.trellisldp.webapp;
 
 import static java.util.Collections.singleton;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.awaitility.Awaitility.setDefaultPollInterval;
 import static org.glassfish.jersey.client.ClientProperties.CONNECT_TIMEOUT;
 import static org.glassfish.jersey.client.ClientProperties.READ_TIMEOUT;
 import static org.glassfish.jersey.client.HttpUrlConnectorProvider.SET_METHOD_WORKAROUND;
@@ -59,6 +61,7 @@ public class TrellisApplicationTest extends JerseyTest {
     @BeforeAll
     public void before() throws Exception {
         super.setUp();
+        setDefaultPollInterval(100L, MILLISECONDS);
     }
 
     @AfterAll


### PR DESCRIPTION
Resolves #283 

This updates the test code to explicitly fetch LDP-NR descriptions when RDF is being requested.