### PR TITLE
Add hint to BinaryService::generateIdentifier

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -187,7 +187,7 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public String generateIdentifier() {
+    public String generateIdentifier(final String hint) {
         return idSupplier.get();
     }
 

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -97,8 +97,9 @@ public class FileBinaryServiceTest {
     @Test
     public void testIdSupplier() {
         final BinaryService service = new FileBinaryService();
-        assertTrue(service.generateIdentifier().startsWith("file:///"), "Identifier has incorrect prefix!");
-        assertNotEquals(service.generateIdentifier(), service.generateIdentifier(), "Identifiers are not unique!");
+        assertTrue(service.generateIdentifier(null).startsWith("file:///"), "Identifier has incorrect prefix!");
+        assertNotEquals(service.generateIdentifier("foo"), service.generateIdentifier("bar"),
+                "Identifiers are not unique!");
     }
 
     @Test

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -89,7 +89,11 @@ public interface BinaryService extends RetrievalService<Binary> {
     /**
      * Get a new identifier.
      *
+     * @apiNote an implementation is free to ignore the {@code hint} parameter entirely. The HTTP
+     *          layer will provide the corresponding resource identifier, and in certain cases,
+     *          that information may be helpful to know where to place the binary in persistent storage.
+     * @param hint a hint about the new identifier to generate. This could be the
      * @return a new identifier
      */
-    String generateIdentifier();
+    String generateIdentifier(String hint);
 }

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -171,7 +171,8 @@ public class PostHandler extends MutatingLdpHandler {
         // Add user-supplied data
         if (ldpType.equals(LDP.NonRDFSource)) {
             final String mimeType = ofNullable(contentType).orElse(APPLICATION_OCTET_STREAM);
-            final IRI binaryLocation = rdf.createIRI(getServices().getBinaryService().generateIdentifier());
+            final IRI binaryLocation = rdf.createIRI(getServices().getBinaryService()
+                    .generateIdentifier(internalId.getIRIString()));
 
             // Persist the content
             final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType(mimeType).build();

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -195,7 +195,8 @@ public class PutHandler extends MutatingLdpHandler {
         if (LDP.NonRDFSource.equals(ldpType) && isNull(rdfSyntax)) {
             LOGGER.trace("Successfully checked for bad digest value");
             final String mimeType = ofNullable(getRequest().getContentType()).orElse(APPLICATION_OCTET_STREAM);
-            final IRI binaryLocation = rdf.createIRI(getServices().getBinaryService().generateIdentifier());
+            final IRI binaryLocation = rdf.createIRI(getServices().getBinaryService()
+                    .generateIdentifier(internalId.getIRIString()));
 
             // Persist the content
             final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType(mimeType).build();

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -285,7 +285,7 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
                 return completedFuture(null);
             });
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));
-        when(mockBinaryService.generateIdentifier()).thenReturn(RANDOM_VALUE);
+        when(mockBinaryService.generateIdentifier(anyString())).thenReturn(RANDOM_VALUE);
         doCallRealMethod().when(mockBinaryService)
             .setContent(any(BinaryMetadata.class), any(InputStream.class), any(), any());
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -232,7 +232,7 @@ abstract class BaseTestHandler {
     private void setUpBinaryService() throws Exception {
         when(mockBinary.getContent(eq(3), eq(10))).thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
         when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
-        when(mockBinaryService.generateIdentifier()).thenReturn("file:///" + randomUUID());
+        when(mockBinaryService.generateIdentifier(any())).thenReturn("file:///" + randomUUID());
         when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA-1")));
         when(mockBinaryService.calculateDigest(any(IRI.class), any(MessageDigest.class)))
             .thenReturn(completedFuture("computed-digest".getBytes()));


### PR DESCRIPTION
Resolves #331 

This still needs a little discussion as to whether this is necessary, but if so, here is a patch that implements it.