### PR TITLE
Better vocab error handling

### DIFF
--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/AbstractVocabularyTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/AbstractVocabularyTest.java
@@ -32,6 +32,7 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.RiotException;
 import org.apache.jena.riot.RiotNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -59,6 +60,8 @@ public abstract class AbstractVocabularyTest {
             RDFParser.source(url).httpAccept(ACCEPT).parse(graph);
         } catch (final HttpException | RiotNotFoundException ex) {
             LOGGER.warn("Could not fetch {}: {}", url, ex.getMessage());
+        } catch (final RiotException ex) {
+            LOGGER.warn("Error fetching {}: {}", url, ex.getMessage());
         }
         assumeTrue(graph.size() > 0, "Remote vocabulary has no terms! Skip the test for " + url);
         return graph;


### PR DESCRIPTION
One reason the tests for #424 keep failing is due to the fact that `purl.org` is down (again) and the DCTerms vocabulary cannot be fetched in the `trellis-vocab` tests. This adds a better mechanism for catching those errors.