### PR TITLE
A little less synchronous

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileBinary.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinary.java
@@ -14,12 +14,15 @@
 
 package org.trellisldp.file;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.concurrent.CompletionStage;
 
 import org.trellisldp.api.Binary;
 
@@ -38,19 +41,20 @@ public class FileBinary implements Binary {
         this.file = file;
     }
 
+    @SuppressWarnings("resource")
     @Override
-    public InputStream getContent() {
+    public CompletionStage<InputStream> getContent() {
         try {
-            return new FileInputStream(file);
+            return completedFuture(new FileInputStream(file));
         } catch (FileNotFoundException e) {
             throw new UncheckedIOException(e);
         }
     }
 
     @Override
-    public InputStream getContent(final int from, final int to) {
+    public CompletionStage<InputStream> getContent(final int from, final int to) {
         try {
-            return FileUtils.getBoundedStream(new FileInputStream(file), from, to);
+            return completedFuture(FileUtils.getBoundedStream(new FileInputStream(file), from, to));
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);
         }

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -24,6 +24,8 @@ import java.io.InputStream;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.rdf.api.IRI;
@@ -171,11 +173,15 @@ public class FileBinaryServiceTest {
         return false;
     }
 
-    private String uncheckedToString(final InputStream is) {
+    private String uncheckedToString(final CompletionStage<InputStream> is) {
         try {
-            return IOUtils.toString(is, UTF_8);
+            return IOUtils.toString(is.toCompletableFuture().get(), UTF_8);
         } catch (final IOException ex) {
             return null;
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        } catch (ExecutionException e) {
+            throw new AssertionError(e);
         }
     }
 

--- a/core/api/src/main/java/org/trellisldp/api/Binary.java
+++ b/core/api/src/main/java/org/trellisldp/api/Binary.java
@@ -15,6 +15,7 @@
 package org.trellisldp.api;
 
 import java.io.InputStream;
+import java.util.concurrent.CompletionStage;
 
 /**
  * The non-RDF content of an LDP NonRDFSource.
@@ -25,13 +26,13 @@ public interface Binary {
     /**
      * @return the content of this {@link Binary}
      */
-    InputStream getContent();
+    CompletionStage<InputStream> getContent();
 
     /**
      * @param from the point in bytes from which to begin content
      * @param to the point in bytes at which to end content
      * @return content from {@code from} to {@code to} inclusive
      */
-    InputStream getContent(int from, int to);
+    CompletionStage<InputStream> getContent(int from, int to);
 
 }

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -56,9 +56,9 @@ public class BinaryServiceTest {
     public void testGetContent() throws IOException {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("FooBar".getBytes(UTF_8));
         when(mockBinaryService.get(eq(identifier))).thenAnswer(inv -> completedFuture(mockBinary));
-        when(mockBinary.getContent(anyInt(), anyInt())).thenReturn(inputStream);
+        when(mockBinary.getContent(anyInt(), anyInt())).thenReturn(completedFuture(inputStream));
         try (final InputStream content = mockBinaryService.get(identifier)
-                .thenApply(b -> b.getContent(0, 6)).toCompletableFuture().join()) {
+                .thenCompose(b -> b.getContent(0, 6)).toCompletableFuture().join()) {
             assertEquals("FooBar", IOUtils.toString(content, UTF_8), "Binary content did not match");
         }
     }

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -388,10 +388,10 @@ public class GetHandler extends BaseLdpHandler {
 
     private CompletionStage<InputStream> getBinaryStream(final IRI dsid, final TrellisRequest req) {
         if (req.getRange() == null) {
-            return getServices().getBinaryService().get(dsid).thenApply(Binary::getContent);
+            return getServices().getBinaryService().get(dsid).thenComposeAsync(Binary::getContent);
         }
         return getServices().getBinaryService().get(dsid)
-                        .thenApply(b -> b.getContent(req.getRange().getFrom(), req.getRange().getTo()));
+                        .thenComposeAsync(b -> b.getContent(req.getRange().getFrom(), req.getRange().getTo()));
     }
 
     private void addLdpHeaders(final ResponseBuilder builder, final IRI model) {

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -403,7 +403,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     @Test
     public void testGetBinaryErrorSkip() throws IOException {
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
-        when(mockBinary.getContent()).thenReturn(mockInputStream);
+        when(mockBinary.getContent()).thenReturn(completedFuture(mockInputStream));
         when(mockInputStream.skip(anyLong())).thenThrow(new IOException());
         final Response res = target(BINARY_PATH).request().header(RANGE, "bytes=300-400").get();
         assertEquals(SC_INTERNAL_SERVER_ERROR, res.getStatus(), "Unexpected response code!");

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -267,8 +267,10 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
 
     private void setUpBinaryService() throws Exception {
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
-        when(mockBinary.getContent(eq(3), eq(10))).thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
-        when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
+        when(mockBinary.getContent(eq(3), eq(10)))
+                        .thenReturn(completedFuture(new ByteArrayInputStream("e input".getBytes(UTF_8))));
+        when(mockBinary.getContent())
+                        .thenReturn(completedFuture(new ByteArrayInputStream("Some input stream".getBytes(UTF_8))));
         when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
         .thenAnswer(inv -> {
             readLines((InputStream) inv.getArguments()[1], UTF_8);

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -227,8 +227,10 @@ abstract class BaseTestHandler {
     }
 
     private void setUpBinaryService() throws Exception {
-        when(mockBinary.getContent(eq(3), eq(10))).thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
-        when(mockBinary.getContent()).thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
+        when(mockBinary.getContent(eq(3), eq(10)))
+                        .thenReturn(completedFuture(new ByteArrayInputStream("e input".getBytes(UTF_8))));
+        when(mockBinary.getContent())
+                        .thenReturn(completedFuture(new ByteArrayInputStream("Some input stream".getBytes(UTF_8))));
         when(mockBinaryService.generateIdentifier()).thenReturn("file:///" + randomUUID());
         when(mockBinaryService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));


### PR DESCRIPTION
but not enough. This is as good as we can do without `@Context`-injecting actual Servlet types into the `GET` method in `TrellisHttpResource`, which I will do in a follow-on PR that will be considerably more involved. Ultimately I'm going to have to cleanly separate the publishing of headers and body just as we now cleanly separate their computation. In order to do that, I'll need to find/make a completely asynchronous path between `ResourceService::get` and JAX-RS, and we don't have that here yet (viz. the appearance of `IOUtils.copy(binary, out);`, which blocks a container thread for the _whole binary_, quite possibly while waiting for backend data to move around).