### PR TITLE
Add config option for LDP ixn model in RDF

### DIFF
--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -98,6 +98,8 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
 
     /** The configuration key used to set where the RDF is stored. **/
     public static final String CONFIG_TRIPLESTORE_RDF_LOCATION = "trellis.triplestore.rdf.location";
+    /** The configuration key used to set whether the LDP type should be included in the body of the RDF. **/
+    public static final String CONFIG_TRIPLESTORE_LDP_TYPE = "trellis.triplestore.ldp.type";
 
     private static final String MODIFIED = "modified";
 
@@ -106,6 +108,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
 
     private final Supplier<String> supplier;
     private final RDFConnection rdfConnection;
+    private final boolean includeLdpType;
     private final Set<IRI> supportedIxnModels;
 
     /**
@@ -133,6 +136,8 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
      */
     public TriplestoreResourceService(final RDFConnection rdfConnection, final IdentifierService identifierService) {
         super();
+        this.includeLdpType = getConfig().getOptionalValue(CONFIG_TRIPLESTORE_LDP_TYPE, Boolean.class)
+            .orElse(Boolean.FALSE);
         this.rdfConnection = requireNonNull(rdfConnection, "RDFConnection may not be null!");
         this.supplier = requireNonNull(identifierService, "IdentifierService may not be null!").getSupplier();
         this.supportedIxnModels = unmodifiableSet(asList(LDP.Resource, LDP.RDFSource, LDP.NonRDFSource, LDP.Container,
@@ -379,7 +384,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
 
     @Override
     public CompletionStage<Resource> get(final IRI identifier) {
-        return TriplestoreResource.findResource(rdfConnection, identifier);
+        return TriplestoreResource.findResource(rdfConnection, identifier, includeLdpType);
     }
 
     @Override

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
@@ -88,7 +88,7 @@ public class TriplestoreResourceTest {
 
     @Test
     public void testEmptyResource() {
-        final TriplestoreResource res = new TriplestoreResource(connect(create()), identifier);
+        final TriplestoreResource res = new TriplestoreResource(connect(create()), identifier, false);
         res.fetchData();
         assertFalse(res.exists(), "Unexpected resource!");
     }
@@ -98,7 +98,7 @@ public class TriplestoreResourceTest {
         final JenaDataset dataset = rdf.createDataset();
         dataset.add(Trellis.PreferServerManaged, identifier, DC.modified, rdf.createLiteral(time, XSD.dateTime));
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
-                identifier);
+                identifier, false);
         res.fetchData();
         assertFalse(res.exists(), "Unexpected resource!");
     }
@@ -107,7 +107,7 @@ public class TriplestoreResourceTest {
     public void testMinimalResource() {
         final JenaDataset dataset = buildLdpDataset(LDP.RDFSource);
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
-                identifier);
+                identifier, false);
 
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
@@ -122,13 +122,28 @@ public class TriplestoreResourceTest {
         auditService.creation(identifier, mockSession).forEach(q ->
                 dataset.add(auditId, q.getSubject(), q.getPredicate(), q.getObject()));
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
-                identifier);
+                identifier, false);
 
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
         assertAll("Check resource", checkResource(res, identifier, LDP.RDFSource, false, false, false));
         assertAll("Check LDP properties", checkLdpProperties(res, null, null, null, null));
         assertAll("Check RDF stream", checkRdfStream(res, 2L, 0L, 5L, 0L, 0L));
+    }
+
+    @Test
+    public void testResourceWithAuditQuads2() {
+        final JenaDataset dataset = buildLdpDataset(LDP.RDFSource);
+        auditService.creation(identifier, mockSession).forEach(q ->
+                dataset.add(auditId, q.getSubject(), q.getPredicate(), q.getObject()));
+        final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
+                identifier, true);
+
+        res.fetchData();
+        assertTrue(res.exists(), "Missing resource!");
+        assertAll("Check resource", checkResource(res, identifier, LDP.RDFSource, false, false, false));
+        assertAll("Check LDP properties", checkLdpProperties(res, null, null, null, null));
+        assertAll("Check RDF stream", checkRdfStream(res, 3L, 0L, 5L, 0L, 0L));
     }
 
     @Test
@@ -140,7 +155,7 @@ public class TriplestoreResourceTest {
         auditService.creation(identifier, mockSession).forEach(q ->
                 dataset.add(auditId, q.getSubject(), q.getPredicate(), q.getObject()));
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
-                identifier);
+                identifier, false);
 
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
@@ -160,7 +175,7 @@ public class TriplestoreResourceTest {
                 dataset.add(auditId, q.getSubject(), q.getPredicate(), q.getObject()));
 
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
-                identifier);
+                identifier, true);
 
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
@@ -170,7 +185,7 @@ public class TriplestoreResourceTest {
         });
         assertAll("Check resource", checkResource(res, identifier, LDP.NonRDFSource, true, false, false));
         assertAll("Check LDP properties", checkLdpProperties(res, null, null, null, null));
-        assertAll("Check RDF stream", checkRdfStream(res, 2L, 0L, 5L, 0L, 0L));
+        assertAll("Check RDF stream", checkRdfStream(res, 3L, 0L, 5L, 0L, 0L));
     }
 
     @Test
@@ -180,7 +195,7 @@ public class TriplestoreResourceTest {
         getChildIRIs().forEach(c -> dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier));
 
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
-                identifier);
+                identifier, false);
 
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
@@ -196,12 +211,12 @@ public class TriplestoreResourceTest {
         getChildIRIs().forEach(c -> dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier));
 
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
-                identifier);
+                identifier, true);
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
         assertAll("Check resource", checkResource(res, identifier, LDP.RDFSource, false, false, true));
         assertAll("Check LDP properties", checkLdpProperties(res, null, null, null, null));
-        assertAll("Check RDF stream", checkRdfStream(res, 2L, 0L, 0L, 0L, 0L));
+        assertAll("Check RDF stream", checkRdfStream(res, 3L, 0L, 0L, 0L, 0L));
     }
 
     @Test
@@ -217,14 +232,14 @@ public class TriplestoreResourceTest {
         getChildIRIs().forEach(c -> dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier));
 
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final TriplestoreResource res = new TriplestoreResource(rdfConnection, identifier);
+        final TriplestoreResource res = new TriplestoreResource(rdfConnection, identifier, true);
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
         assertAll("Check resource", checkResource(res, identifier, LDP.DirectContainer, false, false, true));
         assertAll("Check LDP properties", checkLdpProperties(res, member, DC.subject, null, LDP.MemberSubject));
-        assertAll("Check RDF stream", checkRdfStream(res, 2L, 0L, 0L, 0L, 4L));
+        assertAll("Check RDF stream", checkRdfStream(res, 3L, 0L, 0L, 0L, 4L));
 
-        final TriplestoreResource memberRes = new TriplestoreResource(rdfConnection, member);
+        final TriplestoreResource memberRes = new TriplestoreResource(rdfConnection, member, false);
         memberRes.fetchData();
         assertTrue(memberRes.exists(), "Missing resource!");
         assertAll("Check resource", checkResource(memberRes, member, LDP.RDFSource, false, false, true));
@@ -251,14 +266,14 @@ public class TriplestoreResourceTest {
         });
 
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
-        final TriplestoreResource res = new TriplestoreResource(rdfConnection, identifier);
+        final TriplestoreResource res = new TriplestoreResource(rdfConnection, identifier, false);
         res.fetchData();
         assertTrue(res.exists(), "Missing resource!");
         assertAll("Check resource", checkResource(res, identifier, LDP.IndirectContainer, false, false, true));
         assertAll("Check LDP properties", checkLdpProperties(res, member, DC.relation, null, DC.subject));
         assertAll("Check RDF stream", checkRdfStream(res, 3L, 0L, 0L, 0L, 4L));
 
-        final TriplestoreResource res2 = new TriplestoreResource(rdfConnection, member);
+        final TriplestoreResource res2 = new TriplestoreResource(rdfConnection, member, false);
         res2.fetchData();
         assertTrue(res2.exists(), "Missing resource (2)!");
         assertAll("Check resource", checkResource(res2, member, LDP.RDFSource, false, false, true));


### PR DESCRIPTION
Resoves #407

This change applies only to the triplestore-based persistence layer