### PR TITLE
Switching to make no-op impls the CDI @Alternatives

### DIFF
--- a/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebACService.java
@@ -44,7 +44,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.Graph;
@@ -72,7 +71,7 @@ import org.trellisldp.vocabulary.VCARD;
  *
  * @author acoburn
  */
-@Alternative
+
 public class WebACService implements AccessControlService {
 
     /** The configuration key controlling whether to check member resources at the AuthZ enforcement point. **/

--- a/core/api/src/main/java/org/trellisldp/api/NoopAccessControlService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopAccessControlService.java
@@ -20,12 +20,15 @@ import static org.trellisldp.api.TrellisUtils.getInstance;
 
 import java.util.Set;
 
+import javax.enterprise.inject.Alternative;
+
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
 
 /**
  * A no-op AccessControlService implementation.
  */
+@Alternative
 public class NoopAccessControlService implements AccessControlService {
 
     private static final RDF rdf = getInstance();

--- a/core/api/src/main/java/org/trellisldp/api/NoopAuditService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopAuditService.java
@@ -14,12 +14,15 @@
 
 package org.trellisldp.api;
 
+import javax.enterprise.inject.Alternative;
+
 /**
  * For use when audit functionality is not desired.
  * 
  * @author ajs6f
  *
  */
+@Alternative
 public final class NoopAuditService implements AuditService {
 
 }

--- a/core/api/src/main/java/org/trellisldp/api/NoopCacheService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopCacheService.java
@@ -15,11 +15,14 @@ package org.trellisldp.api;
 
 import java.util.function.Function;
 
+import javax.enterprise.inject.Alternative;
+
 /**
  * A no-op (pass-through) cache service for Trellis.
  * @param <K> the type of key to use
  * @param <V> the type of value to cache
  */
+@Alternative
 public class NoopCacheService<K, V> implements CacheService<K, V> {
 
     @Override

--- a/core/api/src/main/java/org/trellisldp/api/NoopEventService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopEventService.java
@@ -13,9 +13,12 @@
  */
 package org.trellisldp.api;
 
+import javax.enterprise.inject.Alternative;
+
 /**
  * For use when an event service is not desired.
  */
+@Alternative
 public final class NoopEventService implements EventService {
 
     @Override

--- a/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
@@ -21,11 +21,14 @@ import java.time.Instant;
 import java.util.SortedSet;
 import java.util.concurrent.CompletionStage;
 
+import javax.enterprise.inject.Alternative;
+
 import org.apache.commons.rdf.api.IRI;
 
 /**
  * A no-op MementoService implementation.
  */
+@Alternative
 public class NoopMementoService implements MementoService {
 
     @Override

--- a/core/api/src/main/java/org/trellisldp/api/NoopNamespaceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopNamespaceService.java
@@ -17,12 +17,15 @@ package org.trellisldp.api;
 import java.util.Collections;
 import java.util.Map;
 
+import javax.enterprise.inject.Alternative;
+
 /**
  * A {@link NamespaceService} that stores nothing and offers nothing.
  *
  * @author ajs6f
  *
  */
+@Alternative
 public class NoopNamespaceService implements NamespaceService {
 
     @Override


### PR DESCRIPTION
Alternative to https://github.com/trellis-ldp/trellis/pull/413

Based on [the CDI spec](https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#builtin_qualifiers), leaving the no-op impls as `@Alternative`s and the others as (un-annotated) `@Default`s, we should arrive at the behavior that having any non-no-op impl (e.g. `WebACService` or `JmsPublisher`) on the classpath in a JAR with a `beans.xml` (presumably from build) should prefer the substantive impl, which, IIUC, meets @gregjan's immediate needs.