### PR TITLE
Improve handling of client-provided Slug header

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
@@ -30,7 +30,6 @@ import static org.trellisldp.http.core.HttpConstants.ACCEPT_DATETIME;
 import static org.trellisldp.http.core.HttpConstants.EXT;
 import static org.trellisldp.http.core.HttpConstants.PATCH;
 import static org.trellisldp.http.core.HttpConstants.RANGE;
-import static org.trellisldp.http.core.HttpConstants.SLUG;
 import static org.trellisldp.http.core.HttpConstants.TIMEMAP;
 
 import java.io.IOException;
@@ -66,9 +65,6 @@ public class TrellisHttpFilter implements ContainerRequestFilter {
         // Validate header/query parameters
         ofNullable(ctx.getHeaderString(ACCEPT_DATETIME)).filter(x -> isNull(AcceptDatetime.valueOf(x)))
             .ifPresent(x -> ctx.abortWith(status(BAD_REQUEST).build()));
-
-        ofNullable(ctx.getHeaderString(SLUG)).filter(s -> s.contains(slash)).ifPresent(x ->
-            ctx.abortWith(status(BAD_REQUEST).build()));
 
         ofNullable(ctx.getHeaderString(RANGE)).filter(x -> isNull(Range.valueOf(x))).ifPresent(x ->
             ctx.abortWith(status(BAD_REQUEST).build()));

--- a/core/http/src/main/java/org/trellisldp/http/core/Slug.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Slug.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 public class Slug {
 
     private static final Logger LOGGER = getLogger(Slug.class);
+    private static final URLCodec DECODER = new URLCodec();
 
     private final String slugValue;
 
@@ -46,7 +47,7 @@ public class Slug {
      * @param value the value of the Slug header.
      */
     public Slug(final String value) {
-        this.slugValue = replaceChars(requireNonNull(value, "Must be a non-null value!"));
+        this.slugValue = cleanSlugString(requireNonNull(value, "Must be a non-null value!"));
     }
 
     /**
@@ -68,15 +69,16 @@ public class Slug {
 
     private static Optional<String> decodeSlug(final String value) {
         try {
-            final URLCodec decoder = new URLCodec();
-            return of(decoder.decode(value));
+            return of(DECODER.decode(value));
         } catch (final DecoderException ex) {
             LOGGER.warn("Error decoding slug value, ignoring header: {}", ex.getMessage());
         }
         return empty();
     }
 
-    private static String replaceChars(final String value) {
+    private static String cleanSlugString(final String value) {
+        // Remove any fragment URIs and query parameters
+        // Then trim the string and replace any remaining whitespace or slash characters with underscores
         return value.split("#")[0].split("\\?")[0].trim().replaceAll("[\\s/]+", "_");
     }
 }

--- a/core/http/src/main/java/org/trellisldp/http/core/Slug.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Slug.java
@@ -14,12 +14,8 @@
 package org.trellisldp.http.core;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static org.slf4j.LoggerFactory.getLogger;
-
-import java.util.Optional;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.net.URLCodec;
@@ -64,16 +60,16 @@ public class Slug {
      * @return a Slug object with a decoded value or null
      */
     public static Slug valueOf(final String value) {
-        return ofNullable(value).flatMap(Slug::decodeSlug).map(Slug::new).orElse(null);
+        return ofNullable(value).map(Slug::decodeSlug).map(Slug::new).orElse(null);
     }
 
-    private static Optional<String> decodeSlug(final String value) {
+    private static String decodeSlug(final String value) {
         try {
-            return of(DECODER.decode(value));
+            return DECODER.decode(value);
         } catch (final DecoderException ex) {
             LOGGER.warn("Error decoding slug value, ignoring header: {}", ex.getMessage());
         }
-        return empty();
+        return null;
     }
 
     private static String cleanSlugString(final String value) {

--- a/core/http/src/main/java/org/trellisldp/http/core/Slug.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Slug.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http.core;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Optional;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.net.URLCodec;
+import org.slf4j.Logger;
+
+/**
+ * A class representing an HTTP Slug header.
+ *
+ * <p>Any trailing hashURI values (#foo) are removed as are any query parameters (?bar).
+ * Spaces and slashes are converted to underscores.
+ *
+ * @author acoburn
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc5023">RFC 5023</a>
+ */
+public class Slug {
+
+    private static final Logger LOGGER = getLogger(Slug.class);
+
+    private final String slugValue;
+
+    /**
+     * Create a new Slug object.
+     * @param value the value of the Slug header.
+     */
+    public Slug(final String value) {
+        this.slugValue = replaceChars(requireNonNull(value, "Must be a non-null value!"));
+    }
+
+    /**
+     * Get the value of the Slug header.
+     * @return the slug value.
+     */
+    public String getValue() {
+        return slugValue;
+    }
+
+    /**
+     * Get a Slug object from a decoded string value.
+     * @param value the raw value of the HTTP header, may be null
+     * @return a Slug object with a decoded value or null
+     */
+    public static Slug valueOf(final String value) {
+        return ofNullable(value).flatMap(Slug::decodeSlug).map(Slug::new).orElse(null);
+    }
+
+    private static Optional<String> decodeSlug(final String value) {
+        try {
+            final URLCodec decoder = new URLCodec();
+            return of(decoder.decode(value));
+        } catch (final DecoderException ex) {
+            LOGGER.warn("Error decoding slug value, ignoring header: {}", ex.getMessage());
+        }
+        return empty();
+    }
+
+    private static String replaceChars(final String value) {
+        return value.split("#")[0].split("\\?")[0].trim().replaceAll("[\\s/]+", "_");
+    }
+}

--- a/core/http/src/main/java/org/trellisldp/http/core/TrellisRequest.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/TrellisRequest.java
@@ -97,10 +97,11 @@ public class TrellisRequest {
     /**
      * Get the slug header.
      *
-     * @return the value of the slug header
+     * @return the decoded value of the slug header
      */
     public String getSlug() {
-        return headers.getFirst(SLUG);
+        return ofNullable(headers.getFirst(SLUG)).map(Slug::valueOf).filter(Objects::nonNull).map(Slug::getValue)
+            .filter(x -> !x.isEmpty()).orElse(null);
     }
 
     /**

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -1131,13 +1131,162 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostBadSlug() {
+    public void testPostSlugWithSlash() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/child_grandchild"))))
+            .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
 
         final Response res = target(RESOURCE_PATH).request().header(SLUG, "child/grandchild")
             .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
-        assertEquals(SC_BAD_REQUEST, res.getStatus(), "Unexpected response code!");
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + CHILD_PATH + "_grandchild", res.getLocation().toString(),
+                "Incorrect Location header!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostEncodedSlugWithSlash() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/child_grandchild"))))
+            .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "child%2Fgrandchild")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + CHILD_PATH + "_grandchild", res.getLocation().toString(),
+                "Incorrect Location header!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostSlugWithWhitespace() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/child_grandchild"))))
+            .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "child grandchild")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + CHILD_PATH + "_grandchild", res.getLocation().toString(),
+                "Incorrect Location header!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostEncodedSlugWithEncodedWhitespace() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/child_grandchild"))))
+            .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "child%09grandchild")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + CHILD_PATH + "_grandchild", res.getLocation().toString(),
+                "Incorrect Location header!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostEncodedSlugWithInvalidEncoding() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
+            .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "child%0 grandchild")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + RESOURCE_PATH + "/" + RANDOM_VALUE, res.getLocation().toString(),
+                "Incorrect Location header!");
+        assertFalse(getLinks(res).stream().map(Link::getRel).anyMatch(isEqual("describedby")),
+                "Unexpected describedby link!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostEmptySlug() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
+            .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + RESOURCE_PATH + "/" + RANDOM_VALUE, res.getLocation().toString(),
+                "Incorrect Location header!");
+        assertFalse(getLinks(res).stream().map(Link::getRel).anyMatch(isEqual("describedby")),
+                "Unexpected describedby link!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostEmptyEncodedSlug() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+        when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
+            .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "%20%09")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + RESOURCE_PATH + "/" + RANDOM_VALUE, res.getLocation().toString(),
+                "Incorrect Location header!");
+        assertFalse(getLinks(res).stream().map(Link::getRel).anyMatch(isEqual("describedby")),
+                "Unexpected describedby link!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostSlugWithHashURI() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "child#hash")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + CHILD_PATH, res.getLocation().toString(), "Incorrect Location header!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostSlugWithEncodedHashURI() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "child%23hash")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + CHILD_PATH, res.getLocation().toString(), "Incorrect Location header!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostSlugWithQuestionMark() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "child?foo=bar")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + CHILD_PATH, res.getLocation().toString(), "Incorrect Location header!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
+    }
+
+    @Test
+    public void testPostSlugWithEncodedQuestionMark() {
+        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
+
+        final Response res = target(RESOURCE_PATH).request().header(SLUG, "child%3Ffoo=bar")
+            .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
+
+        assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
+        assertEquals(getBaseUrl() + CHILD_PATH, res.getLocation().toString(), "Incorrect Location header!");
+        assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
     }
 
     @Test

--- a/core/http/src/test/java/org/trellisldp/http/core/SlugTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/SlugTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http.core;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author acoburn
+ */
+public class SlugTest {
+
+    @Test
+    public void testSlug() {
+        final Slug slug = Slug.valueOf("slugValue");
+        assertEquals("slugValue", slug.getValue(), "Check slug value");
+    }
+
+    @Test
+    public void testEncodedInput() {
+        final Slug slug = Slug.valueOf("slug%3Avalue");
+        assertEquals("slug:value", slug.getValue(), "Check decoding slug value");
+    }
+
+    @Test
+    public void testSpaceNormalization() {
+        final Slug slug = Slug.valueOf("slug  value");
+        assertEquals("slug_value", slug.getValue(), "Check slug value");
+    }
+
+    @Test
+    public void testSlashNormalization() {
+        final Slug slug = Slug.valueOf("slug/value");
+        assertEquals("slug_value", slug.getValue(), "Check slug value");
+    }
+
+    @Test
+    public void testSpaceSlashNormalization() {
+        final Slug slug = Slug.valueOf("slug\t/ value");
+        assertEquals("slug_value", slug.getValue(), "Check slug value");
+    }
+
+    @Test
+    public void testHashUri() {
+        final Slug slug = Slug.valueOf("slugValue#foo");
+        assertEquals("slugValue", slug.getValue(), "Check slug value");
+    }
+
+    @Test
+    public void testQueryParam() {
+        final Slug slug = Slug.valueOf("slugValue?bar=baz");
+        assertEquals("slugValue", slug.getValue(), "Check slug value");
+    }
+
+    @Test
+    public void testBadInput() {
+        assertNull(Slug.valueOf("An invalid % value"), "Check invalid input");
+    }
+
+    @Test
+    public void testNullInput() {
+        assertNull(Slug.valueOf(null), "Check null input");
+    }
+}


### PR DESCRIPTION
Resolves #376 

Slug values should be URL-decoded, so this adds a new `http.core.Slug` class for handling this step. The rest of the changes are, effectively, adding test cases.

There are also some behavior changes, namely:

1. if the `Slug` headers contains any `/` characters, those will be replaced with an underscore rather than causing the entire request to fail (which is the current behavior)
2. `Slug` headers with whitespace characters will have that whitespace also replaced with underscores.
3. `Slug` headers with a fragment IRI (`#foo`) will have that fragment stripped off
4. `Slug` headers with query parameters (`?bar=baz`) will have that stripped off
