### PR TITLE
sets priorities for alternative CDI beans

### DIFF
--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
 public class BasicAuthFilter implements ContainerRequestFilter {
 
     private static final Logger LOGGER = getLogger(BasicAuthFilter.class);
-    
+
     /** The configuration key controlling the location of the basic auth credentials file. **/
     public static final String CONFIG_AUTH_BASIC_CREDENTIALS = "trellis.auth.basic.credentials";
 

--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
@@ -87,7 +87,7 @@ public class BasicAuthFilter implements ContainerRequestFilter {
     public BasicAuthFilter(final File file, final String realm) {
         this.file = file;
         this.challenge = "Basic realm=\"" + realm + "\"";
-        LOGGER.info("Configured BASIC Authentication Filter.");
+        LOGGER.info("Configured BasicAuthFilter.");
     }
 
     @Override

--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
@@ -18,6 +18,7 @@ import static javax.ws.rs.Priorities.AUTHENTICATION;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.SecurityContext.BASIC_AUTH;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,13 +33,19 @@ import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
 
 /**
  * A basic authentication filter using an Authorization HTTP header.
  */
+@Provider
 @Priority(AUTHENTICATION)
 public class BasicAuthFilter implements ContainerRequestFilter {
 
+    private static final Logger LOGGER = getLogger(BasicAuthFilter.class);
+    
     /** The configuration key controlling the location of the basic auth credentials file. **/
     public static final String CONFIG_AUTH_BASIC_CREDENTIALS = "trellis.auth.basic.credentials";
 
@@ -80,6 +87,7 @@ public class BasicAuthFilter implements ContainerRequestFilter {
     public BasicAuthFilter(final File file, final String realm) {
         this.file = file;
         this.challenge = "Basic realm=\"" + realm + "\"";
+        LOGGER.info("Configured BASIC Authentication Filter.");
     }
 
     @Override

--- a/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -44,8 +44,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import javax.annotation.Priority;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
+import javax.interceptor.Interceptor;
 
 import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
@@ -73,6 +75,7 @@ import org.trellisldp.vocabulary.VCARD;
  * @author acoburn
  */
 @Alternative
+@Priority(Interceptor.Priority.APPLICATION+10)
 public class WebACService implements AccessControlService {
 
     /** The configuration key controlling whether to check member resources at the AuthZ enforcement point. **/
@@ -135,6 +138,7 @@ public class WebACService implements AccessControlService {
         this.resourceService = requireNonNull(resourceService, "A non-null ResourceService must be provided!");
         this.cache = requireNonNull(cache, "A non-null Cache must be provided!");
         this.checkMembershipResources = checkMembershipResources;
+        LOGGER.info("Loading WebACService");
     }
 
     @Override

--- a/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -138,7 +138,7 @@ public class WebACService implements AccessControlService {
         this.resourceService = requireNonNull(resourceService, "A non-null ResourceService must be provided!");
         this.cache = requireNonNull(cache, "A non-null Cache must be provided!");
         this.checkMembershipResources = checkMembershipResources;
-        LOGGER.info("Loading WebACService");
+        LOGGER.info("Configured WebACService.");
     }
 
     @Override

--- a/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -75,7 +75,7 @@ import org.trellisldp.vocabulary.VCARD;
  * @author acoburn
  */
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+10)
+@Priority(Interceptor.Priority.APPLICATION + 10)
 public class WebACService implements AccessControlService {
 
     /** The configuration key controlling whether to check member resources at the AuthZ enforcement point. **/

--- a/core/api/build.gradle
+++ b/core/api/build.gradle
@@ -11,6 +11,7 @@ ext {
 dependencies {
     api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
     api("javax.enterprise:cdi-api:${cdiApiVersion}")
+    api("javax.annotation:javax.annotation-api:$javaxAnnotationsVersion")
 
     testImplementation("commons-io:commons-io:$commonsIoVersion")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")

--- a/core/api/src/main/java/org/trellisldp/api/NoopAccessControlService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopAccessControlService.java
@@ -20,12 +20,18 @@ import static org.trellisldp.api.TrellisUtils.getInstance;
 
 import java.util.Set;
 
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
+
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
 
 /**
  * A no-op AccessControlService implementation.
  */
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION)
 public class NoopAccessControlService implements AccessControlService {
 
     private static final RDF rdf = getInstance();

--- a/core/api/src/main/java/org/trellisldp/api/NoopEventService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopEventService.java
@@ -13,9 +13,15 @@
  */
 package org.trellisldp.api;
 
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
+
 /**
  * For use when an event service is not desired.
  */
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION)
 public final class NoopEventService implements EventService {
 
     @Override

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -172,7 +172,7 @@ public class TrellisHttpResource {
             dataset.add(rdf.createQuad(Trellis.PreferAccessControl, rootAuth, ACL.mode, ACL.Control));
             dataset.add(rdf.createQuad(Trellis.PreferAccessControl, rootAuth, ACL.agentClass, FOAF.Agent));
             dataset.add(rdf.createQuad(Trellis.PreferAccessControl, rootAuth, ACL.accessTo, root));
-            LOGGER.debug("Preparing to initialize Trellis at {}", root);
+            LOGGER.info("Preparing to initialize Trellis at {}", root);
             trellis.getResourceService().get(root).thenCompose(res -> initialize(root, res, dataset))
                 .exceptionally(err -> {
                     LOGGER.warn("Unable to auto-initialize Trellis: {}. See DEBUG log for more info", err.getMessage());
@@ -186,11 +186,11 @@ public class TrellisHttpResource {
 
     private CompletionStage<Void> initialize(final IRI id, final Resource res, final Dataset dataset) {
         if (MISSING_RESOURCE.equals(res) || DELETED_RESOURCE.equals(res)) {
-            LOGGER.info("Initializing root container: {}", id);
+            LOGGER.info("Initializing root container and ACL: {}", id);
             return trellis.getResourceService().create(Metadata.builder(id).interactionModel(LDP.BasicContainer)
                     .build(), dataset);
         } else if (!res.hasAcl()) {
-            LOGGER.info("Initializeing root ACL: {}", id);
+            LOGGER.info("Adding an ACL to root container: {}", id);
             try (final Stream<Quad> quads = res.stream(Trellis.PreferUserManaged)) {
                 quads.forEach(dataset::add);
             }

--- a/core/http/src/main/java/org/trellisldp/http/WebAcFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/WebAcFilter.java
@@ -118,6 +118,7 @@ public class WebAcFilter implements ContainerRequestFilter, ContainerResponseFil
         this.challenges = challengeTypes.stream().map(String::trim).map(ch -> ch + " realm=\"" + realm + "\"")
             .collect(toList());
         this.baseUrl = baseUrl;
+        LOGGER.info("Configured WebAcFilter.");
     }
 
     @Override

--- a/notifications/jms/build.gradle
+++ b/notifications/jms/build.gradle
@@ -15,6 +15,7 @@ ext {
 dependencies {
     api("javax.jms:javax.jms-api:$jmsApiVersion")
     api("org.glassfish.hk2.external:javax.inject:$javaxInjectVersion")
+    api("javax.annotation:javax.annotation-api:$javaxAnnotationsVersion")
     api project(':trellis-api')
 
     implementation("org.apache.activemq:activemq-client:$activeMqVersion")

--- a/notifications/jms/src/main/java/org/trellisldp/jms/JmsPublisher.java
+++ b/notifications/jms/src/main/java/org/trellisldp/jms/JmsPublisher.java
@@ -21,7 +21,10 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.Iterator;
 
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
+import javax.interceptor.Interceptor;
 import javax.jms.Connection;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -41,6 +44,8 @@ import org.trellisldp.api.RuntimeTrellisException;
  *
  * @author acoburn
  */
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+10)
 public class JmsPublisher implements EventService {
 
     /** The configuration key controlling the JMS queue name. **/
@@ -107,6 +112,7 @@ public class JmsPublisher implements EventService {
      * @throws JMSException when there is a connection error
      */
     public JmsPublisher(final Session session, final String queueName, final boolean useQueue) throws JMSException {
+    	LOGGER.info("Loading JmsPublisher");
         requireNonNull(queueName, "JMS Queue name may not be null!");
         this.session = requireNonNull(session, "JMS Session may not be null!");
         if (useQueue) {

--- a/notifications/jms/src/main/java/org/trellisldp/jms/JmsPublisher.java
+++ b/notifications/jms/src/main/java/org/trellisldp/jms/JmsPublisher.java
@@ -45,7 +45,7 @@ import org.trellisldp.api.RuntimeTrellisException;
  * @author acoburn
  */
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+10)
+@Priority(Interceptor.Priority.APPLICATION + 10)
 public class JmsPublisher implements EventService {
 
     /** The configuration key controlling the JMS queue name. **/
@@ -112,7 +112,7 @@ public class JmsPublisher implements EventService {
      * @throws JMSException when there is a connection error
      */
     public JmsPublisher(final Session session, final String queueName, final boolean useQueue) throws JMSException {
-    	LOGGER.info("Loading JmsPublisher");
+        LOGGER.info("Loading JmsPublisher");
         requireNonNull(queueName, "JMS Queue name may not be null!");
         this.session = requireNonNull(session, "JMS Session may not be null!");
         if (useQueue) {


### PR DESCRIPTION
This PR can be more narrowly focused based on feedback, especially if it is adding too much logging. The gist of it is that I needed to set Priority and Alternative annotations in order to get CDI to load the correct implementation, instead of Noops, when present.