### PR TITLE
Open BinaryService return type

### DIFF
--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -34,7 +34,7 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @return the new completion stage with the binary content
      */
     @Override
-    CompletableFuture<Binary> get(IRI identifier);
+    CompletableFuture<? extends Binary> get(IRI identifier);
 
     /**
      * Set the content for a binary object.


### PR DESCRIPTION
I'd like to be able to return a `CompletableFuture<MyImplResource>` from `get` to reuse inside my impl.