### PR TITLE
Add hints to the BinaryService layer

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -41,6 +41,8 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.security.MessageDigest;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -157,7 +159,8 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public CompletableFuture<Void> setContent(final BinaryMetadata metadata, final InputStream stream) {
+    public CompletableFuture<Void> setContent(final BinaryMetadata metadata, final InputStream stream,
+            final Map<String, List<String>> headers) {
         requireNonNull(stream, "InputStream may not be null!");
         return supplyAsync(() -> {
             final File file = getFileFromIdentifier(metadata.getIdentifier());

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -15,6 +15,7 @@ package org.trellisldp.file;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Base64.getEncoder;
+import static java.util.Collections.emptyMap;
 import static org.apache.commons.codec.digest.DigestUtils.getDigest;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -85,7 +86,7 @@ public class FileBinaryServiceTest {
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         final InputStream inputStream = new ByteArrayInputStream("Some data".getBytes(UTF_8));
-        assertNull(service.setContent(BinaryMetadata.builder(fileIRI).build(), inputStream).join(),
+        assertNull(service.setContent(BinaryMetadata.builder(fileIRI).build(), inputStream, emptyMap()).join(),
                 "setContent didn't complete cleanly!");
         assertEquals("Some data", uncheckedToString(service.get(fileIRI).thenApply(Binary::getContent).join()),
                         "incorrect value for getContent!");
@@ -138,7 +139,7 @@ public class FileBinaryServiceTest {
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         final InputStream inputStream = new ByteArrayInputStream(contents.getBytes(UTF_8));
-        assertNull(service.setContent(BinaryMetadata.builder(fileIRI).build(), inputStream).join(),
+        assertNull(service.setContent(BinaryMetadata.builder(fileIRI).build(), inputStream, emptyMap()).join(),
                         "Setting content didn't complete cleanly!");
         assertEquals(contents,
                         service.get(fileIRI).thenApply(Binary::getContent).thenApply(this::uncheckedToString).join(),
@@ -162,7 +163,7 @@ public class FileBinaryServiceTest {
         });
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
-        assertAll(() -> service.setContent(BinaryMetadata.builder(fileIRI).build(), throwingMockInputStream)
+        assertAll(() -> service.setContent(BinaryMetadata.builder(fileIRI).build(), throwingMockInputStream, emptyMap())
             .handle((val, err) -> {
                 assertNotNull(err, "There should have been an error with the input stream!");
                 return null;

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -36,10 +36,10 @@ public interface BinaryService extends RetrievalService<Binary> {
      *
      * @param metadata the binary metadata
      * @param stream the content
-     * @param headers HTTP request headers
+     * @param hints any hints for storing the binary data
      * @return the new completion stage
      */
-    CompletableFuture<Void> setContent(BinaryMetadata metadata, InputStream stream, Map<String, List<String>> headers);
+    CompletableFuture<Void> setContent(BinaryMetadata metadata, InputStream stream, Map<String, List<String>> hints);
 
     /**
      * Set the content for a binary object using a digest algorithm.
@@ -48,13 +48,13 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param metadata the binary metadata
      * @param stream the context
      * @param algorithm the digest algorithm
-     * @param headers HTTP request headers
+     * @param hints any hints for storing the binary data
      * @return the new completion stage containing the server-computed digest.
      */
     default CompletableFuture<byte[]> setContent(final BinaryMetadata metadata, final InputStream stream,
-            final MessageDigest algorithm, final Map<String, List<String>> headers) {
+            final MessageDigest algorithm, final Map<String, List<String>> hints) {
         final DigestInputStream input = new DigestInputStream(stream, algorithm);
-        return setContent(metadata, input, headers).thenApply(future -> input.getMessageDigest().digest());
+        return setContent(metadata, input, hints).thenApply(future -> input.getMessageDigest().digest());
     }
 
     /**

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -16,6 +16,8 @@ package org.trellisldp.api;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -34,9 +36,10 @@ public interface BinaryService extends RetrievalService<Binary> {
      *
      * @param metadata the binary metadata
      * @param stream the content
+     * @param headers HTTP request headers
      * @return the new completion stage
      */
-    CompletableFuture<Void> setContent(BinaryMetadata metadata, InputStream stream);
+    CompletableFuture<Void> setContent(BinaryMetadata metadata, InputStream stream, Map<String, List<String>> headers);
 
     /**
      * Set the content for a binary object using a digest algorithm.
@@ -45,12 +48,13 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param metadata the binary metadata
      * @param stream the context
      * @param algorithm the digest algorithm
+     * @param headers HTTP request headers
      * @return the new completion stage containing the server-computed digest.
      */
     default CompletableFuture<byte[]> setContent(final BinaryMetadata metadata, final InputStream stream,
-            final MessageDigest algorithm) {
+            final MessageDigest algorithm, final Map<String, List<String>> headers) {
         final DigestInputStream input = new DigestInputStream(stream, algorithm);
-        return setContent(metadata, input).thenApply(future -> input.getMessageDigest().digest());
+        return setContent(metadata, input, headers).thenApply(future -> input.getMessageDigest().digest());
     }
 
     /**

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -48,7 +48,7 @@ import org.mockito.Mock;
 public class BinaryServiceTest {
 
     private static final RDF rdf = new SimpleRDF();
-    private static final Map<String, List<String>> headers = emptyMap();
+    private static final Map<String, List<String>> hints = emptyMap();
 
     private final IRI identifier = rdf.createIRI("trellis:data/resource");
 
@@ -62,7 +62,7 @@ public class BinaryServiceTest {
     public void setUp() {
         initMocks(this);
         doCallRealMethod().when(mockBinaryService).setContent(any(BinaryMetadata.class),
-                any(InputStream.class), any(MessageDigest.class), eq(headers));
+                any(InputStream.class), any(MessageDigest.class), eq(hints));
     }
 
     @Test
@@ -78,13 +78,13 @@ public class BinaryServiceTest {
     @Test
     public void testSetContent() throws Exception {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("FooBar".getBytes(UTF_8));
-        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class), eq(headers)))
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class), eq(hints)))
             .thenAnswer(inv -> {
                 readLines((InputStream) inv.getArguments()[1], UTF_8);
                 return completedFuture(null);
             });
         assertDoesNotThrow(mockBinaryService.setContent(BinaryMetadata.builder(identifier).build(),
-                inputStream, MessageDigest.getInstance("MD5"), headers).thenApply(getEncoder()::encodeToString)
+                inputStream, MessageDigest.getInstance("MD5"), hints).thenApply(getEncoder()::encodeToString)
                 .thenAccept(digest -> assertEquals("8yom4qOoqjOM13tuEmPFNQ==", digest))::join);
     }
 }

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -238,7 +238,7 @@ class MutatingLdpHandler extends BaseLdpHandler {
     }
 
     protected CompletableFuture<Void> persistContent(final BinaryMetadata metadata) {
-        return getServices().getBinaryService().setContent(metadata, entity)
+        return getServices().getBinaryService().setContent(metadata, entity, getRequest().getHeaders())
                         .whenComplete(HttpUtils.closeInputStreamAsync(entity));
     }
 
@@ -249,7 +249,8 @@ class MutatingLdpHandler extends BaseLdpHandler {
         try {
             final String alg = of(digest).map(Digest::getAlgorithm).map(String::toUpperCase)
                 .filter(isEqual("SHA").negate()).orElse("SHA-1");
-            return getServices().getBinaryService().setContent(metadata, entity, MessageDigest.getInstance(alg))
+            return getServices().getBinaryService().setContent(metadata, entity, MessageDigest.getInstance(alg),
+                    getRequest().getHeaders())
                 .thenApply(getEncoder()::encodeToString).thenCompose(serverComputed -> {
                     if (digest.getDigest().equals(serverComputed)) {
                         LOGGER.debug("Successfully persisted digest-verified bitstream: {}", metadata.getIdentifier());

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -279,14 +279,15 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent(eq(3), eq(10))).thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
         when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
-        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class), any()))
             .thenAnswer(inv -> {
                 readLines((InputStream) inv.getArguments()[1], UTF_8);
                 return completedFuture(null);
             });
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));
         when(mockBinaryService.generateIdentifier()).thenReturn(RANDOM_VALUE);
-        doCallRealMethod().when(mockBinaryService).setContent(any(BinaryMetadata.class), any(InputStream.class), any());
+        doCallRealMethod().when(mockBinaryService)
+            .setContent(any(BinaryMetadata.class), any(InputStream.class), any(), any());
     }
 
     private void setUpResources() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -238,12 +238,13 @@ abstract class BaseTestHandler {
             .thenReturn(completedFuture("computed-digest".getBytes()));
         when(mockBinaryService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));
-        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class), any()))
             .thenAnswer(inv -> {
                 readLines((InputStream) inv.getArguments()[1], UTF_8);
                 return completedFuture(null);
             });
-        doCallRealMethod().when(mockBinaryService).setContent(any(BinaryMetadata.class), any(InputStream.class), any());
+        doCallRealMethod().when(mockBinaryService)
+            .setContent(any(BinaryMetadata.class), any(InputStream.class), any(), any());
     }
 
     private void setUpBundler() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -186,7 +186,7 @@ public class PostHandlerTest extends BaseTestHandler {
         assertEquals(create(baseUrl + path), res.getLocation(), "Incorrect Location header!");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.RDFSource));
 
-        verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class));
+        verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class), any());
         verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + path));
         verify(mockResourceService).create(any(Metadata.class), any(Dataset.class));
     }
@@ -283,7 +283,7 @@ public class PostHandlerTest extends BaseTestHandler {
                             .create(any(Metadata.class), any(Dataset.class)),
                 () -> verify(mockIoService, never().description("entity shouldn't be read!")).read(any(), any(), any()),
                 () -> verify(mockBinaryService, description("content not set on binary service!"))
-                            .setContent(metadataArgument.capture(), any(InputStream.class)),
+                            .setContent(metadataArgument.capture(), any(InputStream.class), any()),
                 () -> assertEquals(of("text/plain"), metadataArgument.getValue().getMimeType(), "Invalid content-type"),
                 () -> assertTrue(metadataArgument.getValue().getIdentifier().getIRIString().startsWith("file:///"),
                                  "Invalid binary ID!"));

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -110,7 +110,7 @@ public class PutHandlerTest extends BaseTestHandler {
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response type");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.RDFSource));
 
-        verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class));
+        verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class), any());
         verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + "resource"));
     }
 
@@ -126,7 +126,7 @@ public class PutHandlerTest extends BaseTestHandler {
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.Container));
 
-        verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class));
+        verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class), any());
         verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + "resource"));
     }
 
@@ -259,7 +259,7 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
-        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class), any()))
             .thenReturn(asyncException());
 
         final InputStream entity = getClass().getResource("/simpleData.txt").openStream();
@@ -283,7 +283,7 @@ public class PutHandlerTest extends BaseTestHandler {
         return Stream.of(
                 () -> assertAll("Check LDP type Link headers", checkLdpType(res, LDP.RDFSource)),
                 () -> verify(mockBinaryService, never().description("Binary service shouldn't have been called!"))
-                             .setContent(any(BinaryMetadata.class), any(InputStream.class)),
+                             .setContent(any(BinaryMetadata.class), any(InputStream.class), any()),
                 () -> verify(mockIoService, description("IOService should have been called with an RDF resource"))
                              .read(any(InputStream.class), any(RDFSyntax.class), anyString()));
     }
@@ -292,7 +292,7 @@ public class PutHandlerTest extends BaseTestHandler {
         return Stream.of(
                 () -> assertAll("Check LDP type Link headers", checkLdpType(res, LDP.NonRDFSource)),
                 () -> verify(mockBinaryService, description("BinaryService should have been called to set content!"))
-                            .setContent(any(BinaryMetadata.class), any(InputStream.class)),
+                            .setContent(any(BinaryMetadata.class), any(InputStream.class), any()),
                 () -> verify(mockIoService, never().description("IOService shouldn't have been called with a Binary!"))
                             .read(any(InputStream.class), any(RDFSyntax.class), anyString()));
     }


### PR DESCRIPTION
Resolves #328

This passes HTTP headers into the BinaryService, which can
be used as a form of storage hint. They can also be entirely ignored.