### PR TITLE
No need to guard against concurrency in some paths

### DIFF
--- a/core/api/src/main/java/org/trellisldp/api/Resource.java
+++ b/core/api/src/main/java/org/trellisldp/api/Resource.java
@@ -198,7 +198,7 @@ public interface Resource {
      */
     default Dataset dataset() {
         try (final Stream<Quad> quads = stream()) {
-            return quads.collect(TrellisUtils.toDataset().concurrent());
+            return quads.collect(TrellisUtils.toDataset());
         }
     }
 

--- a/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
+++ b/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
@@ -13,20 +13,17 @@
  */
 package org.trellisldp.api;
 
-import static java.util.Collections.newSetFromMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.EnumSet.of;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.ServiceLoader.load;
-import static java.util.stream.Collector.Characteristics.CONCURRENT;
 import static java.util.stream.Collector.Characteristics.IDENTITY_FINISH;
 import static java.util.stream.Collector.Characteristics.UNORDERED;
 
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -144,50 +141,6 @@ public final class TrellisUtils {
         @Override
         public Set<Characteristics> characteristics() {
             return unmodifiableSet(of(UNORDERED, IDENTITY_FINISH));
-        }
-
-        /**
-         * Collect a stream of {@link Quad}s into a {@link Dataset} with concurrent operation.
-         *
-         * @return a {@link Collector} that accumulates a {@link Stream} of {@link Quad}s into a {@link Dataset}
-         */
-        public ConcurrentDatasetCollector concurrent() {
-            return new ConcurrentDatasetCollector();
-        }
-    }
-
-    private static class ConcurrentDatasetCollector implements Collector<Quad, Set<Quad>, Dataset> {
-
-        @Override
-        public Supplier<Set<Quad>> supplier() {
-            return () -> newSetFromMap(new ConcurrentHashMap<>());
-        }
-
-        @Override
-        public BiConsumer<Set<Quad>, Quad> accumulator() {
-            return Set::add;
-        }
-
-        @Override
-        public BinaryOperator<Set<Quad>> combiner() {
-            return (s1, s2) -> {
-                s1.addAll(s2);
-                return s1;
-            };
-        }
-
-        @Override
-        public Function<Set<Quad>, Dataset> finisher() {
-            return set -> {
-                final Dataset dataset = rdf.createDataset();
-                set.forEach(dataset::add);
-                return dataset;
-            };
-        }
-
-        @Override
-        public Set<Characteristics> characteristics() {
-            return unmodifiableSet(of(UNORDERED, CONCURRENT));
         }
     }
 

--- a/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
@@ -14,7 +14,6 @@
 package org.trellisldp.api;
 
 import static java.util.Optional.of;
-import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.generate;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.condition.JRE.JAVA_8;
@@ -22,13 +21,9 @@ import static org.trellisldp.api.TrellisUtils.getInstance;
 import static org.trellisldp.api.TrellisUtils.toDataset;
 import static org.trellisldp.api.TrellisUtils.toGraph;
 
-import java.util.Set;
-import java.util.stream.Collector;
-
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.Quad;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.text.RandomStringGenerator;
 import org.junit.jupiter.api.Test;
@@ -58,14 +53,6 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testCollectDatasetConcurrent() {
-        final Dataset dataset = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
-            .parallel().limit(size).collect(toDataset().concurrent());
-
-        assertTrue(size >= dataset.size(), "Generated dataset has too many triples!");
-    }
-
-    @Test
     public void testCollectDataset() {
         final Dataset dataset = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
             .parallel().limit(size).collect(toDataset());
@@ -80,18 +67,6 @@ public class TrellisUtilsTest {
 
         final TrellisUtils.DatasetCollector collector = toDataset();
         assertEquals(dataset, collector.finisher().apply(dataset), "Dataset finisher returns the wrong object!");
-    }
-
-    @Test
-    public void testDatasetCombiner() {
-        final Set<Quad> quads1 = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
-            .parallel().limit(size).collect(toSet());
-        final Set<Quad> quads2 = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
-            .parallel().limit(size).collect(toSet());
-
-        final Collector<Quad, Set<Quad>, Dataset> collector = toDataset().concurrent();
-        assertEquals(quads1.size() + quads2.size(), collector.combiner().apply(quads1, quads2).size(),
-                "Dataset combiner produces the wrong number of quads!");
     }
 
     private IRI getIRI() {


### PR DESCRIPTION
There is, to my knowledge, no place in the Trellis code in which a `Dataset` might be rolled up concurrently and therefore no need for this extra jazz.