### PR TITLE
Convert to CompletionStage

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -44,7 +44,7 @@ import java.security.MessageDigest;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
@@ -143,12 +143,12 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public CompletableFuture<Binary> get(final IRI identifier) {
+    public CompletionStage<Binary> get(final IRI identifier) {
         return supplyAsync(() -> new FileBinary(getFileFromIdentifier(identifier)));
     }
 
     @Override
-    public CompletableFuture<Void> purgeContent(final IRI identifier) {
+    public CompletionStage<Void> purgeContent(final IRI identifier) {
         return supplyAsync(() -> {
             try {
                 delete(getFileFromIdentifier(identifier).toPath());
@@ -160,7 +160,7 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public CompletableFuture<Void> setContent(final BinaryMetadata metadata, final InputStream stream) {
+    public CompletionStage<Void> setContent(final BinaryMetadata metadata, final InputStream stream) {
         requireNonNull(stream, "InputStream may not be null!");
         return supplyAsync(() -> {
             final File file = getFileFromIdentifier(metadata.getIdentifier());
@@ -177,7 +177,7 @@ public class FileBinaryService implements BinaryService {
     }
 
     @Override
-    public CompletableFuture<MessageDigest> calculateDigest(final IRI identifier, final MessageDigest algorithm) {
+    public CompletionStage<MessageDigest> calculateDigest(final IRI identifier, final MessageDigest algorithm) {
         return supplyAsync(() -> computeDigest(identifier, algorithm));
     }
 

--- a/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 import javax.enterprise.inject.Alternative;
@@ -73,7 +73,7 @@ public class FileMementoService implements MementoService {
     }
 
     @Override
-    public CompletableFuture<Void> put(final Resource resource) {
+    public CompletionStage<Void> put(final Resource resource) {
         return put(resource, resource.getModified());
     }
 
@@ -83,7 +83,7 @@ public class FileMementoService implements MementoService {
      * @param time the time to which the Memento corresponds
      * @return the completion stage representing that the operation has completed
      */
-    public CompletableFuture<Void> put(final Resource resource, final Instant time) {
+    public CompletionStage<Void> put(final Resource resource, final Instant time) {
         return runAsync(() -> {
             final File resourceDir = FileUtils.getResourceDirectory(directory, resource.getIdentifier());
             if (!resourceDir.exists()) {
@@ -94,7 +94,7 @@ public class FileMementoService implements MementoService {
     }
 
     @Override
-    public CompletableFuture<Resource> get(final IRI identifier, final Instant time) {
+    public CompletionStage<Resource> get(final IRI identifier, final Instant time) {
         return supplyAsync(() -> {
             final Instant mementoTime = time.truncatedTo(SECONDS);
             final File resourceDir = FileUtils.getResourceDirectory(directory, identifier);
@@ -111,7 +111,7 @@ public class FileMementoService implements MementoService {
     }
 
     @Override
-    public CompletableFuture<SortedSet<Instant>> mementos(final IRI identifier) {
+    public CompletionStage<SortedSet<Instant>> mementos(final IRI identifier) {
         return supplyAsync(() -> listMementos(identifier));
     }
 

--- a/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
@@ -73,17 +73,18 @@ public class FileMementoServiceTest {
 
             final MementoService svc = new FileMementoService();
 
-            assertEquals(2L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(2L, svc.mementos(identifier).toCompletableFuture().join().size(),
+                    "Incorrect count of Mementos!");
             svc.get(identifier, now()).thenAccept(res -> assertEquals(time2, res.getModified(), "Incorrect date!"))
-                .join();
+                .toCompletableFuture().join();
             svc.get(identifier, time).thenAccept(res -> assertEquals(time, res.getModified(), "Incorrect date!"))
-                .join();
-            assertEquals(MISSING_RESOURCE, svc.get(identifier, parse("2015-02-16T10:00:00Z")).join(),
-                    "Wrong response for a missing resource!");
+                .toCompletableFuture().join();
+            assertEquals(MISSING_RESOURCE, svc.get(identifier, parse("2015-02-16T10:00:00Z"))
+                .toCompletableFuture().join(), "Wrong response for a missing resource!");
             svc.get(identifier, time2).thenAccept(res -> assertEquals(time2, res.getModified(), "Incorrect date!"))
-                .join();
+                .toCompletableFuture().join();
             svc.get(identifier, MAX).thenAccept(res -> assertEquals(time2, res.getModified(), "Incorrect date!"))
-                .join();
+                .toCompletableFuture().join();
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
@@ -115,9 +116,9 @@ public class FileMementoServiceTest {
         when(mockResource.getMembershipResource()).thenReturn(empty());
         when(mockResource.getInsertedContentRelation()).thenReturn(empty());
 
-        svc.put(mockResource).join();
+        svc.put(mockResource).toCompletableFuture().join();
 
-        final Resource res = svc.get(identifier, time).join();
+        final Resource res = svc.get(identifier, time).toCompletableFuture().join();
         assertEquals(identifier, res.getIdentifier());
         assertEquals(time, res.getModified());
         assertEquals(LDP.NonRDFSource, res.getInteractionModel());
@@ -158,9 +159,9 @@ public class FileMementoServiceTest {
         when(mockResource.getMembershipResource()).thenReturn(of(member));
         when(mockResource.getInsertedContentRelation()).thenReturn(of(FOAF.primaryTopic));
 
-        svc.put(mockResource).join();
+        svc.put(mockResource).toCompletableFuture().join();
 
-        final Resource res = svc.get(identifier, time).join();
+        final Resource res = svc.get(identifier, time).toCompletableFuture().join();
         assertEquals(identifier, res.getIdentifier());
         assertEquals(time, res.getModified());
         assertEquals(LDP.IndirectContainer, res.getInteractionModel());
@@ -185,8 +186,10 @@ public class FileMementoServiceTest {
 
             assertTrue(dir.exists(), "Resource directory doesn't exist!");
             assertTrue(dir.isDirectory(), "Invalid resource directory!");
-            assertTrue(svc.mementos(identifier).join().isEmpty(), "Resource directory isn't empty!");
-            assertEquals(MISSING_RESOURCE, svc.get(identifier, now()).join(), "Wrong response for missing resource!");
+            assertTrue(svc.mementos(identifier).toCompletableFuture().join().isEmpty(),
+                    "Resource directory isn't empty!");
+            assertEquals(MISSING_RESOURCE, svc.get(identifier, now()).toCompletableFuture().join(),
+                    "Wrong response for missing resource!");
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
@@ -204,8 +207,10 @@ public class FileMementoServiceTest {
 
             assertTrue(dir.exists(), "Resource directory doesn't exist!");
             assertTrue(dir.isDirectory(), "Invalid resource directory!");
-            assertEquals(MISSING_RESOURCE, svc.get(identifier, now()).join(), "Wrong response for missing resource!");
-            assertTrue(svc.mementos(identifier).join().isEmpty(), "Memento list isn't empty!");
+            assertEquals(MISSING_RESOURCE, svc.get(identifier, now()).toCompletableFuture().join(),
+                    "Wrong response for missing resource!");
+            assertTrue(svc.mementos(identifier).toCompletableFuture().join().isEmpty(),
+                    "Memento list isn't empty!");
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }
@@ -225,15 +230,18 @@ public class FileMementoServiceTest {
 
             final FileMementoService svc = new FileMementoService();
 
-            assertTrue(svc.mementos(identifier).join().isEmpty(), "Memento list isn't empty!");
+            assertTrue(svc.mementos(identifier).toCompletableFuture().join().isEmpty(),
+                    "Memento list isn't empty!");
             final File file = new File(getClass().getResource("/resource.nq").getFile());
             assertTrue(file.exists(), "Memento resource doesn't exist!");
             final Resource res = new FileResource(identifier, file);
-            svc.put(res).join();
+            svc.put(res).toCompletableFuture().join();
 
-            assertEquals(1L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
-            svc.put(res, res.getModified().plusSeconds(10)).join();
-            assertEquals(2L, svc.mementos(identifier).join().size(), "Incorrect count of Mementos!");
+            assertEquals(1L, svc.mementos(identifier).toCompletableFuture().join().size(),
+                    "Incorrect count of Mementos!");
+            svc.put(res, res.getModified().plusSeconds(10)).toCompletableFuture().join();
+            assertEquals(2L, svc.mementos(identifier).toCompletableFuture().join().size(),
+                    "Incorrect count of Mementos!");
         } finally {
             System.clearProperty(FileMementoService.CONFIG_FILE_MEMENTO_BASE_PATH);
         }

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -52,7 +52,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -140,7 +140,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public CompletableFuture<Void> delete(final Metadata metadata) {
+    public CompletionStage<Void> delete(final Metadata metadata) {
         LOGGER.debug("Deleting: {}", metadata.getIdentifier());
         return runAsync(() -> {
             try (final Dataset dataset = rdf.createDataset()) {
@@ -155,7 +155,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public CompletableFuture<Void> replace(final Metadata metadata, final Dataset dataset) {
+    public CompletionStage<Void> replace(final Metadata metadata, final Dataset dataset) {
         LOGGER.debug("Persisting: {}", metadata.getIdentifier());
         return runAsync(() ->
                 createOrReplace(metadata, dataset, OperationType.REPLACE));
@@ -378,7 +378,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public CompletableFuture<Resource> get(final IRI identifier) {
+    public CompletionStage<Resource> get(final IRI identifier) {
         return TriplestoreResource.findResource(rdfConnection, identifier);
     }
 
@@ -388,7 +388,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public CompletableFuture<Void> add(final IRI id, final Dataset dataset) {
+    public CompletionStage<Void> add(final IRI id, final Dataset dataset) {
         return runAsync(() -> {
             final IRI graphName = rdf.createIRI(id.getIRIString() + "?ext=audit");
             try (final Dataset data = rdf.createDataset()) {
@@ -402,7 +402,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     }
 
     @Override
-    public CompletableFuture<Void> touch(final IRI identifier) {
+    public CompletionStage<Void> touch(final IRI identifier) {
         final Literal time = rdf.createLiteral(now().toString(), XSD.dateTime);
         return runAsync(() -> {
             try {

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.IRI;
 
@@ -37,7 +37,7 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param stream the content
      * @return the new completion stage
      */
-    CompletableFuture<Void> setContent(BinaryMetadata metadata, InputStream stream);
+    CompletionStage<Void> setContent(BinaryMetadata metadata, InputStream stream);
 
     /**
      * Set the content for a binary object using a digest algorithm.
@@ -48,7 +48,7 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param algorithm the digest algorithm
      * @return the new completion stage containing the server-computed digest.
      */
-    default CompletableFuture<MessageDigest> setContent(final BinaryMetadata metadata, final InputStream stream,
+    default CompletionStage<MessageDigest> setContent(final BinaryMetadata metadata, final InputStream stream,
                     final MessageDigest algorithm) {
         final DigestInputStream input = new DigestInputStream(stream, algorithm);
         return setContent(metadata, input).thenApply(future -> input.getMessageDigest());
@@ -60,10 +60,10 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param identifier the binary object identifier
      * @return a new completion stage that, when the stage completes normally, indicates that the binary data
      *         were successfully deleted from the corresponding persistence layer. In the case of an unsuccessful
-     *         operation, the {@link CompletableFuture} will complete exceptionally and can be handled with
-     *         {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
+     *         operation, the {@link CompletionStage} will complete exceptionally and can be handled with
+     *         {@link CompletionStage#handle}, {@link CompletionStage#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> purgeContent(IRI identifier);
+    CompletionStage<Void> purgeContent(IRI identifier);
 
     /**
      * Calculate the digest for a binary object.
@@ -74,7 +74,7 @@ public interface BinaryService extends RetrievalService<Binary> {
      * @param algorithm the algorithm
      * @return the new completion stage containing a computed digest for the binary resource
      */
-    CompletableFuture<MessageDigest> calculateDigest(IRI identifier, MessageDigest algorithm);
+    CompletionStage<MessageDigest> calculateDigest(IRI identifier, MessageDigest algorithm);
 
     /**
      * Get a list of supported algorithms.

--- a/core/api/src/main/java/org/trellisldp/api/ImmutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ImmutableDataService.java
@@ -14,7 +14,7 @@
 
 package org.trellisldp.api;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
@@ -35,9 +35,9 @@ public interface ImmutableDataService<T> extends RetrievalService<T> {
      * @param dataset a dataset to persist
      * @return a new completion stage that, when the stage completes normally, indicates that the supplied data
      * were successfully stored in the corresponding persistence layer. In the case of an unsuccessful write operation,
-     * the {@link CompletableFuture} will complete exceptionally and can be handled with
-     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
+     * the {@link CompletionStage} will complete exceptionally and can be handled with
+     * {@link CompletionStage#handle}, {@link CompletionStage#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> add(IRI identifier, Dataset dataset);
+    CompletionStage<Void> add(IRI identifier, Dataset dataset);
 
 }

--- a/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/JoiningResourceService.java
@@ -20,7 +20,7 @@ import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 
 import java.time.Instant;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.Dataset;
@@ -52,7 +52,7 @@ public abstract class JoiningResourceService implements ResourceService {
     }
 
     @Override
-    public CompletableFuture<Resource> get(final IRI identifier) {
+    public CompletionStage<Resource> get(final IRI identifier) {
         return mutableData.get(identifier).thenCombine(immutableData.get(identifier), (mutable, immutable) -> {
             if (MISSING_RESOURCE.equals(mutable) && MISSING_RESOURCE.equals(immutable)) {
                 return MISSING_RESOURCE;
@@ -67,22 +67,22 @@ public abstract class JoiningResourceService implements ResourceService {
     }
 
     @Override
-    public CompletableFuture<Void> add(final IRI id, final Dataset dataset) {
+    public CompletionStage<Void> add(final IRI id, final Dataset dataset) {
         return immutableData.add(id, dataset);
     }
 
     @Override
-    public CompletableFuture<Void> create(final Metadata metadata, final Dataset dataset) {
+    public CompletionStage<Void> create(final Metadata metadata, final Dataset dataset) {
         return mutableData.create(metadata, dataset);
     }
 
     @Override
-    public CompletableFuture<Void> replace(final Metadata metadata, final Dataset dataset) {
+    public CompletionStage<Void> replace(final Metadata metadata, final Dataset dataset) {
         return mutableData.replace(metadata, dataset);
     }
 
     @Override
-    public CompletableFuture<Void> delete(final Metadata metadata) {
+    public CompletionStage<Void> delete(final Metadata metadata) {
         return mutableData.delete(metadata);
     }
 

--- a/core/api/src/main/java/org/trellisldp/api/MementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MementoService.java
@@ -15,7 +15,7 @@ package org.trellisldp.api;
 
 import java.time.Instant;
 import java.util.SortedSet;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.IRI;
 
@@ -39,7 +39,7 @@ public interface MementoService {
      * @return a new completion stage that, when the stage completes normally, indicates that the Memento resource was
      * successfully created in the corresponding persistence layer.
      */
-    default CompletableFuture<Void> put(final ResourceService resourceService, final IRI identifier) {
+    default CompletionStage<Void> put(final ResourceService resourceService, final IRI identifier) {
         return resourceService.get(identifier).thenCompose(this::put);
     }
 
@@ -48,10 +48,10 @@ public interface MementoService {
      * @param resource the resource
      * @return a new completion stage that, when the stage completes normally, indicates that the Memento resource was
      * successfully created in the corresponding persistence layer. In the case of an unsuccessful write operation,
-     * the {@link CompletableFuture} will complete exceptionally and can be handled with
-     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
+     * the {@link CompletionStage} will complete exceptionally and can be handled with
+     * {@link CompletionStage#handle}, {@link CompletionStage#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> put(Resource resource);
+    CompletionStage<Void> put(Resource resource);
 
     /**
      * Fetch a Memento resource for the given time.
@@ -59,12 +59,12 @@ public interface MementoService {
      * @param time the requested time
      * @return the new completion stage, containing the fetched resource
      */
-    CompletableFuture<Resource> get(IRI identifier, Instant time);
+    CompletionStage<Resource> get(IRI identifier, Instant time);
 
     /**
      * Get the times for all of the Mementos of the given resource.
      * @param identifier the resource identifier
      * @return the new completion stage containing a collection of Memento dateTimes
      */
-    CompletableFuture<SortedSet<Instant>> mementos(IRI identifier);
+    CompletionStage<SortedSet<Instant>> mementos(IRI identifier);
 }

--- a/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MutableDataService.java
@@ -14,7 +14,7 @@
 
 package org.trellisldp.api;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.Dataset;
 
@@ -34,10 +34,10 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param dataset the dataset to be persisted
      * @return a new completion stage that, when the stage completes normally, indicates that the supplied data were
      * successfully created in the corresponding persistence layer. In the case of an unsuccessful write operation,
-     * the {@link CompletableFuture} will complete exceptionally and can be handled with
-     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
+     * the {@link CompletionStage} will complete exceptionally and can be handled with
+     * {@link CompletionStage#handle}, {@link CompletionStage#exceptionally} or similar methods.
      */
-    default CompletableFuture<Void> create(Metadata metadata, Dataset dataset) {
+    default CompletionStage<Void> create(Metadata metadata, Dataset dataset) {
         return replace(metadata, dataset);
     }
 
@@ -48,10 +48,10 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param dataset the dataset to be persisted
      * @return a new completion stage that, when the stage completes normally, indicates that the supplied data
      * were successfully stored in the corresponding persistence layer. In the case of an unsuccessful write operation,
-     * the {@link CompletableFuture} will complete exceptionally and can be handled with
-     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
+     * the {@link CompletionStage} will complete exceptionally and can be handled with
+     * {@link CompletionStage#handle}, {@link CompletionStage#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> replace(Metadata metadata, Dataset dataset);
+    CompletionStage<Void> replace(Metadata metadata, Dataset dataset);
 
     /**
      * Delete a resource from the server.
@@ -59,9 +59,9 @@ public interface MutableDataService<U> extends RetrievalService<U> {
      * @param metadata metadata for the resource
      * @return a new completion stage that, when the stage completes normally, indicates that the resource
      * was successfully deleted from the corresponding persistence layer. In the case of an unsuccessful delete
-     * operation, the {@link CompletableFuture} will complete exceptionally and can be handled with
-     * {@link CompletableFuture#handle}, {@link CompletableFuture#exceptionally} or similar methods.
+     * operation, the {@link CompletionStage} will complete exceptionally and can be handled with
+     * {@link CompletionStage#handle}, {@link CompletionStage#exceptionally} or similar methods.
      */
-    CompletableFuture<Void> delete(Metadata metadata);
+    CompletionStage<Void> delete(Metadata metadata);
 
 }

--- a/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
@@ -19,7 +19,7 @@ import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 
 import java.time.Instant;
 import java.util.SortedSet;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.IRI;
 
@@ -29,22 +29,22 @@ import org.apache.commons.rdf.api.IRI;
 public class NoopMementoService implements MementoService {
 
     @Override
-    public CompletableFuture<Void> put(final ResourceService resourceService, final IRI identifier) {
+    public CompletionStage<Void> put(final ResourceService resourceService, final IRI identifier) {
         return completedFuture(null);
     }
 
     @Override
-    public CompletableFuture<Void> put(final Resource resource) {
+    public CompletionStage<Void> put(final Resource resource) {
         return completedFuture(null);
     }
 
     @Override
-    public CompletableFuture<Resource> get(final IRI identifier, final Instant time) {
+    public CompletionStage<Resource> get(final IRI identifier, final Instant time) {
         return completedFuture(MISSING_RESOURCE);
     }
 
     @Override
-    public CompletableFuture<SortedSet<Instant>> mementos(final IRI identifier) {
+    public CompletionStage<SortedSet<Instant>> mementos(final IRI identifier) {
         return completedFuture(emptySortedSet());
     }
 }

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -18,7 +18,7 @@ import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.api.TrellisUtils.getInstance;
 
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.BlankNode;
 import org.apache.commons.rdf.api.IRI;
@@ -112,7 +112,7 @@ public interface ResourceService extends MutableDataService<Resource>, Immutable
      * @return a new completion stage that, when the stage completes normally, indicates that the
      *         identified resource has been updated with a new modification date.
      */
-    CompletableFuture<Void> touch(IRI identifier);
+    CompletionStage<Void> touch(IRI identifier);
 
     /**
      * Return a collection of interaction models supported by this Resource Service.

--- a/core/api/src/main/java/org/trellisldp/api/RetrievalService.java
+++ b/core/api/src/main/java/org/trellisldp/api/RetrievalService.java
@@ -14,7 +14,7 @@
 
 package org.trellisldp.api;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.IRI;
 
@@ -33,5 +33,5 @@ public interface RetrievalService<T> {
      * @param identifier the resource identifier
      * @return the resource
      */
-    CompletableFuture<? extends T> get(IRI identifier);
+    CompletionStage<? extends T> get(IRI identifier);
 }

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -62,7 +62,8 @@ public class BinaryServiceTest {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("FooBar".getBytes(UTF_8));
         when(mockBinaryService.get(eq(identifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent(anyInt(), anyInt())).thenReturn(inputStream);
-        try (final InputStream content = mockBinaryService.get(identifier).thenApply(b -> b.getContent(0, 6)).join()) {
+        try (final InputStream content = mockBinaryService.get(identifier)
+                .thenApply(b -> b.getContent(0, 6)).toCompletableFuture().join()) {
             assertEquals("FooBar", IOUtils.toString(content, UTF_8), "Binary content did not match");
         }
     }
@@ -79,6 +80,7 @@ public class BinaryServiceTest {
                         .setContent(BinaryMetadata.builder(identifier).build(), inputStream,
                                         MessageDigest.getInstance("MD5"))
                         .thenApply(MessageDigest::digest).thenApply(getEncoder()::encodeToString)
-                        .thenAccept(digest -> assertEquals("8yom4qOoqjOM13tuEmPFNQ==", digest))::join);
+                        .thenAccept(digest -> assertEquals("8yom4qOoqjOM13tuEmPFNQ==", digest))
+                        .toCompletableFuture()::join);
     }
 }

--- a/core/api/src/test/java/org/trellisldp/api/NoopMementoServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopMementoServiceTest.java
@@ -67,30 +67,30 @@ public class NoopMementoServiceTest {
 
     @Test
     public void testPutDefaultMethod() {
-        mockMementoService.put(mockResourceService, identifier).join();
+        mockMementoService.put(mockResourceService, identifier).toCompletableFuture().join();
         verify(mockResourceService).get(eq(identifier));
         verify(mockMementoService).put(eq(mockResource));
     }
 
     @Test
     public void testPutResourceServiceNoop() {
-        testService.put(mockResourceService, identifier).join();
+        testService.put(mockResourceService, identifier).toCompletableFuture().join();
         verifyZeroInteractions(mockResourceService);
     }
 
     @Test
     public void testPutResourceNoop() {
-        testService.put(mockResource).join();
+        testService.put(mockResource).toCompletableFuture().join();
         verifyZeroInteractions(mockResource);
     }
 
     @Test
     public void testGetResource() {
-        assertEquals(MISSING_RESOURCE, testService.get(identifier, time).join());
+        assertEquals(MISSING_RESOURCE, testService.get(identifier, time).toCompletableFuture().join());
     }
 
     @Test
     public void testMementos() {
-        assertTrue(testService.mementos(identifier).thenApply(SortedSet::isEmpty).join());
+        assertTrue(testService.mementos(identifier).thenApply(SortedSet::isEmpty).toCompletableFuture().join());
     }
 }

--- a/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -19,7 +19,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.BlankNode;
 import org.apache.commons.rdf.api.Dataset;
@@ -51,7 +51,7 @@ public class ResourceServiceTest {
 
     private static class MyRetrievalService implements RetrievalService<Resource> {
         @Override
-        public CompletableFuture<Resource> get(final IRI id) {
+        public CompletionStage<Resource> get(final IRI id) {
             return completedFuture(mockResource);
         }
     }
@@ -71,12 +71,13 @@ public class ResourceServiceTest {
     @Test
     public void testRetrievalService2() {
         final RetrievalService<Resource> svc = new MyRetrievalService();
-        assertEquals(mockResource, svc.get(existing).join(), "Incorrect resource returned by retrieval service!");
+        assertEquals(mockResource, svc.get(existing).toCompletableFuture().join(),
+                "Incorrect resource returned by retrieval service!");
     }
 
     @Test
     public void testRetrievalService() {
-        assertEquals(mockResource, mockRetrievalService.get(existing).join(),
+        assertEquals(mockResource, mockRetrievalService.get(existing).toCompletableFuture().join(),
                 "Incorrect resource found by retrieval service!");
     }
 
@@ -88,7 +89,7 @@ public class ResourceServiceTest {
 
         when(mockResourceService.replace(eq(metadata), eq(dataset))).thenReturn(completedFuture(null));
 
-        assertDoesNotThrow(() -> mockResourceService.create(metadata, dataset).join());
+        assertDoesNotThrow(() -> mockResourceService.create(metadata, dataset).toCompletableFuture().join());
         verify(mockResourceService).replace(eq(metadata), eq(dataset));
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -48,7 +48,7 @@ import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -157,7 +157,7 @@ public class PatchHandler extends MutatingLdpHandler {
      * @param builder the Trellis response builder
      * @return a response builder promise
      */
-    public CompletableFuture<ResponseBuilder> updateResource(final ResponseBuilder builder) {
+    public CompletionStage<ResponseBuilder> updateResource(final ResponseBuilder builder) {
         LOGGER.debug("Updating {} via PATCH", getIdentifier());
 
         // Add the LDP link types
@@ -210,7 +210,7 @@ public class PatchHandler extends MutatingLdpHandler {
         return ldpResourceTypes(ldpType).map(IRI::getIRIString);
     }
 
-    private CompletableFuture<ResponseBuilder> assembleResponse(final TrellisDataset mutable,
+    private CompletionStage<ResponseBuilder> assembleResponse(final TrellisDataset mutable,
             final TrellisDataset immutable, final ResponseBuilder builder) {
 
         // Put triples in buffer, short-circuit on exception

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -57,8 +57,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -188,9 +188,9 @@ abstract class BaseTestHandler {
         return () -> assertEquals(expectation, actual.contains(type), "Expecting " + type + " to be "
                 + (expectation ? "present" : "absent"));
     }
-    protected void unwrapAsyncError(final CompletableFuture async) {
+    protected void unwrapAsyncError(final CompletionStage async) {
         try {
-            async.join();
+            async.toCompletableFuture().join();
         } catch (final CompletionException ex) {
             if (ex.getCause() instanceof WebApplicationException) {
                 throw (WebApplicationException) ex.getCause();
@@ -207,7 +207,7 @@ abstract class BaseTestHandler {
         return hasLink(iri, TYPE);
     }
 
-    protected static CompletableFuture<Void> asyncException() {
+    protected static CompletionStage<Void> asyncException() {
         return runAsync(() -> {
             throw new RuntimeTrellisException("Expected exception");
         });

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -46,7 +46,8 @@ public class DeleteHandlerTest extends BaseTestHandler {
     @Test
     public void testDelete() {
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, null);
-        final Response res = handler.deleteResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.deleteResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect delete response!");
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -101,7 +101,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response type!");
         assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
@@ -134,7 +134,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response status!");
         assertEquals("text/ldpatch", res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
@@ -151,7 +151,7 @@ public class GetHandlerTest extends BaseTestHandler {
     public void testGetVersionedLdprs() {
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, true, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(from(time), res.getLastModified(), "Incorrect modified date!");
@@ -190,7 +190,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertTrue(res.getLinks().stream().anyMatch(hasType(SKOS.Concept)), "Missing extra type link header!");
@@ -218,7 +218,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(from(time), res.getLastModified(), "Incorrect modified date!");
@@ -254,7 +254,7 @@ public class GetHandlerTest extends BaseTestHandler {
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
 
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code");
         assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
         assertEquals(from(time), res.getLastModified(), "Incorrect modified date!");
@@ -297,7 +297,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
@@ -315,7 +315,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertAll("Check binary description", checkBinaryDescription(res));
     }
@@ -328,7 +328,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertAll("Check binary description", checkBinaryDescription(res));
     }
@@ -356,7 +356,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(-1, res.getLength(), "Incorrect response length!");
@@ -379,7 +379,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertAll("Check LDP type link headers", checkLdpType(res, LDP.RDFSource));

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -91,7 +91,7 @@ public class PatchHandlerTest extends BaseTestHandler {
 
         final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, baseUrl);
         final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
     }
@@ -106,7 +106,7 @@ public class PatchHandlerTest extends BaseTestHandler {
 
         final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
         final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
 
@@ -122,7 +122,7 @@ public class PatchHandlerTest extends BaseTestHandler {
 
         final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
         final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals("return=representation", res.getHeaderString(PREFERENCE_APPLIED),
@@ -144,7 +144,7 @@ public class PatchHandlerTest extends BaseTestHandler {
 
         final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
         final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
-            .join().build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals("return=representation", res.getHeaderString(PREFERENCE_APPLIED),
@@ -192,8 +192,8 @@ public class PatchHandlerTest extends BaseTestHandler {
 
         final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, baseUrl);
         final Response res = assertThrows(BadRequestException.class, () ->
-                patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource)).join(),
-                "No exception when the update triggers an error!").getResponse();
+                patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
+                .toCompletableFuture().join(), "No exception when the update triggers an error!").getResponse();
         assertEquals(BAD_REQUEST, res.getStatusInfo(), "Incorrect response type!");
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -64,7 +64,8 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel("type").build());
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "newresource"), res.getLocation(), "Incorrect Location header!");
@@ -89,7 +90,8 @@ public class PostHandlerTest extends BaseTestHandler {
     @Test
     public void testDefaultType1() throws IOException {
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "newresource"), res.getLocation(), "Incorrect Location header!");
@@ -101,7 +103,8 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getContentType()).thenReturn("text/plain");
 
         final PostHandler handler = buildPostHandler("/simpleData.txt", "newresource", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, DELETED_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, DELETED_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "newresource"), res.getLocation(), "Incorrect Location header!");
@@ -113,7 +116,8 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "newresource"), res.getLocation(), "Incorrect Location header!");
@@ -126,7 +130,8 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
 
         final PostHandler handler = buildPostHandler("/simpleData.txt", "newresource", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "newresource"), res.getLocation(), "Incorrect Location header!");
@@ -138,7 +143,8 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getContentType()).thenReturn("text/turtle");
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "newresource"), res.getLocation(), "Incorrect Location header!");
@@ -152,8 +158,8 @@ public class PostHandlerTest extends BaseTestHandler {
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
         final Response res = assertThrows(BadRequestException.class, () ->
-                handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join(),
-                "No exception thrown when the IXN model isn't supported!").getResponse();
+                handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+                .toCompletableFuture().join(), "No exception thrown when the IXN model isn't supported!").getResponse();
 
         assertEquals(BAD_REQUEST, res.getStatusInfo(), "Incorrect response code!");
         assertTrue(res.getLinks().stream().anyMatch(link ->
@@ -172,7 +178,8 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getContentType()).thenReturn("text/turtle");
 
         final PostHandler handler = buildPostHandler("/simpleTriple.ttl", "newresource", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + path), res.getLocation(), "Incorrect Location header!");
@@ -188,7 +195,8 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getContentType()).thenReturn("text/plain");
 
         final PostHandler handler = buildPostHandler("/simpleData.txt", "new-resource", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "new-resource"), res.getLocation(), "Incorrect Location header!");
@@ -202,7 +210,8 @@ public class PostHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getDigest()).thenReturn(new Digest("md5", "1VOyRwUXW1CPdC5nelt7GQ=="));
 
         final PostHandler handler = buildPostHandler("/simpleData.txt", "resource-with-entity", null);
-        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join().build();
+        final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+            .toCompletableFuture().join().build();
 
         assertEquals(CREATED, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(create(baseUrl + "resource-with-entity"), res.getLocation(), "Incorrect Location hearder!");
@@ -221,7 +230,7 @@ public class PostHandlerTest extends BaseTestHandler {
                 .thenApply(ResponseBuilder::build)
                 .exceptionally(err -> of(err).map(Throwable::getCause).filter(WebApplicationException.class::isInstance)
                     .map(WebApplicationException.class::cast).orElseGet(() -> new WebApplicationException(err))
-                    .getResponse()).join();
+                    .getResponse()).toCompletableFuture().join();
         assertEquals(BAD_REQUEST, res.getStatusInfo(), "Incorrect response type!");
     }
 
@@ -258,7 +267,8 @@ public class PostHandlerTest extends BaseTestHandler {
         final PostHandler handler = new PostHandler(mockTrellisRequest, root, "bad-resource", mockInputStream,
                 mockBundler, null);
         final Response res = assertThrows(WebApplicationException.class, () ->
-                handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).join()).getResponse();
+                handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).toCompletableFuture().join())
+            .getResponse();
         assertEquals(INTERNAL_SERVER_ERROR, res.getStatusInfo(), "Incorrect response code!");
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -68,7 +68,7 @@ public class PutHandlerTest extends BaseTestHandler {
         final PutHandler handler = buildPutHandler("/simpleTriple.ttl", null);
 
         final Response res = assertThrows(WebApplicationException.class, () ->
-                handler.setResource(handler.initialize(mockParent, mockResource)).join(),
+                handler.setResource(handler.initialize(mockParent, mockResource)).toCompletableFuture().join(),
                 "No exception when trying to invalidly change IXN models!").getResponse();
         assertEquals(CONFLICT, res.getStatusInfo(), "Incorrect response code!");
     }
@@ -95,7 +95,8 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
 
         final PutHandler handler = buildPutHandler("/simpleTriple.ttl", null);
-        final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response type");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.RDFSource));
@@ -111,7 +112,8 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel("type").build());
 
         final PutHandler handler = buildPutHandler("/simpleTriple.ttl", null);
-        final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code");
         assertAll("Check LDP type Link headers", checkLdpType(res, LDP.Container));
@@ -127,7 +129,8 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
 
         final PutHandler handler = buildPutHandler("/simpleData.txt", null);
-        final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
         assertAll("Check Binary PUT interactions", checkBinaryPut(res));
@@ -141,7 +144,8 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
 
         final PutHandler handler = buildPutHandler("/simpleData.txt", null);
-        final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
         assertAll("Check Binary PUT interactions", checkBinaryPut(res));
@@ -155,7 +159,8 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.RDFSource.getIRIString()).rel("type").build());
 
         final PutHandler handler = buildPutHandler("/simpleLiteral.ttl", null);
-        final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
         assertAll("Check RDF PUT interactions", checkRdfPut(res));
@@ -168,7 +173,8 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
 
         final PutHandler handler = buildPutHandler("/simpleLiteral.ttl", null);
-        final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
         assertAll("Check RDF PUT interactions", checkRdfPut(res));
@@ -177,7 +183,8 @@ public class PutHandlerTest extends BaseTestHandler {
     @Test
     public void testPutLdpResourceEmpty() {
         final PutHandler handler = buildPutHandler("/emptyData.txt", null);
-        final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
         assertAll("Check RDF PUT interactions", checkRdfPut(res));
@@ -190,7 +197,8 @@ public class PutHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
 
         final PutHandler handler = buildPutHandler("/simpleTriple.ttl", null);
-        final Response res = handler.setResource(handler.initialize(mockParent, mockResource)).join().build();
+        final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
+            .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
         assertAll("Check RDF PUT interactions", checkRdfPut(res));
@@ -204,7 +212,7 @@ public class PutHandlerTest extends BaseTestHandler {
 
         final PutHandler handler = buildPutHandler("/simpleTriple.ttl", null);
         final Response res = assertThrows(BadRequestException.class, () ->
-                handler.setResource(handler.initialize(mockParent, mockResource)).join(),
+                handler.setResource(handler.initialize(mockParent, mockResource)).toCompletableFuture().join(),
                 "No exception when the interaction model isn't supported!").getResponse();
 
         assertEquals(BAD_REQUEST, res.getStatusInfo(), "Incorrect response code!");
@@ -239,7 +247,7 @@ public class PutHandlerTest extends BaseTestHandler {
 
         final PutHandler handler = buildPutHandler("/simpleData.txt", null);
         final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
-            .thenCompose(handler::updateMemento).join().build();
+            .thenCompose(handler::updateMemento).toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
     }


### PR DESCRIPTION
Resolves #345 

This wasn't as simple as advertised. Basically, the testing code makes _extensive_ use of `CompletableFuture::join` as well as `CompletableFuture::allOf`, so there is quite a lot of `CompletionStage::toCompletableFuture` going on. It's a little ugly, but I also don't have any strong opinions about this in the test code.

There are also a few spots in the HTTP layer where `CompletableFuture::allOf` is used, and so in those cases, `CompletionStage::toCompletableFuture` had to be added.

WDYT? Is this change worth the benefit of using `CompletionStage`?