### PR TITLE
Make ETag generation more flexible

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/core/EtagGenerator.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/EtagGenerator.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.http.core;
+
+import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
+
+import org.trellisldp.api.Resource;
+
+public interface EtagGenerator {
+
+    /**
+     * Generate the value portion for an entity tag for the given resource.
+     * @param resource the Trellis resource
+     * @return the value for the entity tag
+     */
+    default String getValue(final Resource resource) {
+        return md5Hex(resource.getModified().getNano() + "." + resource.getIdentifier());
+    }
+}

--- a/core/http/src/main/java/org/trellisldp/http/core/EtagGenerator.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/EtagGenerator.java
@@ -21,6 +21,10 @@ public interface EtagGenerator {
 
     /**
      * Generate the value portion for an entity tag for the given resource.
+     *
+     * @implSpec The default implementation of this method generates an ETag value based on
+     *           the precision of {@link Resource#getModified} implementation, up to and
+     *           including nano-second precision.
      * @param resource the Trellis resource
      * @return the value for the entity tag
      */

--- a/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -18,6 +18,7 @@ import static javax.ws.rs.core.HttpHeaders.IF_MODIFIED_SINCE;
 import static javax.ws.rs.core.HttpHeaders.IF_NONE_MATCH;
 import static javax.ws.rs.core.HttpHeaders.IF_UNMODIFIED_SINCE;
 import static org.trellisldp.api.TrellisUtils.getInstance;
+import static org.trellisldp.http.impl.HttpUtils.loadEtagGenerator;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import org.apache.commons.rdf.api.RDF;
 import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ServiceBundler;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.TrellisRequest;
 
 /**
@@ -40,6 +42,7 @@ class BaseLdpHandler {
 
     protected static final RDF rdf = getInstance();
 
+    protected static final EtagGenerator etagGenerator = loadEtagGenerator();
     protected static final List<ConstraintService> constraintServices = new ArrayList<>();
 
     static {

--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -23,7 +23,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 import static org.trellisldp.http.core.HttpConstants.ACL;
-import static org.trellisldp.http.impl.HttpUtils.buildEtagHash;
 import static org.trellisldp.http.impl.HttpUtils.closeDataset;
 import static org.trellisldp.http.impl.HttpUtils.skolemizeQuads;
 import static org.trellisldp.vocabulary.Trellis.PreferUserManaged;
@@ -95,7 +94,7 @@ public class DeleteHandler extends MutatingLdpHandler {
         }
 
         // Check the cache
-        final EntityTag etag = new EntityTag(buildEtagHash(getIdentifier(), resource.getModified(), null));
+        final EntityTag etag = new EntityTag(etagGenerator.getValue(resource));
         checkCache(resource.getModified(), etag);
 
         setResource(resource);

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -52,7 +52,6 @@ import static org.trellisldp.http.core.HttpConstants.RANGE;
 import static org.trellisldp.http.core.Prefer.PREFER_MINIMAL;
 import static org.trellisldp.http.core.Prefer.PREFER_REPRESENTATION;
 import static org.trellisldp.http.core.Prefer.PREFER_RETURN;
-import static org.trellisldp.http.impl.HttpUtils.buildEtagHash;
 import static org.trellisldp.http.impl.HttpUtils.getDefaultProfile;
 import static org.trellisldp.http.impl.HttpUtils.getProfile;
 import static org.trellisldp.http.impl.HttpUtils.getSyntax;
@@ -295,8 +294,7 @@ public class GetHandler extends BaseLdpHandler {
                         .collect(toList()), null, null) : getRequest().getPrefer();
 
         // Check for a cache hit
-        final EntityTag etag = new EntityTag(buildEtagHash(getIdentifier(), getResource().getModified(), prefer),
-                weakEtags);
+        final EntityTag etag = new EntityTag(etagGenerator.getValue(getResource()), weakEtags);
         checkCache(getResource().getModified(), etag);
 
         builder.tag(etag);
@@ -347,9 +345,8 @@ public class GetHandler extends BaseLdpHandler {
 
     private ResponseBuilder getLdpNr(final ResponseBuilder builder) {
 
-        final Instant mod = getResource().getModified();
-        final EntityTag etag = new EntityTag(buildEtagHash(getIdentifier() + "BINARY", mod, null));
-        checkCache(mod, etag);
+        final EntityTag etag = new EntityTag(etagGenerator.getValue(getResource()));
+        checkCache(getResource().getModified(), etag);
 
         final IRI dsid = getResource().getBinaryMetadata().map(BinaryMetadata::getIdentifier).orElse(null);
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -28,7 +28,6 @@ import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 import static org.trellisldp.http.core.HttpConstants.ACL;
 import static org.trellisldp.http.core.HttpConstants.PREFERENCE_APPLIED;
 import static org.trellisldp.http.core.Prefer.PREFER_REPRESENTATION;
-import static org.trellisldp.http.impl.HttpUtils.buildEtagHash;
 import static org.trellisldp.http.impl.HttpUtils.closeDataset;
 import static org.trellisldp.http.impl.HttpUtils.getDefaultProfile;
 import static org.trellisldp.http.impl.HttpUtils.getProfile;
@@ -139,8 +138,7 @@ public class PatchHandler extends MutatingLdpHandler {
             throw new NotSupportedException();
         }
         // Check the cache headers
-        final EntityTag etag = new EntityTag(buildEtagHash(getIdentifier(), resource.getModified(),
-                    getRequest().getPrefer()));
+        final EntityTag etag = new EntityTag(etagGenerator.getValue(resource));
         checkCache(resource.getModified(), etag);
 
         setResource(resource);

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -31,7 +31,6 @@ import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.api.TrellisUtils.getContainer;
 import static org.trellisldp.http.core.HttpConstants.ACL;
-import static org.trellisldp.http.impl.HttpUtils.buildEtagHash;
 import static org.trellisldp.http.impl.HttpUtils.checkRequiredPreconditions;
 import static org.trellisldp.http.impl.HttpUtils.closeDataset;
 import static org.trellisldp.http.impl.HttpUtils.ldpResourceTypes;
@@ -118,13 +117,8 @@ public class PutHandler extends MutatingLdpHandler {
         // Check the cache
         if (getResource() != null) {
             final Instant modified = getResource().getModified();
-            final EntityTag etag;
+            final EntityTag etag = new EntityTag(etagGenerator.getValue(getResource()));
 
-            if (getResource().getBinaryMetadata().isPresent() && !isRdfType(getRequest().getContentType()) ) {
-                etag = new EntityTag(buildEtagHash(getIdentifier() + "BINARY", modified, null));
-            } else {
-                etag = new EntityTag(buildEtagHash(getIdentifier(), modified, getRequest().getPrefer()));
-            }
             // Check the cache
             checkRequiredPreconditions(preconditionRequired, getRequest().getHeaders().getFirst(IF_MATCH),
                     getRequest().getHeaders().getFirst(IF_UNMODIFIED_SINCE));
@@ -204,13 +198,6 @@ public class PutHandler extends MutatingLdpHandler {
             }
         }
         return null;
-    }
-
-    private static boolean isRdfType(final String contentType) {
-        if (contentType != null) {
-            return RDFSyntax.byMediaType(contentType).isPresent();
-        }
-        return false;
     }
 
     private IRI getLdpType() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -38,7 +38,6 @@ import static javax.ws.rs.core.MediaType.WILDCARD_TYPE;
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
-import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
 import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
 import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
 import static org.apache.commons.rdf.api.RDFSyntax.RDFA;
@@ -65,7 +64,6 @@ import static org.trellisldp.vocabulary.JSONLD.compacted;
 
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -80,6 +78,7 @@ import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.trellisldp.api.BinaryMetadata;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.Prefer;
 import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.OA;
@@ -89,6 +88,8 @@ import org.trellisldp.vocabulary.SKOS;
  * @author acoburn
  */
 public class GetHandlerTest extends BaseTestHandler {
+
+    private static final EtagGenerator etagGenerator = new EtagGenerator() { };
 
     private BinaryMetadata testBinary = BinaryMetadata.builder(rdf.createIRI("file:///testResource.txt"))
         .mimeType("text/plain").build();
@@ -114,8 +115,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final EntityTag etag = res.getEntityTag();
         assertTrue(etag.isWeak(), "ETag isn't weak for an RDF document!");
-        assertEquals(md5Hex(time.toEpochMilli() + "." + time.getNano() + ".." + baseUrl), etag.getValue(),
-                "Unexpected ETag value!");
+        assertEquals(etagGenerator.getValue(mockResource), etag.getValue(), "Unexpected ETag value!");
 
         final List<Object> varies = res.getHeaders().get(VARY);
         assertFalse(varies.contains(RANGE), "Unexpected Vary: range header!");
@@ -165,8 +165,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final EntityTag etag = res.getEntityTag();
         assertTrue(etag.isWeak(), "ETag header is not weak for an RDF resource!");
-        assertEquals(md5Hex(time.toEpochMilli() + "." + time.getNano() + ".." + baseUrl), etag.getValue(),
-                "Unexpected ETag value!");
+        assertEquals(etagGenerator.getValue(mockResource), etag.getValue(), "Unexpected ETag value!");
 
         final List<Object> varies = res.getHeaders().get(VARY);
         assertTrue(varies.contains(PREFER), "Missing Vary: prefer header!");
@@ -229,9 +228,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final EntityTag etag = res.getEntityTag();
         assertTrue(etag.isWeak(), "ETag header isn't weak for LDP-RS!");
-        final String preferHash = new ArrayList<>().hashCode() + "." + new ArrayList<>().hashCode();
-        assertEquals(md5Hex(time.toEpochMilli() + "." + time.getNano() + "." + preferHash + "." + baseUrl),
-                etag.getValue(), "Unexpected ETag value!");
+        assertEquals(etagGenerator.getValue(mockResource), etag.getValue(), "Unexpected ETag value!");
 
         final List<Object> varies = res.getHeaders().get(VARY);
         assertTrue(varies.contains(ACCEPT_DATETIME), "Missing Vary: accept-datetime header!");
@@ -274,8 +271,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final EntityTag etag = res.getEntityTag();
         assertTrue(etag.isWeak(), "ETag isn't weak for RDF!");
-        assertEquals(md5Hex(time.toEpochMilli() + "." + time.getNano() + ".." + baseUrl), etag.getValue(),
-                "Incorrect ETag value for LDP-C!");
+        assertEquals(etagGenerator.getValue(mockResource), etag.getValue(), "Incorrect ETag value for LDP-C!");
 
         final List<Object> varies = res.getHeaders().get(VARY);
         assertTrue(varies.contains(ACCEPT_DATETIME), "Missing Vary: accept-datetime header!");


### PR DESCRIPTION
Resolves #434

This also simplifies the default etag generation code, making it, by default, invariant across response content-types and/or prefer headers, which also makes it considerably more usable by clients.

In addition, should an implementation choose to implement a different mechanism for generating ETags, that is easily done via the standard `ServiceLoader` mechanism.