### PR TITLE
Change Memento URL granularity to a second

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/core/Version.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Version.java
@@ -14,7 +14,7 @@
 package org.trellisldp.http.core;
 
 import static java.lang.Long.parseLong;
-import static java.time.Instant.ofEpochMilli;
+import static java.time.Instant.ofEpochSecond;
 import static java.util.Objects.nonNull;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -62,7 +62,7 @@ public class Version {
     private static Optional<Instant> parse(final String version) {
         if (nonNull(version)) {
             try {
-                return of(ofEpochMilli(parseLong(version.trim())));
+                return of(ofEpochSecond(parseLong(version.trim())));
             } catch (final NumberFormatException ex) {
                 LOGGER.warn("Unable to parse version string '{}': {}", version, ex.getMessage());
             }

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -256,7 +256,7 @@ public class GetHandler extends BaseLdpHandler {
         if (nonNull(getRequest().getVersion()) || nonNull(getRequest().getExt())) {
             final List<String> query = new ArrayList<>();
 
-            ofNullable(getRequest().getVersion()).map(Version::getInstant).map(Instant::toEpochMilli)
+            ofNullable(getRequest().getVersion()).map(Version::getInstant).map(Instant::getEpochSecond)
                 .map(x -> "version=" + x).ifPresent(query::add);
 
             if (ACL.equals(getRequest().getExt())) {
@@ -272,7 +272,7 @@ public class GetHandler extends BaseLdpHandler {
     private String getBaseBinaryIdentifier() {
         // Add the version parameter, if present
         return getIdentifier() + ofNullable(getRequest().getVersion()).map(Version::getInstant)
-            .map(Instant::toEpochMilli).map(x -> "?version=" + x).orElse("");
+            .map(Instant::getEpochSecond).map(x -> "?version=" + x).orElse("");
     }
 
     private void addAllowHeaders(final ResponseBuilder builder) {

--- a/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
@@ -148,7 +148,7 @@ public final class MementoResource {
             final String baseUrl) {
         final String identifier = getBaseUrl(baseUrl, req) + req.getPath();
         return status(FOUND)
-            .location(fromUri(identifier + "?version=" + req.getDatetime().getInstant().toEpochMilli()).build())
+            .location(fromUri(identifier + "?version=" + req.getDatetime().getInstant().getEpochSecond()).build())
             .link(identifier, ORIGINAL + " " + TIMEGATE)
             .links(getMementoLinks(identifier, mementos).map(MementoResource::filterLinkParams).toArray(Link[]::new))
             .header(VARY, ACCEPT_DATETIME);
@@ -209,7 +209,7 @@ public final class MementoResource {
 
     private static Function<Instant, Link> mementoToLink(final String identifier) {
         return time ->
-            Link.fromUri(identifier + "?version=" + time.toEpochMilli()).rel(MEMENTO)
+            Link.fromUri(identifier + "?version=" + time.getEpochSecond()).rel(MEMENTO)
                 .param(DATETIME, ofInstant(time.truncatedTo(SECONDS), UTC)
                         .format(RFC_1123_DATE_TIME)).build();
     }

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -247,7 +247,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
                 "Incorrect Memento-Datetime value!");
         assertTrue(getLinks(res).stream().anyMatch(hasLink(rdf.createIRI(HUB), "hub")), "Missing rel=hub header!");
         assertTrue(getLinks(res).stream().anyMatch(hasLink(rdf.createIRI(getBaseUrl() + RESOURCE_PATH
-                                    + "?version=1496262729000"), "self")), "Missing rel=self header!");
+                                    + "?version=1496262729"), "self")), "Missing rel=self header!");
         assertFalse(getLinks(res).stream().anyMatch(hasLink(rdf.createIRI(getBaseUrl() + RESOURCE_PATH), "self")),
                 "Unexpected versionless rel=self header");
         assertNotNull(res.getHeaderString(MEMENTO_DATETIME), "Missing Memento-Datetime header!");
@@ -370,7 +370,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     public void testGetVersionNotFound() {
-        final Response res = target(NON_EXISTENT_PATH).queryParam("version", "1496260729000").request().get();
+        final Response res = target(NON_EXISTENT_PATH).queryParam("version", "1496260729").request().get();
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
@@ -637,13 +637,13 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
                     x.containsKey("hasEnd")),
                 "Missing hasBeginning/hasEnd properties in timemap graph!");
         assertTrue(graph.stream().anyMatch(x -> x.containsKey("@id") &&
-                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496260729000") &&
+                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496260729") &&
                     x.containsKey("hasTime")), "Missing hasTime property in timemap graph for version 1!");
         assertTrue(graph.stream().anyMatch(x -> x.containsKey("@id") &&
-                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496261729000") &&
+                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496261729") &&
                     x.containsKey("hasTime")), "Missing hasTime property in timemap graph for version 2!");
         assertTrue(graph.stream().anyMatch(x -> x.containsKey("@id") &&
-                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496262729000") &&
+                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496262729") &&
                     x.containsKey("hasTime")), "Missign hasTime property in timemap graph for version 3!");
     }
 
@@ -680,15 +680,15 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
                     x.containsKey("http://www.w3.org/2006/time#hasEnd")),
                 "Missing hasBeginning/hasEnd properties in expanded JSON-LD!");
         assertTrue(obj.stream().anyMatch(x -> x.containsKey("@id") &&
-                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496260729000") &&
+                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496260729") &&
                     x.containsKey("http://www.w3.org/2006/time#hasTime")),
                 "Missing hasTime property in first memento!");
         assertTrue(obj.stream().anyMatch(x -> x.containsKey("@id") &&
-                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496261729000") &&
+                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496261729") &&
                     x.containsKey("http://www.w3.org/2006/time#hasTime")),
                 "Missing hasTime property in second memento!");
         assertTrue(obj.stream().anyMatch(x -> x.containsKey("@id") &&
-                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496262729000") &&
+                    x.get("@id").equals(getBaseUrl() + RESOURCE_PATH + "?version=1496262729") &&
                     x.containsKey("http://www.w3.org/2006/time#hasTime")),
                 "Missing hasTime property in third memento!");
     }
@@ -897,7 +897,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     public void testOptionsVersionNotFound() {
-        final Response res = target(NON_EXISTENT_PATH).queryParam("version", "1496260729000").request().options();
+        final Response res = target(NON_EXISTENT_PATH).queryParam("version", "1496260729").request().options();
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
@@ -2276,16 +2276,16 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
                 () -> assertTrue(links.stream().anyMatch(l -> l.getRels().contains("memento") &&
                     RFC_1123_DATE_TIME.withZone(UTC).format(ofEpochSecond(timestamp - 2000))
                         .equals(l.getParams().get("datetime")) &&
-                    l.getUri().toString().equals(getBaseUrl() + path + "?version=1496260729000")),
+                    l.getUri().toString().equals(getBaseUrl() + path + "?version=1496260729")),
                                  "Missing expected first rel=memento Link!"),
                 () -> assertTrue(links.stream().anyMatch(l -> l.getRels().contains("memento") &&
                     RFC_1123_DATE_TIME.withZone(UTC).format(ofEpochSecond(timestamp - 1000))
                         .equals(l.getParams().get("datetime")) &&
-                    l.getUri().toString().equals(getBaseUrl() + path + "?version=1496261729000")),
+                    l.getUri().toString().equals(getBaseUrl() + path + "?version=1496261729")),
                                  "Missing expected second rel=memento Link!"),
                 () -> assertTrue(links.stream().anyMatch(l -> l.getRels().contains("memento") &&
                     RFC_1123_DATE_TIME.withZone(UTC).format(time).equals(l.getParams().get("datetime")) &&
-                    l.getUri().toString().equals(getBaseUrl() + path + "?version=1496262729000")),
+                    l.getUri().toString().equals(getBaseUrl() + path + "?version=1496262729")),
                                  "Missing expected third rel=memento Link!"),
                 () -> assertTrue(links.stream().anyMatch(l -> l.getRels().contains("timemap") &&
                     RFC_1123_DATE_TIME.withZone(UTC).format(ofEpochSecond(timestamp - 2000))

--- a/core/http/src/test/java/org/trellisldp/http/core/VersionTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/VersionTest.java
@@ -25,9 +25,9 @@ public class VersionTest {
 
     @Test
     public void testVersion() {
-        final Version v = Version.valueOf("1493646202676");
-        assertEquals("2017-05-01T13:43:22.676Z", v.getInstant().toString(), "Check datetime string");
-        assertEquals("2017-05-01T13:43:22.676Z", v.toString(), "Check stringified version");
+        final Version v = Version.valueOf("1493646202");
+        assertEquals("2017-05-01T13:43:22Z", v.getInstant().toString(), "Check datetime string");
+        assertEquals("2017-05-01T13:43:22Z", v.toString(), "Check stringified version");
     }
 
     @Test


### PR DESCRIPTION
Resolves #299

This changes the URLs for Memento resources to have second-level
precision rather than millisecond precision. Because Memento datetime
negotiation is limited to second precision, it makes little sense to
allow more precise notation. Plus, the millisecond precision seemed to result in problems with conversions to RFC 1123 dates.