### PR TITLE
Various small syntax cleanups

### DIFF
--- a/components/agent/src/main/java/org/trellisldp/agent/SimpleAgentService.java
+++ b/components/agent/src/main/java/org/trellisldp/agent/SimpleAgentService.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.agent;
 
-import static java.util.Objects.nonNull;
 import static org.trellisldp.api.TrellisUtils.getInstance;
 
 import org.apache.commons.rdf.api.IRI;

--- a/components/agent/src/main/java/org/trellisldp/agent/SimpleAgentService.java
+++ b/components/agent/src/main/java/org/trellisldp/agent/SimpleAgentService.java
@@ -36,7 +36,7 @@ public class SimpleAgentService implements AgentService {
 
     @Override
     public IRI asAgent(final String user) {
-        if (nonNull(user) && !user.isEmpty()) {
+        if (user != null && !user.isEmpty()) {
             return rdf.createIRI(user);
         }
         return Trellis.AnonymousAgent;

--- a/components/constraint-rules/src/main/java/org/trellisldp/constraint/LdpConstraints.java
+++ b/components/constraint-rules/src/main/java/org/trellisldp/constraint/LdpConstraints.java
@@ -14,19 +14,18 @@
 package org.trellisldp.constraint;
 
 import static java.util.Collections.singleton;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
-import static java.util.Optional.of;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.concat;
 
-import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -62,103 +61,110 @@ import org.trellisldp.vocabulary.Trellis;
 public class LdpConstraints implements ConstraintService {
 
     // Identify those predicates that are prohibited in the given ixn model
-    private static final Predicate<Triple> memberContainerConstraints = triple ->
-        triple.getPredicate().equals(ACL.accessControl) || triple.getPredicate().equals(LDP.contains);
+    private static boolean memberContainerConstraints(final Triple triple) {
+        return triple.getPredicate().equals(ACL.accessControl) || triple.getPredicate().equals(LDP.contains);
+    }
 
     // Identify those predicates that are prohibited in the given ixn model
-    private static final Predicate<Triple> basicConstraints = memberContainerConstraints.or(triple ->
-        triple.getPredicate().equals(LDP.insertedContentRelation) ||
-        triple.getPredicate().equals(LDP.membershipResource) ||
-        triple.getPredicate().equals(LDP.hasMemberRelation) ||
-        triple.getPredicate().equals(LDP.isMemberOfRelation));
+    private static boolean basicConstraints(final Triple triple) {
+        return memberContainerConstraints(triple) || triple.getPredicate().equals(LDP.insertedContentRelation)
+                        || triple.getPredicate().equals(LDP.membershipResource)
+                        || triple.getPredicate().equals(LDP.hasMemberRelation)
+                        || triple.getPredicate().equals(LDP.isMemberOfRelation);
+    }
 
     private static final Set<IRI> propertiesWithInDomainRange = singleton(LDP.membershipResource);
 
-    private static final Map<IRI, Predicate<Triple>> typeMap = unmodifiableMap(Stream.of(
-                new SimpleEntry<>(LDP.BasicContainer, basicConstraints),
-                new SimpleEntry<>(LDP.Container, basicConstraints),
-                new SimpleEntry<>(LDP.DirectContainer, memberContainerConstraints),
-                new SimpleEntry<>(LDP.IndirectContainer, memberContainerConstraints),
-                new SimpleEntry<>(LDP.NonRDFSource, basicConstraints),
-                new SimpleEntry<>(LDP.RDFSource, basicConstraints))
-            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    private static final Map<IRI, Predicate<Triple>> typeMapElements = new HashMap<>();
+
+    static {
+        typeMapElements.put(LDP.BasicContainer, LdpConstraints::basicConstraints);
+        typeMapElements.put(LDP.Container, LdpConstraints::basicConstraints);
+        typeMapElements.put(LDP.DirectContainer, LdpConstraints::memberContainerConstraints);
+        typeMapElements.put(LDP.IndirectContainer, LdpConstraints::memberContainerConstraints);
+        typeMapElements.put(LDP.NonRDFSource, LdpConstraints::basicConstraints);
+        typeMapElements.put(LDP.RDFSource, LdpConstraints::basicConstraints);
+    }
+
+    private static final Map<IRI, Predicate<Triple>> typeMap = unmodifiableMap(typeMapElements);
 
     // Properties that need to be used with objects that are IRIs
-    private static final Set<IRI> propertiesWithUriRange = unmodifiableSet(Stream.of(
-                LDP.membershipResource, LDP.hasMemberRelation, LDP.isMemberOfRelation, LDP.inbox,
-                LDP.insertedContentRelation, OA.annotationService).collect(toSet()));
+    private static final List<IRI> propertiesWithUriRange = unmodifiableList(
+                    Arrays.asList(LDP.membershipResource, LDP.hasMemberRelation, LDP.isMemberOfRelation, LDP.inbox,
+                                    LDP.insertedContentRelation, OA.annotationService));
 
     // Properties that cannot be used as dynamic Membership properties
-    private static final Set<IRI> restrictedMemberProperties = unmodifiableSet(Stream.of(
-                ACL.accessControl, LDP.contains, RDF.type, LDP.membershipResource, LDP.hasMemberRelation,
-                LDP.inbox, LDP.insertedContentRelation, OA.annotationService).collect(toSet()));
+    private static final List<IRI> restrictedMemberProperties = unmodifiableList(Arrays.asList(ACL.accessControl,
+                    LDP.contains, RDF.type, LDP.membershipResource, LDP.hasMemberRelation, LDP.inbox,
+                    LDP.insertedContentRelation, OA.annotationService));
 
     // Verify that the object of a triple whose predicate is either ldp:hasMemberRelation or ldp:isMemberOfRelation
     // is not equal to ldp:contains or any of the other cardinality-restricted IRIs
-    private static Predicate<Triple> invalidMembershipProperty = triple ->
-        (LDP.hasMemberRelation.equals(triple.getPredicate()) || LDP.isMemberOfRelation.equals(triple.getPredicate())) &&
-        restrictedMemberProperties.contains(triple.getObject());
+    private static boolean invalidMembershipProperty(final Triple triple) {
+        return (LDP.hasMemberRelation.equals(triple.getPredicate())
+                        || LDP.isMemberOfRelation.equals(triple.getPredicate()))
+                        && restrictedMemberProperties.contains(triple.getObject());
+    }
 
     // Verify that the range of the property is an IRI (if the property is in the above set)
-    private static Predicate<Triple> uriRangeFilter = invalidMembershipProperty.or(triple ->
-        propertiesWithUriRange.contains(triple.getPredicate()) && !(triple.getObject() instanceof IRI))
-        .or(triple -> RDF.type.equals(triple.getPredicate()) && !(triple.getObject() instanceof IRI));
+    private static boolean uriRangeFilter(final Triple triple) {
+        return invalidMembershipProperty(triple)
+                        || (propertiesWithUriRange.contains(triple.getPredicate())
+                                        && !(triple.getObject() instanceof IRI))
+                        || (RDF.type.equals(triple.getPredicate()) && !(triple.getObject() instanceof IRI));
+    }
 
     // Ensure that any LDP properties are appropriate for the interaction model
-    private static Predicate<Triple> propertyFilter(final IRI model) {
-        return of(model).filter(typeMap::containsKey).map(typeMap::get).orElse(basicConstraints);
+    private static boolean propertyFilter(final Triple t, final IRI model) {
+        return typeMap.getOrDefault(model, LdpConstraints::basicConstraints).test(t);
     }
 
     // Verify that the range of the property is in the server's domain
-    private static Predicate<Triple> inDomainRangeFilter(final String domain) {
-        return triple -> propertiesWithInDomainRange.contains(triple.getPredicate()) &&
-            !triple.getObject().ntriplesString().startsWith("<" + domain);
+    private static boolean inDomainRangeFilter(final Triple triple, final String domain) {
+        return propertiesWithInDomainRange.contains(triple.getPredicate())
+                        && !triple.getObject().ntriplesString().startsWith("<" + domain);
     }
 
     // Verify that ldp:membershipResource and one of ldp:hasMemberRelation or ldp:isMemberOfRelation is present
     private static boolean hasMembershipProps(final Graph graph) {
         return graph.contains(null, LDP.membershipResource, null)
-                && (graph.stream(null, LDP.hasMemberRelation, null).count()
-                    + graph.stream(null, LDP.isMemberOfRelation, null).count() == 1L);
+                        && (graph.stream(null, LDP.hasMemberRelation, null).count()
+                                        + graph.stream(null, LDP.isMemberOfRelation, null).count() == 1L);
     }
 
     // Verify that the cardinality of the `propertiesWithUriRange` properties. Keep any whose cardinality is > 1
-    private static Predicate<Graph> checkCardinality(final IRI model) {
-        return graph -> {
-            if (LDP.IndirectContainer.equals(model)) {
-                if (!graph.contains(null, LDP.insertedContentRelation, null) || !hasMembershipProps(graph)) {
-                    return true;
-                }
-            } else if (LDP.DirectContainer.equals(model) && !hasMembershipProps(graph)) {
-                return true;
-            }
-
-            return propertiesWithUriRange.stream().anyMatch(p -> graph.stream(null, p, null).count() > 1);
-        };
+    private static boolean violatesCardinality(final Graph graph, final IRI model) {
+        final boolean isIndirect = LDP.IndirectContainer.equals(model);
+        return isIndirect && (!graph.contains(null, LDP.insertedContentRelation, null) || !hasMembershipProps(graph))
+                        || !isIndirect && LDP.DirectContainer.equals(model) && !hasMembershipProps(graph)
+                        || propertiesWithUriRange.stream().anyMatch(p -> graph.stream(null, p, null).count() > 1);
     }
 
-    private Function<Triple, Stream<ConstraintViolation>> checkModelConstraints(final IRI model, final String domain) {
+    private List<ConstraintViolation> violatesModelConstraints(final Triple triple, final IRI model,
+                    final String domain) {
         requireNonNull(model, "The interaction model must not be null!");
-
-        return triple -> {
-            final Stream.Builder<ConstraintViolation> builder = Stream.builder();
-            of(triple).filter(propertyFilter(model)).map(t -> new ConstraintViolation(Trellis.InvalidProperty, t))
-                .ifPresent(builder::accept);
-
-            of(triple).filter(uriRangeFilter).map(t -> new ConstraintViolation(Trellis.InvalidRange, t))
-                .ifPresent(builder::accept);
-
-            of(triple).filter(inDomainRangeFilter(domain)).map(t -> new ConstraintViolation(Trellis.InvalidRange, t))
-                .ifPresent(builder::accept);
-
-            return builder.build();
-        };
-    }
+        final List<ConstraintViolation> violations = new ArrayList<>();
+        if (propertyFilter(triple, model)) {
+            violations.add(new ConstraintViolation(Trellis.InvalidProperty, triple));
+        }
+        if (uriRangeFilter(triple)) {
+            violations.add(new ConstraintViolation(Trellis.InvalidRange, triple));
+        }
+        if (inDomainRangeFilter(triple, domain)) {
+            violations.add(new ConstraintViolation(Trellis.InvalidRange, triple));
+        }
+        return violations;
+    };
 
     @Override
     public Stream<ConstraintViolation> constrainedBy(final IRI model, final Graph graph, final String domain) {
-        return concat(graph.stream().flatMap(checkModelConstraints(model, domain)),
-                Stream.of(graph).filter(checkCardinality(model))
-                    .map(g -> new ConstraintViolation(Trellis.InvalidCardinality, g.stream().collect(toList()))));
+        Stream<ConstraintViolation> violations = graph.stream()
+                        .flatMap(t -> violatesModelConstraints(t, model, domain).stream());
+        if (violatesCardinality(graph, model)) {
+            final ConstraintViolation cardinalityViolation = new ConstraintViolation(Trellis.InvalidCardinality,
+                            graph.stream().collect(toList()));
+            violations = concat(violations, Stream.of(cardinalityViolation));
+        }
+        return violations;
     }
 }

--- a/components/event-serialization/src/main/java/org/trellisldp/event/ActivityStreamMessage.java
+++ b/components/event-serialization/src/main/java/org/trellisldp/event/ActivityStreamMessage.java
@@ -70,18 +70,14 @@ class ActivityStreamMessage {
         }
 
         /**
-         * Get the identifier.
-         *
-         * @return the id
+         * @return the identifier
          */
         public String getId() {
             return id;
         }
 
         /**
-         * Get the resource types.
-         *
-         * @return the types
+         * @return the resource types
          */
         public List<String> getType() {
             return type;
@@ -89,8 +85,6 @@ class ActivityStreamMessage {
     }
 
     /**
-     * Get the event identifier.
-     *
      * @return the event identifier
      */
     public String getId() {
@@ -98,8 +92,6 @@ class ActivityStreamMessage {
     }
 
     /**
-     * Get the event types.
-     *
      * @return the event types
      */
     public List<String> getType() {
@@ -107,28 +99,28 @@ class ActivityStreamMessage {
     }
 
     /**
-     * The inbox assocated with the resource.
+     * @return the inbox assocated with the resource
      */
     public String getInbox() {
         return inbox;
     }
 
     /**
-     * The actors associated with this event.
+     * @return the actors associated with this event
      */
     public List<String> getActor() {
         return actor;
     }
 
     /**
-     * The target resource.
+     * @return the target resource
      */
     public EventResource getObject() {
         return object;
     }
 
     /**
-     * The created date.
+     * @return the created date
      */
     @JsonProperty("published")
     public String getPublished() {

--- a/core/api/src/main/java/org/trellisldp/api/NoopAccessControlService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopAccessControlService.java
@@ -31,7 +31,7 @@ public class NoopAccessControlService implements AccessControlService {
     private static final RDF rdf = getInstance();
     private static final String URI = "http://www.w3.org/ns/auth/acl#";
     private static final Set<IRI> modes = unmodifiableSet(asList("Control", "Read", "Write", "Append")
-            .stream().map(mode -> URI + mode).map(rdf::createIRI).collect(toSet()));
+            .stream().map(URI::concat).map(rdf::createIRI).collect(toSet()));
 
     @Override
     public Set<IRI> getAccessModes(final IRI identifier, final Session session) {

--- a/core/api/src/main/java/org/trellisldp/api/NoopCacheService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopCacheService.java
@@ -17,6 +17,8 @@ import java.util.function.Function;
 
 /**
  * A no-op (pass-through) cache service for Trellis.
+ * @param <K> the type of key to use
+ * @param <V> the type of value to cache
  */
 public class NoopCacheService<K, V> implements CacheService<K, V> {
 

--- a/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
+++ b/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
@@ -40,15 +40,14 @@ import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.api.Triple;
 
 /**
- * The TrellisUtils class provides a set of convenience methods related to
- * generating and processing RDF objects.
+ * The TrellisUtils class provides a set of convenience methods related to generating and processing RDF objects.
  *
  * @author acoburn
  */
 public final class TrellisUtils {
 
     private static RDF rdf = findFirst(RDF.class)
-        .orElseThrow(() -> new RuntimeTrellisException("No RDF Commons implementation available!"));
+                    .orElseThrow(() -> new RuntimeTrellisException("No RDF Commons implementation available!"));
 
     /**
      * The internal trellis scheme.
@@ -81,13 +80,14 @@ public final class TrellisUtils {
 
     /**
      * Get a service.
+     * 
      * @param service the interface or abstract class representing the service
      * @param <T> the class of the service type
      * @return the first service provider or empty Optional if no service providers are located
      */
     private static <T> Optional<T> findFirst(final Class<T> service) {
-        return Optional.of(ServiceLoader.load(service)).map(ServiceLoader::iterator).filter(Iterator::hasNext)
-            .map(Iterator::next);
+        Iterator<T> services = ServiceLoader.load(service).iterator();
+        return services.hasNext() ? Optional.of(services.next()) : Optional.empty();
     }
 
     /**
@@ -98,8 +98,10 @@ public final class TrellisUtils {
      */
     public static Optional<IRI> getContainer(final IRI identifier) {
         final String path = identifier.getIRIString().substring(TRELLIS_DATA_PREFIX.length());
-        return Optional.of(path).filter(p -> !p.isEmpty()).map(x -> x.lastIndexOf('/')).map(idx -> idx < 0 ? 0 : idx)
-                    .map(idx -> TRELLIS_DATA_PREFIX + path.substring(0, idx)).map(rdf::createIRI);
+        if (path.isEmpty()) return Optional.empty();
+        int lastIndex = path.lastIndexOf('/');
+        int i = lastIndex < 0 ? 0 : lastIndex;
+        return Optional.of(rdf.createIRI(TRELLIS_DATA_PREFIX + path.substring(0, i)));
     }
 
     /**
@@ -117,8 +119,7 @@ public final class TrellisUtils {
     /**
      * Collect a stream of Quads into a Dataset.
      *
-     * @return a {@link Collector} that accumulates a {@link Stream} of
-     *         {@link Quad}s into a {@link Dataset}
+     * @return a {@link Collector} that accumulates a {@link Stream} of {@link Quad}s into a {@link Dataset}
      */
     public static DatasetCollector toDataset() {
         return new DatasetCollector();
@@ -155,11 +156,9 @@ public final class TrellisUtils {
         }
 
         /**
-         * Collect a stream of {@link Quad}s into a {@link Dataset} with concurrent
-         * operation.
+         * Collect a stream of {@link Quad}s into a {@link Dataset} with concurrent operation.
          *
-         * @return a {@link Collector} that accumulates a {@link Stream} of
-         *         {@link Quad}s into a {@link Dataset}
+         * @return a {@link Collector} that accumulates a {@link Stream} of {@link Quad}s into a {@link Dataset}
          */
         public ConcurrentDatasetCollector concurrent() {
             return new ConcurrentDatasetCollector();

--- a/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
+++ b/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
@@ -86,7 +86,7 @@ public final class TrellisUtils {
      * @return the first service provider or empty Optional if no service providers are located
      */
     private static <T> Optional<T> findFirst(final Class<T> service) {
-        Iterator<T> services = ServiceLoader.load(service).iterator();
+        final Iterator<T> services = ServiceLoader.load(service).iterator();
         return services.hasNext() ? Optional.of(services.next()) : Optional.empty();
     }
 
@@ -97,11 +97,12 @@ public final class TrellisUtils {
      * @return a container, if one exists. Only the root resource would return empty here.
      */
     public static Optional<IRI> getContainer(final IRI identifier) {
+        if (identifier.getIRIString().equals(TRELLIS_DATA_PREFIX)) {
+            return Optional.empty();
+        }
         final String path = identifier.getIRIString().substring(TRELLIS_DATA_PREFIX.length());
-        if (path.isEmpty()) return Optional.empty();
-        int lastIndex = path.lastIndexOf('/');
-        int i = lastIndex < 0 ? 0 : lastIndex;
-        return Optional.of(rdf.createIRI(TRELLIS_DATA_PREFIX + path.substring(0, i)));
+        final int index = Math.max(path.lastIndexOf('/'), 0);
+        return Optional.of(rdf.createIRI(TRELLIS_DATA_PREFIX + path.substring(0, index)));
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/AgentAuthorizationFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/AgentAuthorizationFilter.java
@@ -14,7 +14,6 @@
 package org.trellisldp.http;
 
 import static java.util.Arrays.stream;
-import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.Priorities.AUTHORIZATION;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
@@ -96,7 +95,7 @@ public class AgentAuthorizationFilter implements ContainerRequestFilter {
     }
 
     private static String getPrincipalName(final Principal principal) {
-        if (nonNull(principal) && !principal.getName().isEmpty()) {
+        if (principal != null && !principal.getName().isEmpty()) {
             return principal.getName();
         }
         return null;

--- a/core/http/src/main/java/org/trellisldp/http/CrossOriginResourceSharingFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/CrossOriginResourceSharingFilter.java
@@ -18,7 +18,6 @@ import static java.util.Arrays.stream;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
-import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.HttpMethod.OPTIONS;
@@ -142,7 +141,7 @@ public class CrossOriginResourceSharingFilter implements ContainerResponseFilter
         final String origin = req.getHeaderString("Origin");
 
         // 6.1.1 Terminate if an Origin header is not present
-        if (isNull(origin)) {
+        if (origin == null) {
             LOGGER.debug("CORS: No Origin header");
             return emptyMap();
         }
@@ -173,7 +172,7 @@ public class CrossOriginResourceSharingFilter implements ContainerResponseFilter
         final String origin = req.getHeaderString("Origin");
 
         // 6.1.1 Terminate if an Origin header is not present
-        if (isNull(origin)) {
+        if (origin == null) {
             LOGGER.debug("CORS PreFlight: No Origin header");
             return emptyMap();
         }
@@ -231,7 +230,7 @@ public class CrossOriginResourceSharingFilter implements ContainerResponseFilter
     }
 
     private static Set<String> populateFieldNames(final String requestHeaders) {
-        return isNull(requestHeaders)
+        return requestHeaders == null
             ? emptySet()
             : stream(requestHeaders.split(",")).map(String::trim).collect(toSet());
     }

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
@@ -14,8 +14,7 @@
 package org.trellisldp.http;
 
 import static java.util.Arrays.asList;
-import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
+import static java.util.Collections.unmodifiableList;
 import static javax.ws.rs.HttpMethod.DELETE;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.HttpMethod.PUT;
@@ -51,7 +50,7 @@ import org.trellisldp.http.core.Version;
 @Priority(AUTHORIZATION - 20)
 public class TrellisHttpFilter implements ContainerRequestFilter {
 
-    private static final List<String> MUTATING_METHODS = asList(POST, PUT, DELETE, PATCH);
+    private static final List<String> MUTATING_METHODS = unmodifiableList(asList(POST, PUT, DELETE, PATCH));
 
     @Override
     public void filter(final ContainerRequestContext ctx) throws IOException {
@@ -76,21 +75,21 @@ public class TrellisHttpFilter implements ContainerRequestFilter {
 
     private void validateAcceptDatetime(final ContainerRequestContext ctx) {
         final String acceptDatetime = ctx.getHeaderString(ACCEPT_DATETIME);
-        if (nonNull(acceptDatetime) && isNull(AcceptDatetime.valueOf(acceptDatetime))) {
+        if (acceptDatetime != null && AcceptDatetime.valueOf(acceptDatetime) == null) {
             ctx.abortWith(status(BAD_REQUEST).build());
         }
     }
 
     private void validateRange(final ContainerRequestContext ctx) {
         final String range = ctx.getHeaderString(RANGE);
-        if (nonNull(range) && isNull(Range.valueOf(range))) {
+        if (range != null && Range.valueOf(range) == null) {
             ctx.abortWith(status(BAD_REQUEST).build());
         }
     }
 
     private void validateLink(final ContainerRequestContext ctx) {
         final String link = ctx.getHeaderString(LINK);
-        if (nonNull(link)) {
+        if (link != null) {
             try {
                 Link.valueOf(link);
             } catch (final IllegalArgumentException ex) {
@@ -101,9 +100,9 @@ public class TrellisHttpFilter implements ContainerRequestFilter {
 
     private void validateVersion(final ContainerRequestContext ctx) {
         final String version = ctx.getUriInfo().getQueryParameters().getFirst("version");
-        if (nonNull(version)) {
+        if (version != null) {
             // Check well-formedness
-            if (isNull(Version.valueOf(version))) {
+            if (Version.valueOf(version) == null) {
                 ctx.abortWith(status(BAD_REQUEST).build());
             // Do not allow mutating versioned resources
             } else if (MUTATING_METHODS.contains(ctx.getMethod())) {
@@ -115,7 +114,7 @@ public class TrellisHttpFilter implements ContainerRequestFilter {
     private void validateTimeMap(final ContainerRequestContext ctx) {
         final List<String> exts = ctx.getUriInfo().getQueryParameters().get(EXT);
         // Do not allow direct manipulation of timemaps
-        if (nonNull(exts) && exts.contains(TIMEMAP) && MUTATING_METHODS.contains(ctx.getMethod())) {
+        if (exts != null && exts.contains(TIMEMAP) && MUTATING_METHODS.contains(ctx.getMethod())) {
             ctx.abortWith(status(METHOD_NOT_ALLOWED).build());
         }
     }

--- a/core/http/src/main/java/org/trellisldp/http/WebAcFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/WebAcFilter.java
@@ -15,7 +15,6 @@ package org.trellisldp.http;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.Priorities.AUTHORIZATION;
@@ -151,7 +150,7 @@ public class WebAcFilter implements ContainerRequestFilter, ContainerResponseFil
     }
 
     private UriBuilder getRequestUri(final ContainerRequestContext req) {
-        if (nonNull(baseUrl)) {
+        if (baseUrl != null) {
             return UriBuilder.fromUri(baseUrl).path(req.getUriInfo().getPath());
         }
         return req.getUriInfo().getAbsolutePathBuilder();
@@ -159,7 +158,7 @@ public class WebAcFilter implements ContainerRequestFilter, ContainerResponseFil
 
     protected Session getOrCreateSession(final ContainerRequestContext ctx) {
         final Object session = ctx.getProperty(SESSION_PROPERTY);
-        if (nonNull(session)) {
+        if (session != null) {
             return (Session) session;
         }
         final Session s = new HttpSession();

--- a/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.http;
 
-import static java.util.Objects.nonNull;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.HEAD;
 import static javax.ws.rs.core.HttpHeaders.LINK;
@@ -63,7 +62,7 @@ public class WebSubHeaderFilter implements ContainerResponseFilter {
     @Override
     public void filter(final ContainerRequestContext req, final ContainerResponseContext res) throws IOException {
         if ((GET.equals(req.getMethod()) || HEAD.equals(req.getMethod()))
-                && SUCCESSFUL.equals(res.getStatusInfo().getFamily()) && nonNull(hub)) {
+                && SUCCESSFUL.equals(res.getStatusInfo().getFamily()) && hub != null) {
             res.getHeaders().add(LINK, fromUri(hub).rel("hub").build());
         }
     }

--- a/core/http/src/main/java/org/trellisldp/http/core/AcceptDatetime.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/AcceptDatetime.java
@@ -15,7 +15,6 @@ package org.trellisldp.http.core;
 
 import static java.time.ZonedDateTime.parse;
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
-import static java.util.Objects.nonNull;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.time.DateTimeException;
@@ -64,9 +63,9 @@ public class AcceptDatetime {
      * @return an AcceptDatetime object or null if the value is not parseable
      */
     public static AcceptDatetime valueOf(final String value) {
-        if (nonNull(value)) {
+        if (value != null) {
             final Instant time = parseDatetime(value);
-            if (nonNull(time)) {
+            if (time != null) {
                 return new AcceptDatetime(time);
             }
         }

--- a/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
@@ -13,13 +13,13 @@
  */
 package org.trellisldp.http.core;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.addAll;
 import static java.util.Collections.unmodifiableSet;
-import static java.util.stream.Collectors.toSet;
 import static org.trellisldp.vocabulary.LDP.PreferContainment;
 import static org.trellisldp.vocabulary.LDP.PreferMembership;
 import static org.trellisldp.vocabulary.Trellis.PreferUserManaged;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.rdf.api.IRI;
@@ -121,9 +121,14 @@ public final class HttpConstants {
     /** The Memento link parameter indicating the ending range of a TimeMap. **/
     public static final String UNTIL = "until";
 
+    private static final Set<IRI> DEFAULT_REPRESENTATION_ELEMENTS = new HashSet<>(); 
+
+    static {
+        addAll(DEFAULT_REPRESENTATION_ELEMENTS, PreferContainment, PreferMembership, PreferUserManaged);
+    }
+
     /** The implied or default set of IRIs used with a Prefer header. **/
-    public static final Set<IRI> DEFAULT_REPRESENTATION = unmodifiableSet(asList(PreferContainment, PreferMembership,
-                PreferUserManaged).stream().collect(toSet()));
+    public static final Set<IRI> DEFAULT_REPRESENTATION = unmodifiableSet(DEFAULT_REPRESENTATION_ELEMENTS);
 
     private HttpConstants() {
         // prevent instantiation

--- a/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
@@ -121,7 +121,7 @@ public final class HttpConstants {
     /** The Memento link parameter indicating the ending range of a TimeMap. **/
     public static final String UNTIL = "until";
 
-    private static final Set<IRI> DEFAULT_REPRESENTATION_ELEMENTS = new HashSet<>(); 
+    private static final Set<IRI> DEFAULT_REPRESENTATION_ELEMENTS = new HashSet<>();
 
     static {
         addAll(DEFAULT_REPRESENTATION_ELEMENTS, PreferContainment, PreferMembership, PreferUserManaged);

--- a/core/http/src/main/java/org/trellisldp/http/core/Prefer.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Prefer.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableList;
-import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;
 
@@ -80,9 +79,9 @@ public class Prefer {
         this.preference = PREFER_MINIMAL.equals(preference) || PREFER_REPRESENTATION.equals(preference)
             ? preference : null;
         this.handling = PREFER_LENIENT.equals(handling) || PREFER_STRICT.equals(handling) ? handling : null;
-        this.include = nonNull(include) ? include : emptyList();
-        this.omit = nonNull(omit) ? omit : emptyList();
-        this.params = nonNull(params) ? params : emptySet();
+        this.include = include != null ? include : emptyList();
+        this.omit = omit != null ? omit : emptyList();
+        this.params = params != null ? params : emptySet();
     }
 
     /**
@@ -92,7 +91,7 @@ public class Prefer {
      * @return a Prefer object or null on an invalid string
      */
     public static Prefer valueOf(final String value) {
-        if (nonNull(value)) {
+        if (value != null) {
             final Map<String, String> data = new HashMap<>();
             final Set<String> params = new HashSet<>();
             stream(value.split(";")).map(String::trim).map(pref -> pref.split("=", 2)).forEach(x -> {
@@ -184,7 +183,7 @@ public class Prefer {
     }
 
     private static List<String> parseParameter(final String param) {
-        if (nonNull(param)) {
+        if (param != null) {
             return asList(trimQuotes(param).split("\\s+"));
         }
         return emptyList();

--- a/core/http/src/main/java/org/trellisldp/http/core/Range.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Range.java
@@ -14,7 +14,6 @@
 package org.trellisldp.http.core;
 
 import static java.lang.Integer.parseInt;
-import static java.util.Objects.nonNull;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import org.slf4j.Logger;
@@ -76,7 +75,7 @@ public class Range {
     }
 
     private static int[] parse(final String range) {
-        if (nonNull(range) && range.startsWith("bytes=")) {
+        if (range != null && range.startsWith("bytes=")) {
             final String[] parts = range.substring("bytes=".length()).split("-");
             if (parts.length == 2) {
                 try {

--- a/core/http/src/main/java/org/trellisldp/http/core/Slug.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Slug.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.http.core;
 
-import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -60,9 +59,9 @@ public class Slug {
      * @return a Slug object with a decoded value or null
      */
     public static Slug valueOf(final String value) {
-        if (nonNull(value)) {
+        if (value != null) {
             final String decoded = decodeSlug(value);
-            if (nonNull(decoded)) {
+            if (decoded != null) {
                 return new Slug(decoded);
             }
         }

--- a/core/http/src/main/java/org/trellisldp/http/core/TrellisRequest.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/TrellisRequest.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.http.core;
 
-import static java.util.Objects.nonNull;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static org.trellisldp.http.core.HttpConstants.ACCEPT_DATETIME;
@@ -99,7 +98,7 @@ public class TrellisRequest {
      */
     public String getSlug() {
         final Slug slug = Slug.valueOf(headers.getFirst(SLUG));
-        if (nonNull(slug) && !slug.getValue().isEmpty()) {
+        if (slug != null && !slug.getValue().isEmpty()) {
             return slug.getValue();
         }
         return null;
@@ -112,7 +111,7 @@ public class TrellisRequest {
      */
     public Link getLink() {
         final String link = headers.getFirst(LINK);
-        if (nonNull(link)) {
+        if (link != null) {
             return Link.valueOf(link);
         }
         return null;
@@ -243,9 +242,9 @@ public class TrellisRequest {
     }
 
     private static String getPrincipalName(final SecurityContext secCtx) {
-        if (nonNull(secCtx)) {
+        if (secCtx != null) {
             final Principal principal = secCtx.getUserPrincipal();
-            if (nonNull(principal)) {
+            if (principal != null) {
                 return principal.getName();
             }
         }

--- a/core/http/src/main/java/org/trellisldp/http/core/Version.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Version.java
@@ -15,7 +15,6 @@ package org.trellisldp.http.core;
 
 import static java.lang.Long.parseLong;
 import static java.time.Instant.ofEpochSecond;
-import static java.util.Objects.nonNull;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.time.Instant;
@@ -72,9 +71,9 @@ public class Version {
      * @return a Version header or null if the value is not parseable
      */
     public static Version valueOf(final String value) {
-        if (nonNull(value)) {
+        if (value != null) {
             final Instant time = parse(value);
-            if (nonNull(time)) {
+            if (time != null) {
                 return new Version(time);
             }
         }

--- a/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.http.impl;
 
-import static java.util.Objects.nonNull;
 import static javax.ws.rs.core.HttpHeaders.IF_MATCH;
 import static javax.ws.rs.core.HttpHeaders.IF_MODIFIED_SINCE;
 import static javax.ws.rs.core.HttpHeaders.IF_NONE_MATCH;
@@ -139,7 +138,7 @@ class BaseLdpHandler {
     }
 
     private static String getRequestBaseUrl(final TrellisRequest req, final String baseUrl) {
-        final String base = nonNull(baseUrl) ? baseUrl : req.getBaseUrl();
+        final String base = baseUrl != null ? baseUrl : req.getBaseUrl();
         if (base.endsWith("/")) {
             return base;
         }

--- a/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
@@ -18,8 +18,6 @@ import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Arrays.stream;
 import static java.util.Collections.unmodifiableSet;
-import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
@@ -95,7 +93,7 @@ public final class HttpUtils {
      */
     public static Stream<IRI> ldpResourceTypes(final IRI ixnModel) {
         final Stream.Builder<IRI> supertypes = Stream.builder();
-        if (nonNull(ixnModel)) {
+        if (ixnModel != null) {
             LOGGER.debug("Finding types that subsume {}", ixnModel.getIRIString());
             supertypes.accept(ixnModel);
             final IRI superClass = LDP.getSuperclassOf(ixnModel);
@@ -114,7 +112,7 @@ public final class HttpUtils {
      */
     public static String buildEtagHash(final String identifier, final Instant modified, final Prefer prefer) {
         final String sep = ".";
-        final String hash = nonNull(prefer) ? prefer.getInclude().hashCode() + sep + prefer.getOmit().hashCode() : "";
+        final String hash = prefer != null ? prefer.getInclude().hashCode() + sep + prefer.getOmit().hashCode() : "";
         return md5Hex(modified.toEpochMilli() + sep + modified.getNano() + sep + hash + sep + identifier);
     }
 
@@ -126,7 +124,7 @@ public final class HttpUtils {
      */
     public static Set<IRI> triplePreferences(final Prefer prefer) {
         final Set<IRI> include = new HashSet<>(DEFAULT_REPRESENTATION);
-        if (nonNull(prefer)) {
+        if (prefer != null) {
             if (prefer.getInclude().contains(LDP.PreferMinimalContainer.getIRIString())) {
                 include.remove(LDP.PreferContainment);
                 include.remove(LDP.PreferMembership);
@@ -157,7 +155,7 @@ public final class HttpUtils {
     }
 
     private static boolean notCompareWithString(final RDFTerm term, final String str) {
-        return nonNull(str) && !str.isEmpty() && (term instanceof IRI && !((IRI) term).getIRIString().equals(str)
+        return str != null && !str.isEmpty() && (term instanceof IRI && !((IRI) term).getIRIString().equals(str)
                     || term instanceof Literal && !((Literal) term).getLexicalForm().equals(str));
     }
 
@@ -210,9 +208,9 @@ public final class HttpUtils {
     public static RDFSyntax getSyntax(final IOService ioService, final List<MediaType> acceptableTypes,
             final String mimeType) {
         if (acceptableTypes.isEmpty()) {
-            return nonNull(mimeType) ? null : TURTLE;
+            return mimeType != null ? null : TURTLE;
         }
-        final MediaType mt = nonNull(mimeType) ? MediaType.valueOf(mimeType) : null;
+        final MediaType mt = mimeType != null ? MediaType.valueOf(mimeType) : null;
         for (final MediaType type : acceptableTypes) {
             if (type.isCompatible(mt)) {
                 return null;
@@ -220,7 +218,7 @@ public final class HttpUtils {
             final RDFSyntax syntax = ioService.supportedReadSyntaxes().stream()
                 .filter(s -> MediaType.valueOf(s.mediaType()).isCompatible(type))
                 .findFirst().orElse(null);
-            if (nonNull(syntax)) {
+            if (syntax != null) {
                 return syntax;
             }
         }
@@ -286,7 +284,7 @@ public final class HttpUtils {
             final String defaultJsonLdProfile) {
         if (RDFA.equals(syntax)) {
             return identifier;
-        } else if (nonNull(defaultJsonLdProfile)) {
+        } else if (defaultJsonLdProfile != null) {
             return rdf.createIRI(defaultJsonLdProfile);
         }
         return compacted;
@@ -312,7 +310,7 @@ public final class HttpUtils {
             final Instant modified) {
         if (isGetOrHead(method)) {
             final Instant time = parseDate(ifModifiedSince);
-            if (nonNull(time) && time.isAfter(modified.truncatedTo(SECONDS))) {
+            if (time != null && time.isAfter(modified.truncatedTo(SECONDS))) {
                 throw new RedirectionException(notModified().build());
             }
         }
@@ -325,7 +323,7 @@ public final class HttpUtils {
      */
     public static void checkIfUnmodifiedSince(final String ifUnmodifiedSince, final Instant modified) {
         final Instant time = parseDate(ifUnmodifiedSince);
-        if (nonNull(time) && modified.truncatedTo(SECONDS).isAfter(time)) {
+        if (time != null && modified.truncatedTo(SECONDS).isAfter(time)) {
             throw new ClientErrorException(status(PRECONDITION_FAILED).build());
         }
     }
@@ -336,7 +334,7 @@ public final class HttpUtils {
      * @param etag the resource etag
      */
     public static void checkIfMatch(final String ifMatch, final EntityTag etag) {
-        if (isNull(ifMatch)) {
+        if (ifMatch == null) {
             return;
         }
         final Set<String> items = stream(ifMatch.split(",")).map(String::trim).collect(toSet());
@@ -359,7 +357,7 @@ public final class HttpUtils {
      * @param etag the resource etag
      */
     public static void checkIfNoneMatch(final String method, final String ifNoneMatch, final EntityTag etag) {
-        if (isNull(ifNoneMatch)) {
+        if (ifNoneMatch == null) {
             return;
         }
 
@@ -381,7 +379,7 @@ public final class HttpUtils {
     }
 
     private static Instant parseDate(final String date) {
-        if (nonNull(date)) {
+        if (date != null) {
             try {
                 return parse(date.trim(), RFC_1123_DATE_TIME).toInstant();
             } catch (final DateTimeException ex) {
@@ -399,7 +397,7 @@ public final class HttpUtils {
      */
     public static void checkRequiredPreconditions(final boolean required, final String ifMatch,
             final String ifUnmodifiedSince) {
-        if (required && isNull(ifMatch) && isNull(ifUnmodifiedSince)) {
+        if (required && ifMatch == null && ifUnmodifiedSince == null) {
             throw new ClientErrorException(status(PRECONDITION_REQUIRED).build());
         }
     }

--- a/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
@@ -18,7 +18,6 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.ofInstant;
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static java.util.Objects.nonNull;
 import static java.util.Optional.of;
 import static java.util.ServiceLoader.load;
 import static java.util.stream.Collectors.joining;
@@ -116,9 +115,9 @@ public final class MementoResource {
 
         final RDFSyntax syntax = getSyntax(trellis.getIOService(), acceptableTypes, APPLICATION_LINK_FORMAT);
 
-        if (nonNull(syntax)) {
+        if (syntax != null) {
             final IRI profile = getProfile(acceptableTypes, syntax);
-            final IRI jsonldProfile = nonNull(profile) ? profile : compacted;
+            final IRI jsonldProfile = profile != null ? profile : compacted;
 
             final StreamingOutput stream = new StreamingOutput() {
                 @Override

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -14,7 +14,6 @@
 package org.trellisldp.http.impl;
 
 import static java.util.Arrays.asList;
-import static java.util.Objects.nonNull;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Predicate.isEqual;
@@ -99,7 +98,7 @@ class MutatingLdpHandler extends BaseLdpHandler {
             final String baseUrl, final InputStream entity) {
         super(req, trellis, baseUrl);
         this.entity = entity;
-        if (nonNull(req.getPrincipalName())) {
+        if (req.getPrincipalName() != null) {
             this.session = new HttpSession(getServices().getAgentService().asAgent(req.getPrincipalName()));
         } else {
             this.session = new HttpSession();
@@ -111,14 +110,14 @@ class MutatingLdpHandler extends BaseLdpHandler {
     }
 
     protected IRI getParentIdentifier() {
-        if (nonNull(parent)) {
+        if (parent != null) {
             return parent.getIdentifier();
         }
         return null;
     }
 
     protected IRI getParentModel() {
-        if (nonNull(parent)) {
+        if (parent != null) {
             return parent.getInteractionModel();
         }
         return null;
@@ -290,10 +289,10 @@ class MutatingLdpHandler extends BaseLdpHandler {
     private CompletionStage<Void> emitMembershipUpdateEvent() {
         final IRI membershipResource = parent.getMembershipResource().map(MutatingLdpHandler::removeHashFragment)
             .orElse(null);
-        if (nonNull(membershipResource)) {
+        if (membershipResource != null) {
             return allOf(getServices().getResourceService().touch(membershipResource).toCompletableFuture(),
                 getServices().getResourceService().get(membershipResource).thenAccept(res -> {
-                    if (nonNull(res.getIdentifier())) {
+                    if (res.getIdentifier() != null) {
                         getServices().getEventService().emit(new SimpleEvent(getUrl(res.getIdentifier()),
                                     getSession().getAgent(), asList(PROV.Activity, AS.Update),
                                     asList(res.getInteractionModel())));

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -13,8 +13,6 @@
  */
 package org.trellisldp.http.impl;
 
-import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
@@ -125,14 +123,14 @@ public class PatchHandler extends MutatingLdpHandler {
         } else if (DELETED_RESOURCE.equals(resource)) {
             // Can't patch non-existent resources
             throw new ClientErrorException(GONE);
-        } else if (isNull(updateBody)) {
+        } else if (updateBody == null) {
             LOGGER.error("Missing body for update: {}", resource.getIdentifier());
             throw new BadRequestException("Missing body for update");
         } else if (!supportsInteractionModel(LDP.RDFSource)) {
             throw new BadRequestException(status(BAD_REQUEST)
                 .link(UnsupportedInteractionModel.getIRIString(), LDP.constrainedBy.getIRIString())
                 .entity("Unsupported interaction model provided").type(TEXT_PLAIN_TYPE).build());
-        } else if (isNull(syntax)) {
+        } else if (syntax == null) {
             // Get the incoming syntax and check that the underlying I/O service supports it
             LOGGER.warn("Content-Type: {} not supported", getRequest().getContentType());
             throw new NotSupportedException();
@@ -235,7 +233,7 @@ public class PatchHandler extends MutatingLdpHandler {
             .thenApply(future -> {
                 final RDFSyntax outputSyntax = getSyntax(getServices().getIOService(),
                         getRequest().getAcceptableMediaTypes(), null);
-                if (nonNull(preference)) {
+                if (preference != null) {
                     final IRI profile = getResponseProfile(outputSyntax);
                     final StreamingOutput stream = new StreamingOutput() {
                         @Override
@@ -254,7 +252,7 @@ public class PatchHandler extends MutatingLdpHandler {
 
     private IRI getResponseProfile(final RDFSyntax outputSyntax) {
         final IRI profile = getProfile(getRequest().getAcceptableMediaTypes(), outputSyntax);
-        if (nonNull(profile)) {
+        if (profile != null) {
             return profile;
         }
         return getDefaultProfile(outputSyntax, getIdentifier(), defaultJsonLdProfile);
@@ -275,7 +273,7 @@ public class PatchHandler extends MutatingLdpHandler {
     }
 
     private static String getPreference(final Prefer prefer) {
-        if (nonNull(prefer)) {
+        if (prefer != null) {
             return prefer.getPreference().filter(PREFER_REPRESENTATION::equals).orElse(null);
         }
         return null;

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -14,8 +14,6 @@
 package org.trellisldp.http.impl;
 
 import static java.net.URI.create;
-import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static javax.ws.rs.HttpMethod.DELETE;
@@ -108,7 +106,7 @@ public class PostHandler extends MutatingLdpHandler {
     }
 
     private static RDFSyntax getRdfSyntax(final String contentType, final List<RDFSyntax> supported) {
-        if (nonNull(contentType)) {
+        if (contentType != null) {
             final MediaType type = MediaType.valueOf(contentType);
             for (final RDFSyntax s : supported) {
                 if (type.isCompatible(MediaType.valueOf(s.mediaType()))) {
@@ -120,7 +118,7 @@ public class PostHandler extends MutatingLdpHandler {
     }
 
     private static IRI getLdpType(final Link link, final RDFSyntax syntax, final String contentType) {
-        if (nonNull(link) && "type".equals(link.getRel())) {
+        if (link != null && "type".equals(link.getRel())) {
             final String uri = link.getUri().toString();
             if (uri.startsWith(LDP.getNamespace())) {
                 final IRI iri = rdf.createIRI(uri);
@@ -129,7 +127,7 @@ public class PostHandler extends MutatingLdpHandler {
                 }
             }
         }
-        return nonNull(contentType) && isNull(syntax) ? LDP.NonRDFSource : LDP.RDFSource;
+        return contentType != null && syntax == null ? LDP.NonRDFSource : LDP.RDFSource;
     }
 
     /**
@@ -154,7 +152,7 @@ public class PostHandler extends MutatingLdpHandler {
         } else if (!supportsInteractionModel(ldpType)) {
             throw new BadRequestException("Unsupported interaction model provided", status(BAD_REQUEST)
                 .link(UnsupportedInteractionModel.getIRIString(), LDP.constrainedBy.getIRIString()).build());
-        } else if (ldpType.equals(LDP.NonRDFSource) && nonNull(rdfSyntax)) {
+        } else if (ldpType.equals(LDP.NonRDFSource) && rdfSyntax != null) {
             LOGGER.error("Cannot save {} as a NonRDFSource with RDF syntax", getIdentifier());
             throw new BadRequestException("Cannot save resource as a NonRDFSource with RDF syntax");
         }
@@ -187,7 +185,7 @@ public class PostHandler extends MutatingLdpHandler {
 
         // Add user-supplied data
         if (ldpType.equals(LDP.NonRDFSource)) {
-            final String mimeType = nonNull(contentType) ? contentType : APPLICATION_OCTET_STREAM;
+            final String mimeType = contentType != null ? contentType : APPLICATION_OCTET_STREAM;
             final IRI binaryLocation = rdf.createIRI(getServices().getBinaryService().generateIdentifier());
 
             // Persist the content
@@ -198,7 +196,7 @@ public class PostHandler extends MutatingLdpHandler {
             metadata = metadataBuilder(internalId, ldpType, mutable).container(parentIdentifier).binary(binary);
             builder.link(getIdentifier() + "?ext=description", "describedby");
         } else {
-            final RDFSyntax s = nonNull(rdfSyntax) ? rdfSyntax : TURTLE;
+            final RDFSyntax s = rdfSyntax != null ? rdfSyntax : TURTLE;
             readEntityIntoDataset(PreferUserManaged, s, mutable);
 
             // Check for any constraints

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -230,7 +230,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final EntityTag etag = res.getEntityTag();
         assertTrue(etag.isWeak(), "ETag header isn't weak for LDP-RS!");
-        final String preferHash = new ArrayList().hashCode() + "." + new ArrayList().hashCode();
+        final String preferHash = new ArrayList<>().hashCode() + "." + new ArrayList<>().hashCode();
         assertEquals(md5Hex(time.toEpochMilli() + "." + time.getNano() + "." + preferHash + "." + baseUrl),
                 etag.getValue(), "Unexpected ETag value!");
 
@@ -344,7 +344,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetBinary() throws IOException {
+    public void testGetBinary() {
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(WILDCARD_TYPE));

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -63,7 +63,6 @@ import static org.trellisldp.http.core.RdfMediaType.APPLICATION_SPARQL_UPDATE;
 import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE_TYPE;
 import static org.trellisldp.vocabulary.JSONLD.compacted;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;


### PR DESCRIPTION
Mostly removing the use of Objects::nonNull and Objects::isNull, with a few other bits thrown in.

This PR only covers the stack up through `-http` and ignores all the backends and optional components. They can be handled in separate PRs to avoid crazy levels of line-change too fast.