### PR TITLE
Make `WebACService` a CDI `@Alternative`

### DIFF
--- a/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -47,6 +47,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.Graph;
@@ -72,6 +73,7 @@ import org.trellisldp.vocabulary.VCARD;
  *
  * @author acoburn
  */
+@Alternative
 public class WebACService implements AccessControlService {
 
     /** The configuration key controlling whether to check member resources at the AuthZ enforcement point. **/


### PR DESCRIPTION
Make `WebACService` a CDI `@Alternative` to avoid ambiguity with `NoopAccessControlService`