### PR TITLE
Add authZ support for acl:origin

### DIFF
--- a/components/webac/src/main/java/org/trellisldp/webac/Authorization.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/Authorization.java
@@ -74,6 +74,7 @@ public class Authorization {
         this.dataMap.put(ACL.mode, new HashSet<>());
         this.dataMap.put(ACL.accessTo, new HashSet<>());
         this.dataMap.put(ACL.default_, new HashSet<>());
+        this.dataMap.put(ACL.origin, new HashSet<>());
 
         graph.stream(identifier, null, null).filter(triple -> dataMap.containsKey(triple.getPredicate()))
             .filter(triple -> triple.getObject() instanceof IRI)
@@ -141,5 +142,14 @@ public class Authorization {
      */
     public Set<IRI> getDefault() {
         return unmodifiableSet(dataMap.get(ACL.default_));
+    }
+
+    /**
+     * Retrieve the acceptable origins of the ACL document.
+     *
+     * @return the origin IRIs
+     */
+    public Set<IRI> getOrigin() {
+        return unmodifiableSet(dataMap.get(ACL.origin));
     }
 }

--- a/components/webac/src/main/java/org/trellisldp/webac/WebAcFilter.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebAcFilter.java
@@ -102,6 +102,7 @@ public class WebAcFilter implements ContainerRequestFilter, ContainerResponseFil
 
     private static final Logger LOGGER = getLogger(WebAcFilter.class);
     private static final RDF rdf = getInstance();
+    private static final String ORIGIN = "Origin";
     private static final Set<String> readable = new HashSet<>(asList("GET", "HEAD", "OPTIONS"));
     private static final Set<String> writable = new HashSet<>(asList("PUT", "PATCH", "DELETE"));
     private static final Set<String> appendable = new HashSet<>(asList("POST"));
@@ -166,8 +167,9 @@ public class WebAcFilter implements ContainerRequestFilter, ContainerResponseFil
         final String path = ctx.getUriInfo().getPath();
         final Session s = getOrCreateSession(ctx);
         final String method = ctx.getMethod();
+        final String origin = ctx.getHeaderString(ORIGIN);
 
-        final Set<IRI> modes = accessService.getAccessModes(rdf.createIRI(TRELLIS_DATA_PREFIX + path), s);
+        final Set<IRI> modes = accessService.getAccessModes(rdf.createIRI(TRELLIS_DATA_PREFIX + path), s, origin);
         if (ctx.getUriInfo().getQueryParameters().getOrDefault(HttpConstants.EXT, emptyList())
                 .contains(HttpConstants.ACL) || reqAudit(ctx)) {
             verifyCanControl(modes, s, path);

--- a/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
@@ -207,7 +207,7 @@ public class WebAcService {
     }
 
     private Predicate<Authorization> originFilter(final String origin) {
-        return auth -> origin == null || auth.getOrigin().size() == 0
+        return auth -> origin == null || auth.getOrigin().isEmpty()
             || auth.getOrigin().contains(rdf.createIRI(origin));
     }
 

--- a/components/webac/src/test/java/org/trellisldp/webac/AuthorizationTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/AuthorizationTest.java
@@ -66,6 +66,9 @@ public class AuthorizationTest {
         graph.add(rdf.createTriple(other, ACL.accessToClass, PROV.Entity));
 
         graph.add(rdf.createTriple(subject, ACL.default_, rdf.createIRI("trellis:data/container")));
+
+        graph.add(rdf.createTriple(subject, ACL.origin, rdf.createIRI("https://example.com")));
+        graph.add(rdf.createTriple(subject, ACL.origin, rdf.createIRI("https://app.example.com")));
     }
 
     @Test
@@ -93,5 +96,9 @@ public class AuthorizationTest {
 
         assertEquals(1, auth.getDefault().size(), "Incorrect number of default values!");
         assertTrue(auth.getDefault().contains(rdf.createIRI("trellis:data/container")), "missing default value!");
+
+        assertEquals(2, auth.getOrigin().size(), "Incorrect number of origin values!");
+        assertTrue(auth.getOrigin().contains(rdf.createIRI("https://example.com")));
+        assertTrue(auth.getOrigin().contains(rdf.createIRI("https://app.example.com")));
     }
 }

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
@@ -16,16 +16,19 @@ package org.trellisldp.webac;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.trellisldp.http.core.HttpConstants.SESSION_PROPERTY;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -36,11 +39,14 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.rdf.api.IRI;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mock;
 import org.trellisldp.api.Session;
+import org.trellisldp.http.core.HttpSession;
 import org.trellisldp.vocabulary.ACL;
 import org.trellisldp.vocabulary.Trellis;
 
@@ -59,6 +65,8 @@ public class WebAcFilterTest {
         allModes.add(ACL.Control);
     }
 
+    private static final Session session = new HttpSession(ACL.AuthenticatedAgent);
+
     @Mock
     private WebAcService mockWebAcService;
 
@@ -74,10 +82,24 @@ public class WebAcFilterTest {
     @Mock
     private MultivaluedMap<String, String> mockQueryParams;
 
+    @BeforeAll
+    public static void setUpProperties() {
+        System.setProperty(WebAcFilter.CONFIG_WEBAC_METHOD_READABLE, "READ");
+        System.setProperty(WebAcFilter.CONFIG_WEBAC_METHOD_WRITABLE, "WRITE");
+        System.setProperty(WebAcFilter.CONFIG_WEBAC_METHOD_APPENDABLE, "APPEND");
+    }
+
+    @AfterAll
+    public static void cleanUpProperties() {
+        System.clearProperty(WebAcFilter.CONFIG_WEBAC_METHOD_READABLE);
+        System.clearProperty(WebAcFilter.CONFIG_WEBAC_METHOD_WRITABLE);
+        System.clearProperty(WebAcFilter.CONFIG_WEBAC_METHOD_APPENDABLE);
+    }
+
     @BeforeEach
     public void setUp() {
         initMocks(this);
-        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(allModes);
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(allModes);
         when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         when(mockUriInfo.getQueryParameters()).thenReturn(mockQueryParams);
         when(mockQueryParams.getOrDefault(eq("ext"), eq(emptyList()))).thenReturn(emptyList());
@@ -93,10 +115,87 @@ public class WebAcFilterTest {
     }
 
     @Test
+    public void testFilterRead() throws Exception {
+        final Set<IRI> modes = new HashSet<>();
+        when(mockContext.getMethod()).thenReturn("GET");
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(modes);
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        modes.add(ACL.Read);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
+
+        modes.clear();
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
+                "No expception thrown when not authorized!");
+
+        when(mockContext.getProperty(SESSION_PROPERTY)).thenReturn(session);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
+    }
+
+    @Test
+    public void testFilterCustomRead() throws Exception {
+        final Set<IRI> modes = new HashSet<>();
+        when(mockContext.getMethod()).thenReturn("READ");
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(modes);
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        modes.add(ACL.Read);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
+
+        modes.clear();
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
+                "No expception thrown when not authorized!");
+
+        when(mockContext.getProperty(SESSION_PROPERTY)).thenReturn(session);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
+    }
+
+
+    @Test
+    public void testFilterWrite() throws Exception {
+        final Set<IRI> modes = new HashSet<>();
+        when(mockContext.getMethod()).thenReturn("PUT");
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(modes);
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        modes.add(ACL.Write);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Write ability!");
+
+        modes.clear();
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
+                "No expception thrown when not authorized!");
+
+        when(mockContext.getProperty(SESSION_PROPERTY)).thenReturn(session);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
+    }
+
+    @Test
+    public void testFilterCustomWrite() throws Exception {
+        final Set<IRI> modes = new HashSet<>();
+        when(mockContext.getMethod()).thenReturn("WRITE");
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(modes);
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        modes.add(ACL.Write);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Write ability!");
+
+        modes.clear();
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
+                "No expception thrown when not authorized!");
+
+        when(mockContext.getProperty(SESSION_PROPERTY)).thenReturn(session);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
+    }
+
+    @Test
     public void testFilterAppend() throws Exception {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("POST");
-        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(modes);
 
         final WebAcFilter filter = new WebAcFilter(mockWebAcService);
         modes.add(ACL.Append);
@@ -111,13 +210,42 @@ public class WebAcFilterTest {
         modes.clear();
         assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
                 "No expception thrown when not authorized!");
+
+        when(mockContext.getProperty(SESSION_PROPERTY)).thenReturn(session);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
+    }
+
+    @Test
+    public void testFilterCustomAppend() throws Exception {
+        final Set<IRI> modes = new HashSet<>();
+        when(mockContext.getMethod()).thenReturn("APPEND");
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(modes);
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        modes.add(ACL.Append);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Append ability!");
+
+        modes.add(ACL.Write);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Write ability!");
+
+        modes.remove(ACL.Append);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after removing Append ability!");
+
+        modes.clear();
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
+                "No expception thrown when not authorized!");
+
+        when(mockContext.getProperty(SESSION_PROPERTY)).thenReturn(session);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
     }
 
     @Test
     public void testFilterControl() throws Exception {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("GET");
-        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(modes);
 
         final WebAcFilter filter = new WebAcFilter(mockWebAcService);
         modes.add(ACL.Read);
@@ -131,12 +259,41 @@ public class WebAcFilterTest {
 
         modes.add(ACL.Control);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Control ability!");
+
+        modes.clear();
+        when(mockContext.getProperty(SESSION_PROPERTY)).thenReturn(session);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
+    }
+
+    @Test
+    public void testFilterControl2() throws Exception {
+        final Set<IRI> modes = new HashSet<>();
+        when(mockContext.getMethod()).thenReturn("GET");
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(modes);
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        modes.add(ACL.Read);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
+
+        when(mockQueryParams.getOrDefault(eq("ext"), eq(emptyList()))).thenReturn(asList("acl"));
+
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
+                "No expception thrown when not authorized!");
+
+        modes.add(ACL.Control);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Control ability!");
+
+        modes.clear();
+        when(mockContext.getProperty(SESSION_PROPERTY)).thenReturn(session);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
     }
 
     @Test
     public void testFilterChallenges() throws Exception {
         when(mockContext.getMethod()).thenReturn("POST");
-        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class), any())).thenReturn(emptySet());
 
         final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm",
                 "http://example.com/");
@@ -184,6 +341,37 @@ public class WebAcFilterTest {
         assertNotNull(link);
         assertEquals("acl", link.getRel());
         assertEquals("http://example.com/?ext=acl", link.getUri().toString());
+    }
+
+    @Test
+    public void testFilterResponseWebac2() throws Exception {
+        final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        final MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("ext", "foo");
+        params.add("ext", "acl");
+        when(mockResponseContext.getStatusInfo()).thenReturn(OK);
+        when(mockResponseContext.getHeaders()).thenReturn(headers);
+        when(mockUriInfo.getQueryParameters()).thenReturn(params);
+        when(mockUriInfo.getAbsolutePathBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", null);
+
+        assertTrue(headers.isEmpty());
+        filter.filter(mockContext, mockResponseContext);
+        assertTrue(headers.isEmpty());
+    }
+
+    @Test
+    public void testFilterResponseForbidden() throws Exception {
+        final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        when(mockResponseContext.getStatusInfo()).thenReturn(FORBIDDEN);
+        when(mockResponseContext.getHeaders()).thenReturn(headers);
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", null);
+
+        assertTrue(headers.isEmpty());
+        filter.filter(mockContext, mockResponseContext);
+        assertTrue(headers.isEmpty());
     }
 
     @Test

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/ACL.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/ACL.java
@@ -49,6 +49,7 @@ public final class ACL {
     public static final IRI default_ = createIRI(getNamespace() + "default");
     public static final IRI delegates = createIRI(getNamespace() + "delegates");
     public static final IRI mode = createIRI(getNamespace() + "mode");
+    public static final IRI origin = createIRI(getNamespace() + "origin");
     public static final IRI owner = createIRI(getNamespace() + "owner");
 
     /**


### PR DESCRIPTION
Resolves #9

The logic here assumes that any `acl:origin` defined in an ACL has already been white-listed at the server level. That is, setting `<> acl:origin <https://bad.example.com>` in an ACL document does not suddenly give that Origin access to a resource if the server configuration hasn't already given that Origin access (e.g. via `*` or specifically by name)