### PR TITLE
Optimization for MementoService::put operations

### DIFF
--- a/core/api/src/main/java/org/trellisldp/api/MementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MementoService.java
@@ -29,9 +29,24 @@ import org.apache.commons.rdf.api.IRI;
 public interface MementoService {
 
     /**
+     * Create a new Memento for a resource, retrieved from a {@link ResourceService}.
+     * @param resourceService the resource service.
+     * @param identifier the identifier.
+     * @apiNote the default implementation of this method fetches a resource from a {@link ResourceService} that is
+     *          external to the Memento service. In the case that the two services are managed by the same persistence
+     *          layer, it may not be necessary to fetch a {@link Resource} from the persistence layer, in which case
+     *          this method can be overridden as a no-op method, e.g. {@code return completedFuture(null);}.
+     * @return a new completion stage that, when the stage completes normally, indicates that the Memento resource was
+     * successfully created in the corresponding persistence layer.
+     */
+    default CompletableFuture<Void> put(final ResourceService resourceService, final IRI identifier) {
+        return resourceService.get(identifier).thenCompose(this::put);
+    }
+
+    /**
      * Create a new Memento for a resource.
      * @param resource the resource
-     * @return a new completion stage that, when the stage completes normally, indicates that Memento resource was
+     * @return a new completion stage that, when the stage completes normally, indicates that the Memento resource was
      * successfully created in the corresponding persistence layer. In the case of an unsuccessful write operation,
      * the {@link CompletableFuture} will complete exceptionally and can be handled with
      * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.

--- a/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
@@ -29,6 +29,11 @@ import org.apache.commons.rdf.api.IRI;
 public class NoopMementoService implements MementoService {
 
     @Override
+    public CompletableFuture<Void> put(final ResourceService resourceService, final IRI identifier) {
+        return completedFuture(null);
+    }
+
+    @Override
     public CompletableFuture<Void> put(final Resource resource) {
         return completedFuture(null);
     }

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -132,8 +132,7 @@ class MutatingLdpHandler extends BaseLdpHandler {
      * @return a response builder promise
      */
     public CompletableFuture<ResponseBuilder> updateMemento(final ResponseBuilder builder) {
-        return getServices().getResourceService().get(getInternalId())
-            .thenCompose(getServices().getMementoService()::put)
+        return getServices().getMementoService().put(getServices().getResourceService(), getInternalId())
             .exceptionally(ex -> {
                     LOGGER.warn("Unable to store memento for {}: {}", getInternalId(), ex.getMessage());
                     return null;

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -269,6 +269,7 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         when(mockMementoService.mementos(eq(deletedIdentifier))).thenReturn(completedFuture(emptySortedSet()));
         when(mockMementoService.mementos(eq(userDeletedIdentifier))).thenReturn(completedFuture(emptySortedSet()));
         when(mockMementoService.put(any())).thenReturn(completedFuture(null));
+        doCallRealMethod().when(mockMementoService).put(any(ResourceService.class), any(IRI.class));
     }
 
     private void setUpBinaryService() throws Exception {

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.description;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -59,6 +60,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.MementoService;
 import org.trellisldp.api.Metadata;
+import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.vocabulary.LDP;
@@ -258,6 +260,7 @@ public class PutHandlerTest extends BaseTestHandler {
     public void testMementoError() {
         final MementoService mockMementoService = mock(MementoService.class);
         when(mockBundler.getMementoService()).thenReturn(mockMementoService);
+        doCallRealMethod().when(mockMementoService).put(any(ResourceService.class), any(IRI.class));
         when(mockMementoService.put(any())).thenAnswer(inv -> runAsync(() -> {
             throw new RuntimeTrellisException("Expected error");
         }));


### PR DESCRIPTION
Resolves #325

This allows overriding the process by which Resource objects are
fetched from an existing ResourceService before sending to a
MementoService.

This would apply to both no-op MementoService implementations as well
as MementoServices that use the same backend persistence as a
ResourceService.