### PR TITLE
Simplify BinaryService::setContent method

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -43,7 +43,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.security.MessageDigest;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -55,6 +54,7 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.slf4j.Logger;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.DefaultIdentifierService;
 import org.trellisldp.api.IdentifierService;
@@ -181,18 +181,17 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public CompletableFuture<Void> setContent(final IRI identifier, final InputStream stream,
-            final Map<String, String> metadata) {
+    public CompletableFuture<Void> setContent(final BinaryMetadata metadata, final InputStream stream) {
         requireNonNull(stream, "InputStream may not be null!");
         return supplyAsync(() -> {
-            final File file = getFileFromIdentifier(identifier);
-            LOGGER.debug("Setting binary content for {} at {}", identifier.getIRIString(), file.getAbsolutePath());
+            final File file = getFileFromIdentifier(metadata.getIdentifier());
+            LOGGER.debug("Setting binary content for {} at {}", metadata.getIdentifier(), file.getAbsolutePath());
             try (final InputStream input = stream) {
                 final File parent = file.getParentFile();
                 parent.mkdirs();
                 copy(stream, file.toPath(), REPLACE_EXISTING);
             } catch (final IOException ex) {
-                throw new UncheckedIOException("Error while setting content for " + identifier, ex);
+                throw new UncheckedIOException("Error while setting content for " + metadata.getIdentifier(), ex);
             }
             return null;
         });

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.BinaryService;
 
 /**
@@ -73,7 +74,8 @@ public class FileBinaryServiceTest {
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         final InputStream inputStream = new ByteArrayInputStream("Some data".getBytes(UTF_8));
-        assertNull(service.setContent(fileIRI, inputStream).join(), "setContent didn't complete cleanly!");
+        assertNull(service.setContent(BinaryMetadata.builder(fileIRI).build(), inputStream).join(),
+                "setContent didn't complete cleanly!");
         assertEquals("Some data", uncheckedToString(service.getContent(fileIRI).join()),
                 "incorrect value for getContent!");
         assertNull(service.purgeContent(fileIRI).join(), "purgeContent didn't complete cleanly!");
@@ -116,7 +118,8 @@ public class FileBinaryServiceTest {
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         final InputStream inputStream = new ByteArrayInputStream(contents.getBytes(UTF_8));
-        assertNull(service.setContent(fileIRI, inputStream).join(), "Setting content didn't complete cleanly!");
+        assertNull(service.setContent(BinaryMetadata.builder(fileIRI).build(), inputStream).join(),
+                "Setting content didn't complete cleanly!");
         assertEquals(contents, service.getContent(fileIRI).thenApply(this::uncheckedToString).join(),
                 "Fetching new content returned incorrect value!");
     }
@@ -144,7 +147,8 @@ public class FileBinaryServiceTest {
         });
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
-        assertAll(() -> service.setContent(fileIRI, throwingMockInputStream).handle((val, err) -> {
+        assertAll(() -> service.setContent(BinaryMetadata.builder(fileIRI).build(), throwingMockInputStream)
+            .handle((val, err) -> {
                 assertNotNull(err, "There should have been an error with the input stream!");
                 return null;
             }).join());

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -13,10 +13,7 @@
  */
 package org.trellisldp.api;
 
-import static java.util.Collections.emptyMap;
-
 import java.io.InputStream;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -51,26 +48,11 @@ public interface BinaryService {
     /**
      * Set the content for a binary object.
      *
-     * @param identifier the binary object identifier
+     * @param metadata the binary metadata
      * @param stream the content
      * @return the new completion stage
      */
-    default CompletableFuture<Void> setContent(IRI identifier, InputStream stream) {
-        return setContent(identifier, stream, emptyMap());
-    }
-
-    /**
-     * Set the content for a binary object.
-     *
-     * @param identifier the binary object identifier
-     * @param stream the content
-     * @param metadata any user metadata
-     * @return a new completion stage that, when the stage completes normally, indicates that the binary
-     * data were successfully stored in the corresponding persistence layer. In the case of an unsuccessful
-     * operation, the {@link CompletableFuture} will complete exceptionally and can be handled with
-     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
-     */
-    CompletableFuture<Void> setContent(IRI identifier, InputStream stream, Map<String, String> metadata);
+    CompletableFuture<Void> setContent(BinaryMetadata metadata, InputStream stream);
 
     /**
      * Purge the content from its corresponding datastore.

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -14,13 +14,10 @@
 package org.trellisldp.api;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -54,17 +51,6 @@ public class BinaryServiceTest {
     @BeforeEach
     public void setUp() {
         initMocks(this);
-        doCallRealMethod().when(mockBinaryService).setContent(any(), any());
-    }
-
-    @Test
-    public void testDefaultMethods() {
-        when(mockBinaryService.getContent(any())).thenReturn(completedFuture(mockInputStream));
-        mockBinaryService.setContent(identifier, mockInputStream);
-        verify(mockBinaryService).setContent(eq(identifier), eq(mockInputStream),
-                eq(emptyMap()));
-        assertEquals(mockInputStream, mockBinaryService.getContent(identifier).join(),
-                "getContent returns wrong input stream");
     }
 
     @Test

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -20,8 +20,6 @@ import static java.util.Optional.ofNullable;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.status;
 import static org.apache.commons.codec.digest.DigestUtils.getDigest;
@@ -37,8 +35,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.Principal;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -272,13 +268,10 @@ class MutatingLdpHandler extends BaseLdpHandler {
         }
     }
 
-    protected CompletableFuture<Void> persistContent(final IRI contentLocation, final BinaryMetadata metadata) {
-        final Map<String, String> md = new HashMap<>();
-        metadata.getSize().ifPresent(size -> md.put(CONTENT_LENGTH, size.toString()));
-        metadata.getMimeType().ifPresent(mimeType -> md.put(CONTENT_TYPE, mimeType));
+    protected CompletableFuture<Void> persistContent(final BinaryMetadata metadata) {
         try {
             final InputStream input = new FileInputStream(entity);
-            return getServices().getBinaryService().setContent(contentLocation, input, md)
+            return getServices().getBinaryService().setContent(metadata, input)
                 .whenComplete(HttpUtils.closeInputStreamAsync(input));
         } catch (final IOException ex) {
             throw new WebApplicationException("Error saving binary content: " + ex.getMessage());

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -179,7 +179,7 @@ public class PostHandler extends MutatingLdpHandler {
             // Persist the content
             final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType(mimeType)
                 .size(getEntityLength()).build();
-            persistPromise = persistContent(binaryLocation, binary).thenAccept(future ->
+            persistPromise = persistContent(binary).thenAccept(future ->
                 LOGGER.debug("Successfully persisted bitstream with content type {} to {}", mimeType, binaryLocation));
 
             metadata = metadataBuilder(internalId, ldpType, mutable).container(parentIdentifier).binary(binary);

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -201,7 +201,7 @@ public class PutHandler extends MutatingLdpHandler {
             // Persist the content
             final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType(mimeType)
                 .size(getEntityLength()).build();
-            persistPromise = persistContent(binaryLocation, binary).thenAccept(future ->
+            persistPromise = persistContent(binary).thenAccept(future ->
                 LOGGER.debug("Successfully persisted bitstream with content type {} to {}", mimeType, binaryLocation));
 
             metadata = metadataBuilder(internalId, ldpType, mutable).binary(binary);

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -273,7 +273,7 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
             .thenAnswer(x -> completedFuture(new ByteArrayInputStream("e input".getBytes(UTF_8))));
         when(mockBinaryService.getContent(eq(binaryInternalIdentifier)))
             .thenAnswer(x -> completedFuture(new ByteArrayInputStream("Some input stream".getBytes(UTF_8))));
-        when(mockBinaryService.setContent(any(IRI.class), any(InputStream.class), any()))
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
             .thenAnswer(x -> completedFuture(null));
         when(mockBinaryService.generateIdentifier()).thenReturn(RANDOM_VALUE);
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -55,7 +55,6 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -84,6 +83,7 @@ import org.mockito.Mock;
 import org.trellisldp.agent.SimpleAgentService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
+import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
@@ -149,7 +149,7 @@ abstract class BaseTestHandler {
     protected ArgumentCaptor<IRI> iriArgument;
 
     @Captor
-    protected ArgumentCaptor<Map<String, String>> metadataArgument;
+    protected ArgumentCaptor<BinaryMetadata> metadataArgument;
 
     @BeforeEach
     public void setUp() {
@@ -247,7 +247,7 @@ abstract class BaseTestHandler {
             .thenAnswer(x -> completedFuture(new ByteArrayInputStream("e input".getBytes(UTF_8))));
         when(mockBinaryService.getContent(any(IRI.class)))
             .thenAnswer(x -> completedFuture(new ByteArrayInputStream("Some input stream".getBytes(UTF_8))));
-        when(mockBinaryService.setContent(any(IRI.class), any(InputStream.class), any()))
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
             .thenAnswer(x -> completedFuture(null));
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -112,7 +112,7 @@ public class PutHandlerTest extends BaseTestHandler {
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response type");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.RDFSource));
 
-        verify(mockBinaryService, never()).setContent(any(IRI.class), any(InputStream.class));
+        verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class));
         verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + "resource"));
     }
 
@@ -128,7 +128,7 @@ public class PutHandlerTest extends BaseTestHandler {
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.Container));
 
-        verify(mockBinaryService, never()).setContent(any(IRI.class), any(InputStream.class));
+        verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class));
         verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + "resource"));
     }
 
@@ -307,7 +307,7 @@ public class PutHandlerTest extends BaseTestHandler {
         return Stream.of(
                 () -> assertAll("Check LDP type Link headers", checkLdpType(res, LDP.RDFSource)),
                 () -> verify(mockBinaryService, never().description("Binary service shouldn't have been called!"))
-                             .setContent(any(IRI.class), any(InputStream.class)),
+                             .setContent(any(BinaryMetadata.class), any(InputStream.class)),
                 () -> verify(mockIoService, description("IOService should have been called with an RDF resource"))
                              .read(any(InputStream.class), any(RDFSyntax.class), anyString()));
     }
@@ -316,7 +316,7 @@ public class PutHandlerTest extends BaseTestHandler {
         return Stream.of(
                 () -> assertAll("Check LDP type Link headers", checkLdpType(res, LDP.NonRDFSource)),
                 () -> verify(mockBinaryService, description("BinaryService should have been called to set content!"))
-                            .setContent(any(IRI.class), any(InputStream.class), any()),
+                            .setContent(any(BinaryMetadata.class), any(InputStream.class)),
                 () -> verify(mockIoService, never().description("IOService shouldn't have been called with a Binary!"))
                             .read(any(InputStream.class), any(RDFSyntax.class), anyString()));
     }


### PR DESCRIPTION
Resolves #305 

Note: this does not resolve the `File` buffering issue mentioned in #305; that will be addressed separately.