### PR TITLE
Move incoming binary digest handling to BinaryService

### DIFF
--- a/core/api/build.gradle
+++ b/core/api/build.gradle
@@ -11,14 +11,13 @@ dependencies {
     api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
     api("javax.enterprise:cdi-api:${cdiApiVersion}")
 
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
-
     testImplementation("commons-io:commons-io:$commonsIoVersion")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
     testImplementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion")
     testImplementation("org.apache.commons:commons-text:$commonsTextVersion")
     testImplementation("org.apache.jena:jena-osgi:$jenaVersion")
     testImplementation("org.apache.commons:commons-compress:$commonsCompressVersion")
+    testImplementation("org.slf4j:slf4j-api:$slf4jVersion")
     testImplementation project(':trellis-vocabulary')
 }
 

--- a/core/api/build.gradle
+++ b/core/api/build.gradle
@@ -11,13 +11,15 @@ dependencies {
     api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
     api("javax.enterprise:cdi-api:${cdiApiVersion}")
 
-    testImplementation project(':trellis-vocabulary')
+    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+
     testImplementation("commons-io:commons-io:$commonsIoVersion")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
     testImplementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion")
     testImplementation("org.apache.commons:commons-text:$commonsTextVersion")
     testImplementation("org.apache.jena:jena-osgi:$jenaVersion")
     testImplementation("org.apache.commons:commons-compress:$commonsCompressVersion")
+    testImplementation project(':trellis-vocabulary')
 }
 
 jar {

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -16,7 +16,6 @@ package org.trellisldp.api;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -49,14 +48,9 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @return the new completion stage containing the server-computed digest.
      */
     default CompletableFuture<byte[]> setContent(final BinaryMetadata metadata, final InputStream stream,
-            final String algorithm) {
-        try {
-            final DigestInputStream input = new DigestInputStream(stream, MessageDigest.getInstance(algorithm));
-            return setContent(metadata, input)
-                .thenApply(future -> input.getMessageDigest().digest());
-        } catch (final NoSuchAlgorithmException ex) {
-            throw new IllegalArgumentException("Invalid message digest", ex);
-        }
+            final MessageDigest algorithm) {
+        final DigestInputStream input = new DigestInputStream(stream, algorithm);
+        return setContent(metadata, input).thenApply(future -> input.getMessageDigest().digest());
     }
 
     /**
@@ -79,7 +73,7 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param algorithm the algorithm
      * @return the new completion stage containing a computed digest for the binary resource
      */
-    CompletableFuture<String> calculateDigest(IRI identifier, String algorithm);
+    CompletableFuture<byte[]> calculateDigest(IRI identifier, MessageDigest algorithm);
 
     /**
      * Get a list of supported algorithms.

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -344,8 +344,9 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinaryDigestError() throws IOException {
-        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("MD5"))).thenAnswer(inv ->
+    public void testGetBinaryDigestError() throws Exception {
+        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("MD5")))
+            .thenAnswer(inv ->
                 supplyAsync(() -> {
                     throw new RuntimeTrellisException("Expected exception");
                 }));

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -101,6 +101,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -304,7 +305,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         final Response res = target(BINARY_PATH).request().header(WANT_DIGEST, "MD5").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
-        assertEquals("md5=md5-digest", res.getHeaderString(DIGEST), "Incorrect Digest header value!");
+        assertEquals("md5=Q29tcHV0ZWREaWdlc3Q=", res.getHeaderString(DIGEST), "Incorrect Digest header value!");
         assertAll("Check Binary response", checkBinaryResponse(res));
 
         final String entity = IOUtils.toString((InputStream) res.getEntity(), UTF_8);
@@ -316,7 +317,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         final Response res = target(BINARY_PATH).request().header(WANT_DIGEST, "SHA").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
-        assertEquals("sha=sha1-digest", res.getHeaderString(DIGEST), "Incorrect Digest header value!");
+        assertEquals("sha=Q29tcHV0ZWREaWdlc3Q=", res.getHeaderString(DIGEST), "Incorrect Digest header value!");
         assertAll("Check Binary response", checkBinaryResponse(res));
 
         final String entity = IOUtils.toString((InputStream) res.getEntity(), UTF_8);
@@ -345,7 +346,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     public void testGetBinaryDigestError() throws Exception {
-        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("MD5")))
+        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), any(MessageDigest.class)))
             .thenAnswer(inv ->
                 supplyAsync(() -> {
                     throw new RuntimeTrellisException("Expected exception");

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -27,6 +27,7 @@ import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
@@ -186,7 +187,7 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     }
 
     @BeforeEach
-    public void setUpMocks() {
+    public void setUpMocks() throws Exception {
         setUpBundler();
         setUpResourceService();
         setUpMementoService();
@@ -268,11 +269,13 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         when(mockMementoService.put(any())).thenReturn(completedFuture(null));
     }
 
-    private void setUpBinaryService() {
-        when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA")));
+    private void setUpBinaryService() throws Exception {
+        when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA-1", "SHA")));
         when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("MD5")))
             .thenReturn(completedFuture("md5-digest"));
         when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("SHA")))
+            .thenReturn(completedFuture("sha1-digest"));
+        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("SHA-1")))
             .thenReturn(completedFuture("sha1-digest"));
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent(eq(3), eq(10))).thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
@@ -284,6 +287,7 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
             });
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));
         when(mockBinaryService.generateIdentifier()).thenReturn(RANDOM_VALUE);
+        doCallRealMethod().when(mockBinaryService).setContent(any(BinaryMetadata.class), any(InputStream.class), any());
     }
 
     private void setUpResources() {

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.MAX;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Arrays.asList;
+import static java.util.Base64.getDecoder;
 import static java.util.Collections.emptySortedSet;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -43,6 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
@@ -271,12 +273,8 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
 
     private void setUpBinaryService() throws Exception {
         when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA-1", "SHA")));
-        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("MD5")))
-            .thenReturn(completedFuture("md5-digest"));
-        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("SHA")))
-            .thenReturn(completedFuture("sha1-digest"));
-        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), eq("SHA-1")))
-            .thenReturn(completedFuture("sha1-digest"));
+        when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), any(MessageDigest.class)))
+            .thenReturn(completedFuture(getDecoder().decode("Q29tcHV0ZWREaWdlc3Q=")));
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent(eq(3), eq(10))).thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
         when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceForbiddenTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceForbiddenTest.java
@@ -72,7 +72,7 @@ public class TrellisHttpResourceForbiddenTest extends BaseTrellisHttpResourceTes
     }
 
     @BeforeEach
-    public void setUpMocks() {
+    public void setUpMocks() throws Exception {
         super.setUpMocks();
         when(mockResourceService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockResource));
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUnauthorizedTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUnauthorizedTest.java
@@ -78,7 +78,7 @@ public class TrellisHttpResourceUnauthorizedTest extends BaseTrellisHttpResource
     }
 
     @BeforeEach
-    public void setUpMocks() {
+    public void setUpMocks() throws Exception {
         super.setUpMocks();
         when(mockResourceService.get(any(IRI.class))).thenAnswer(inv -> of(mockResource));
         when(mockAccessControlService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -54,6 +54,7 @@ import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE_TYPE;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
@@ -247,10 +248,8 @@ abstract class BaseTestHandler {
         when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
         when(mockBinaryService.generateIdentifier()).thenReturn("file:///" + randomUUID());
         when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA-1")));
-        when(mockBinaryService.calculateDigest(any(IRI.class), eq("MD5")))
-            .thenReturn(completedFuture("md5-digest"));
-        when(mockBinaryService.calculateDigest(any(IRI.class), eq("SHA-1")))
-            .thenReturn(completedFuture("sha1-digest"));
+        when(mockBinaryService.calculateDigest(any(IRI.class), any(MessageDigest.class)))
+            .thenReturn(completedFuture("computed-digest".getBytes()));
         when(mockBinaryService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));
         when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Syntax.SPARQL_UPDATE;
@@ -157,7 +158,7 @@ abstract class BaseTestHandler {
     protected ArgumentCaptor<BinaryMetadata> metadataArgument;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
         initMocks(this);
 
         setUpBundler();
@@ -241,13 +242,15 @@ abstract class BaseTestHandler {
         when(mockResourceService.touch(any(IRI.class))).thenReturn(completedFuture(null));
     }
 
-    private void setUpBinaryService() {
+    private void setUpBinaryService() throws Exception {
         when(mockBinary.getContent(eq(3), eq(10))).thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
         when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
         when(mockBinaryService.generateIdentifier()).thenReturn("file:///" + randomUUID());
-        when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA")));
-        when(mockBinaryService.calculateDigest(any(IRI.class), eq("MD5"))).thenReturn(completedFuture("md5-digest"));
-        when(mockBinaryService.calculateDigest(any(IRI.class), eq("SHA"))).thenReturn(completedFuture("sha1-digest"));
+        when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA-1")));
+        when(mockBinaryService.calculateDigest(any(IRI.class), eq("MD5")))
+            .thenReturn(completedFuture("md5-digest"));
+        when(mockBinaryService.calculateDigest(any(IRI.class), eq("SHA-1")))
+            .thenReturn(completedFuture("sha1-digest"));
         when(mockBinaryService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));
         when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
@@ -255,6 +258,7 @@ abstract class BaseTestHandler {
                 readLines((InputStream) inv.getArguments()[1], UTF_8);
                 return completedFuture(null);
             });
+        doCallRealMethod().when(mockBinaryService).setContent(any(BinaryMetadata.class), any(InputStream.class), any());
     }
 
     private void setUpBundler() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -240,11 +240,8 @@ public class PostHandlerTest extends BaseTestHandler {
 
         final PostHandler handler = buildPostHandler("/simpleData.txt", "bad-digest", null);
 
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
-                .thenApply(ResponseBuilder::build)
-                .exceptionally(err -> of(err).map(Throwable::getCause).filter(WebApplicationException.class::isInstance)
-                    .map(WebApplicationException.class::cast).orElseGet(() -> new WebApplicationException(err))
-                    .getResponse()).join();
+        final Response res = assertThrows(BadRequestException.class, () ->
+                handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))).getResponse();
         assertEquals(BAD_REQUEST, res.getStatusInfo(), "Incorrect response code!");
     }
 


### PR DESCRIPTION
Resolves #316

This moves the processing of incoming binary streams to the
BinaryService by adding an additional BinaryService::setContent method.
This method accepts an additional argument: `algorithm`, and responds
with `CompletableFuture<String>` where that response string is the
value of the computed digest. If the value of that digest is null, one
should take that to mean that the supplied algorithm was not supported.

If the digest value does not match the expected value, it is the
reponsibility of the client code (e.g. in the HTTP layer) to call
BinaryService::purgeContent. A runtime exception, on the other hand,
would indicate a server error.