### PR TITLE
Moving hints into BinaryMetadata

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -41,8 +41,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.security.MessageDigest;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -159,8 +157,7 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public CompletableFuture<Void> setContent(final BinaryMetadata metadata, final InputStream stream,
-            final Map<String, List<String>> headers) {
+    public CompletableFuture<Void> setContent(final BinaryMetadata metadata, final InputStream stream) {
         requireNonNull(stream, "InputStream may not be null!");
         return supplyAsync(() -> {
             final File file = getFileFromIdentifier(metadata.getIdentifier());
@@ -177,7 +174,7 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public CompletableFuture<byte[]> calculateDigest(final IRI identifier, final MessageDigest algorithm) {
+    public CompletableFuture<MessageDigest> calculateDigest(final IRI identifier, final MessageDigest algorithm) {
         return supplyAsync(() -> computeDigest(identifier, algorithm));
     }
 
@@ -198,9 +195,9 @@ public class FileBinaryService implements BinaryService {
             .orElseThrow(() -> new IllegalArgumentException("Could not create File object from IRI: " + identifier));
     }
 
-    private byte[] computeDigest(final IRI identifier, final MessageDigest algorithm) {
+    private MessageDigest computeDigest(final IRI identifier, final MessageDigest algorithm) {
         try (final InputStream input = new FileInputStream(getFileFromIdentifier(identifier))) {
-            return updateDigest(algorithm, input).digest();
+            return updateDigest(algorithm, input);
         } catch (final IOException ex) {
             throw new UncheckedIOException("Error computing digest", ex);
         }

--- a/core/api/src/main/java/org/trellisldp/api/BinaryMetadata.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryMetadata.java
@@ -13,9 +13,12 @@
  */
 package org.trellisldp.api;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.rdf.api.IRI;
@@ -38,16 +41,19 @@ public final class BinaryMetadata {
 
     private final IRI identifier;
     private final String mimeType;
+    private final Map<String, List<String>> hints;
 
     /**
      * A simple BinaryMetadata object.
      *
      * @param identifier the identifier
      * @param mimeType the mimeType, may be {@code null}
+     * @param hints hints for persistence, may not be {@code null}
      */
-    private BinaryMetadata(final IRI identifier, final String mimeType) {
-        this.identifier = requireNonNull(identifier, "identifier may not be null!");
+    private BinaryMetadata(final IRI identifier, final String mimeType, final Map<String, List<String>> hints) {
+        this.identifier = requireNonNull(identifier, "Identifier may not be null!");
         this.mimeType = mimeType;
+        this.hints = requireNonNull(hints, "Hints may not be null!");
     }
 
     /**
@@ -69,6 +75,15 @@ public final class BinaryMetadata {
     }
 
     /**
+     * Retrieve any hints for persistence.
+     *
+     * @return the hints
+     */
+    public Map<String, List<String>> getHints() {
+        return hints;
+    }
+
+    /**
      * Get a mutable builder for a {@link BinaryMetadata}.
      * @param identifier the identifier
      * @return a builder for a {@link BinaryMetadata}
@@ -83,6 +98,7 @@ public final class BinaryMetadata {
     public static final class Builder {
         private final IRI identifier;
         private String mimeType;
+        private Map<String, List<String>> hints;
 
         /**
          * Create a BinaryMetadata builder with the provided identifier.
@@ -103,11 +119,21 @@ public final class BinaryMetadata {
         }
 
         /**
-         * Build the BinaryMetadata object, transitioning this builder to the built state.
+         * Set the hints for persistence.
+         * @param hints the hints, may not be {@code null}
+         * @return this builder
+         */
+        public Builder hints(final Map<String, List<String>> hints) {
+            this.hints = requireNonNull(hints, "Hints cannot be null!");
+            return this;
+        }
+
+        /**
+         * Build the BinaryMetadata object.
          * @return the built BinaryMetadata
          */
         public BinaryMetadata build() {
-            return new BinaryMetadata(identifier, mimeType);
+            return new BinaryMetadata(identifier, mimeType, hints == null ? emptyMap() : hints);
         }
     }
 }

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -16,8 +16,6 @@ package org.trellisldp.api;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -28,6 +26,7 @@ import org.apache.commons.rdf.api.IRI;
  * the validity of binary content.
  *
  * @author acoburn
+ * @author ajs6f
  */
 public interface BinaryService extends RetrievalService<Binary> {
 
@@ -36,10 +35,9 @@ public interface BinaryService extends RetrievalService<Binary> {
      *
      * @param metadata the binary metadata
      * @param stream the content
-     * @param hints any hints for storing the binary data
      * @return the new completion stage
      */
-    CompletableFuture<Void> setContent(BinaryMetadata metadata, InputStream stream, Map<String, List<String>> hints);
+    CompletableFuture<Void> setContent(BinaryMetadata metadata, InputStream stream);
 
     /**
      * Set the content for a binary object using a digest algorithm.
@@ -48,13 +46,12 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param metadata the binary metadata
      * @param stream the context
      * @param algorithm the digest algorithm
-     * @param hints any hints for storing the binary data
      * @return the new completion stage containing the server-computed digest.
      */
-    default CompletableFuture<byte[]> setContent(final BinaryMetadata metadata, final InputStream stream,
-            final MessageDigest algorithm, final Map<String, List<String>> hints) {
+    default CompletableFuture<MessageDigest> setContent(final BinaryMetadata metadata, final InputStream stream,
+                    final MessageDigest algorithm) {
         final DigestInputStream input = new DigestInputStream(stream, algorithm);
-        return setContent(metadata, input, hints).thenApply(future -> input.getMessageDigest().digest());
+        return setContent(metadata, input).thenApply(future -> input.getMessageDigest());
     }
 
     /**
@@ -77,7 +74,7 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param algorithm the algorithm
      * @return the new completion stage containing a computed digest for the binary resource
      */
-    CompletableFuture<byte[]> calculateDigest(IRI identifier, MessageDigest algorithm);
+    CompletableFuture<MessageDigest> calculateDigest(IRI identifier, MessageDigest algorithm);
 
     /**
      * Get a list of supported algorithms.

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -58,7 +58,7 @@ public class BinaryServiceTest {
     public void setUp() {
         initMocks(this);
         doCallRealMethod().when(mockBinaryService).setContent(any(BinaryMetadata.class),
-                any(InputStream.class), any(MessageDigest.class), eq(hints));
+                any(InputStream.class), any(MessageDigest.class));
     }
 
     @Test
@@ -74,13 +74,15 @@ public class BinaryServiceTest {
     @Test
     public void testSetContent() throws Exception {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("FooBar".getBytes(UTF_8));
-        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class), eq(hints)))
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
             .thenAnswer(inv -> {
                 readLines((InputStream) inv.getArguments()[1], UTF_8);
                 return completedFuture(null);
             });
-        assertDoesNotThrow(mockBinaryService.setContent(BinaryMetadata.builder(identifier).build(),
-                inputStream, MessageDigest.getInstance("MD5"), hints).thenApply(getEncoder()::encodeToString)
-                .thenAccept(digest -> assertEquals("8yom4qOoqjOM13tuEmPFNQ==", digest))::join);
+        assertDoesNotThrow(mockBinaryService
+                        .setContent(BinaryMetadata.builder(identifier).build(), inputStream,
+                                        MessageDigest.getInstance("MD5"))
+                        .thenApply(MessageDigest::digest).thenApply(getEncoder()::encodeToString)
+                        .thenAccept(digest -> assertEquals("8yom4qOoqjOM13tuEmPFNQ==", digest))::join);
     }
 }

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -76,6 +76,7 @@ import static org.trellisldp.vocabulary.Trellis.PreferUserManaged;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -355,6 +356,7 @@ public class GetHandler extends BaseLdpHandler {
             if (algorithm.isPresent()) {
                 final String alg = algorithm.filter(isEqual("SHA").negate()).orElse("SHA-1");
                 return getServices().getBinaryService().calculateDigest(dsid, getDigest(alg))
+                    .thenApply(MessageDigest::digest)
                     .thenApply(getEncoder()::encodeToString)
                     .thenApply(digest -> Optional.of(algorithm.get().toLowerCase() + "=" + digest));
             }

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -238,7 +238,7 @@ class MutatingLdpHandler extends BaseLdpHandler {
     }
 
     protected CompletableFuture<Void> persistContent(final BinaryMetadata metadata) {
-        return getServices().getBinaryService().setContent(metadata, entity, getRequest().getHeaders())
+        return getServices().getBinaryService().setContent(metadata, entity)
                         .whenComplete(HttpUtils.closeInputStreamAsync(entity));
     }
 
@@ -249,8 +249,8 @@ class MutatingLdpHandler extends BaseLdpHandler {
         try {
             final String alg = of(digest).map(Digest::getAlgorithm).map(String::toUpperCase)
                 .filter(isEqual("SHA").negate()).orElse("SHA-1");
-            return getServices().getBinaryService().setContent(metadata, entity, MessageDigest.getInstance(alg),
-                    getRequest().getHeaders())
+            return getServices().getBinaryService().setContent(metadata, entity, MessageDigest.getInstance(alg))
+                .thenApply(MessageDigest::digest)
                 .thenApply(getEncoder()::encodeToString).thenCompose(serverComputed -> {
                     if (digest.getDigest().equals(serverComputed)) {
                         LOGGER.debug("Successfully persisted digest-verified bitstream: {}", metadata.getIdentifier());

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -174,7 +174,8 @@ public class PostHandler extends MutatingLdpHandler {
             final IRI binaryLocation = rdf.createIRI(getServices().getBinaryService().generateIdentifier());
 
             // Persist the content
-            final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType(mimeType).build();
+            final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType(mimeType)
+                            .hints(getRequest().getHeaders()).build();
             persistPromise = persistContent(binary, getRequest().getDigest());
 
             metadata = metadataBuilder(internalId, ldpType, mutable).container(parentIdentifier).binary(binary);

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -206,7 +206,8 @@ public class PutHandler extends MutatingLdpHandler {
             final IRI binaryLocation = rdf.createIRI(getServices().getBinaryService().generateIdentifier());
 
             // Persist the content
-            final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType(mimeType).build();
+            final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType(mimeType)
+                            .hints(getRequest().getHeaders()).build();
             persistPromise = persistContent(binary, getRequest().getDigest());
 
             metadata = metadataBuilder(internalId, ldpType, mutable).binary(binary);

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -149,6 +149,9 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     protected Binary mockBinary;
 
     @Mock
+    protected MessageDigest mockDigest;
+
+    @Mock
     protected AccessControlService mockAccessControlService;
 
     @Mock
@@ -269,8 +272,9 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
 
     private void setUpBinaryService() throws Exception {
         when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA-1", "SHA")));
+        when(mockDigest.digest()).thenReturn(getDecoder().decode("Q29tcHV0ZWREaWdlc3Q="));
         when(mockBinaryService.calculateDigest(eq(binaryInternalIdentifier), any(MessageDigest.class)))
-            .thenReturn(completedFuture(getDecoder().decode("Q29tcHV0ZWREaWdlc3Q=")));
+            .thenReturn(completedFuture(mockDigest));
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent(eq(3), eq(10))).thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
         when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
@@ -279,10 +283,15 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
                 readLines((InputStream) inv.getArguments()[1], UTF_8);
                 return completedFuture(null);
             });
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
+        .thenAnswer(inv -> {
+            readLines((InputStream) inv.getArguments()[1], UTF_8);
+            return completedFuture(null);
+        });
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));
         when(mockBinaryService.generateIdentifier()).thenReturn(RANDOM_VALUE);
         doCallRealMethod().when(mockBinaryService)
-            .setContent(any(BinaryMetadata.class), any(InputStream.class), any(), any());
+            .setContent(any(BinaryMetadata.class), any(InputStream.class), any());
     }
 
     private void setUpResources() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -133,6 +133,9 @@ abstract class BaseTestHandler {
     protected Binary mockBinary;
 
     @Mock
+    protected MessageDigest mockDigest;
+
+    @Mock
     protected Resource mockResource, mockParent;
 
     @Mock
@@ -231,8 +234,9 @@ abstract class BaseTestHandler {
         when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
         when(mockBinaryService.generateIdentifier()).thenReturn("file:///" + randomUUID());
         when(mockBinaryService.supportedAlgorithms()).thenReturn(new HashSet<>(asList("MD5", "SHA-1")));
+        when(mockDigest.digest()).thenReturn("computed-digest".getBytes(UTF_8));
         when(mockBinaryService.calculateDigest(any(IRI.class), any(MessageDigest.class)))
-            .thenReturn(completedFuture("computed-digest".getBytes()));
+            .thenReturn(completedFuture(mockDigest));
         when(mockBinaryService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));
         when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class), any()))
@@ -240,8 +244,13 @@ abstract class BaseTestHandler {
                 readLines((InputStream) inv.getArguments()[1], UTF_8);
                 return completedFuture(null);
             });
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
+        .thenAnswer(inv -> {
+            readLines((InputStream) inv.getArguments()[1], UTF_8);
+            return completedFuture(null);
+        });
         doCallRealMethod().when(mockBinaryService)
-            .setContent(any(BinaryMetadata.class), any(InputStream.class), any(), any());
+            .setContent(any(BinaryMetadata.class), any(InputStream.class), any());
     }
 
     private void setUpBundler() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -275,7 +275,7 @@ public class PostHandlerTest extends BaseTestHandler {
                             .create(any(Metadata.class), any(Dataset.class)),
                 () -> verify(mockIoService, never().description("entity shouldn't be read!")).read(any(), any(), any()),
                 () -> verify(mockBinaryService, description("content not set on binary service!"))
-                            .setContent(metadataArgument.capture(), any(InputStream.class), any()),
+                            .setContent(metadataArgument.capture(), any(InputStream.class)),
                 () -> assertEquals(of("text/plain"), metadataArgument.getValue().getMimeType(), "Invalid content-type"),
                 () -> assertTrue(metadataArgument.getValue().getIdentifier().getIRIString().startsWith("file:///"),
                                  "Invalid binary ID!"));

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -249,15 +249,16 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
-        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class), any()))
+        when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
             .thenReturn(asyncException());
 
-        final InputStream entity = getClass().getResource("/simpleData.txt").openStream();
-        final PutHandler handler = new PutHandler(mockTrellisRequest, entity, mockBundler, false, null);
+        try (final InputStream entity = getClass().getResource("/simpleData.txt").openStream()) {
+            final PutHandler handler = new PutHandler(mockTrellisRequest, entity, mockBundler, false, null);
 
-        assertThrows(CompletionException.class, () ->
-                unwrapAsyncError(handler.setResource(handler.initialize(mockParent, mockResource))),
-                "No exception when there's a problem with the backend binary service!");
+            assertThrows(CompletionException.class,
+                            () -> unwrapAsyncError(handler.setResource(handler.initialize(mockParent, mockResource))),
+                            "No exception when there's a problem with the backend binary service!");
+        }
     }
 
     private PutHandler buildPutHandler(final String resourceName, final String baseUrl) {
@@ -282,7 +283,7 @@ public class PutHandlerTest extends BaseTestHandler {
         return Stream.of(
                 () -> assertAll("Check LDP type Link headers", checkLdpType(res, LDP.NonRDFSource)),
                 () -> verify(mockBinaryService, description("BinaryService should have been called to set content!"))
-                            .setContent(any(BinaryMetadata.class), any(InputStream.class), any()),
+                            .setContent(any(BinaryMetadata.class), any(InputStream.class)),
                 () -> verify(mockIoService, never().description("IOService shouldn't have been called with a Binary!"))
                             .read(any(InputStream.class), any(RDFSyntax.class), anyString()));
     }


### PR DESCRIPTION
WDYT @acoburn ? I think this is cleaner and makes for less use of `emotyMap()` all through the test code.

I'm also returning `MessageDigest` from checksum operations because there are a bunch of `public` methods on it (e.g. `digest(byte[] buf, int offset, int len)`) that are very legitimately useful.