### PR TITLE
Use LDP type of the deleted resource in events

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/EventTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/EventTests.java
@@ -215,7 +215,7 @@ public interface EventTests extends CommonTests {
         try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2, getJwtSecret()))
                 .delete()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Verify a successful LDP-RS DELETE response");
-            assertAll("Check the LDP-BC parent", checkResourceParentLdpBC(resource, agent2, AS.Delete, LDP.Resource));
+            assertAll("Check the LDP-BC parent", checkResourceParentLdpBC(resource, agent2, AS.Delete, LDP.RDFSource));
         }
     }
 
@@ -261,7 +261,7 @@ public interface EventTests extends CommonTests {
                 .delete()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful LDP-RS DELETE");
             assertAll("Check the LDP-DC parent resource",
-                    checkResourceParentLdpDC(resource, agent2, AS.Delete, LDP.Resource, LDP.Container));
+                    checkResourceParentLdpDC(resource, agent2, AS.Delete, LDP.RDFSource, LDP.Container));
         }
     }
 
@@ -343,7 +343,7 @@ public interface EventTests extends CommonTests {
                 .delete()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful DELETE in an LDP-IC");
             assertAll("Check the LDP-IC parent resource",
-                    checkResourceParentLdpIC(resource, agent2, AS.Delete, LDP.Resource, LDP.Container));
+                    checkResourceParentLdpIC(resource, agent2, AS.Delete, LDP.RDFSource, LDP.Container));
         }
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -127,7 +127,7 @@ public class DeleteHandler extends MutatingLdpHandler {
             return handleAclDeletion(mutable, immutable);
         }
         return handleResourceDeletion(immutable).thenCompose(future ->
-                emitEvent(getInternalId(), AS.Delete, LDP.Resource));
+                emitEvent(getInternalId(), AS.Delete, getResource().getInteractionModel()));
     }
 
     private CompletionStage<Void> handleAclDeletion(final Dataset mutable, final Dataset immutable) {


### PR DESCRIPTION
Resolves #398

When a DELETE request completes, the notification will contain the
rdf:type of the deleted resource, rather than the generic ldp:Resource.