### PR TITLE
Minor code clean-up

### DIFF
--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
@@ -32,7 +32,6 @@ import static org.trellisldp.triplestore.TriplestoreUtils.getObject;
 import static org.trellisldp.triplestore.TriplestoreUtils.getPredicate;
 import static org.trellisldp.triplestore.TriplestoreUtils.getSubject;
 import static org.trellisldp.triplestore.TriplestoreUtils.nodesToTriple;
-import static org.trellisldp.vocabulary.RDF.type;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -483,7 +482,7 @@ public class TriplestoreResource implements Resource {
      */
     private Stream<Quad> fetchUserQuads() {
         if (includeLdpType) {
-            return concat(of(rdf.createQuad(Trellis.PreferUserManaged, identifier, type, getInteractionModel())),
+            return concat(of(rdf.createQuad(Trellis.PreferUserManaged, identifier, RDF.type, getInteractionModel())),
                     fetchAllFromGraph(identifier.getIRIString(), Trellis.PreferUserManaged));
         }
         return fetchAllFromGraph(identifier.getIRIString(), Trellis.PreferUserManaged);

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -2430,21 +2430,6 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         return hasLink(iri, "type");
     }
 
-    private Stream<Quad> getLdfQuads() {
-        return Stream.of(
-            rdf.createQuad(PreferUserManaged, identifier, DC.creator, rdf.createLiteral("User")),
-            rdf.createQuad(PreferUserManaged, rdf.createIRI("ex:foo"), DC.title, rdf.createIRI("ex:title")),
-            rdf.createQuad(PreferUserManaged, identifier, DC.title, rdf.createLiteral("A title")),
-            rdf.createQuad(PreferUserManaged, identifier, DC.title, rdf.createLiteral("Other title")),
-            rdf.createQuad(PreferUserManaged, identifier, type, rdf.createIRI("ex:Type")),
-            rdf.createQuad(PreferUserManaged, rdf.createIRI("ex:foo"), type, rdf.createIRI("ex:Type")),
-            rdf.createQuad(PreferUserManaged, rdf.createIRI("ex:foo"), type, rdf.createIRI("ex:Other")),
-            rdf.createQuad(PreferServerManaged, identifier, DC.created,
-                rdf.createLiteral("2017-04-01T10:15:00Z", XSD.dateTime)),
-            rdf.createQuad(PreferAccessControl, identifier, type, ACL.Authorization),
-            rdf.createQuad(PreferAccessControl, identifier, ACL.mode, ACL.Control));
-    }
-
     private Stream<Quad> getPreferQuads() {
         return Stream.of(
             rdf.createQuad(PreferUserManaged, identifier, DC.title, rdf.createLiteral("A title")),


### PR DESCRIPTION
This removes an unused private method and changes `type` to `RDF.type`, since that's how it's referenced everywhere else in that class.