### PR TITLE
Move services into the ServiceBundler interface

### DIFF
--- a/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
+++ b/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
@@ -14,17 +14,21 @@
 package org.trellisldp.app.triplestore;
 
 import static com.google.common.cache.CacheBuilder.newBuilder;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.HOURS;
 
 import com.google.common.cache.Cache;
 
 import io.dropwizard.setup.Environment;
 
+import java.util.List;
+
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.trellisldp.agent.SimpleAgentService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
+import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.DefaultIdentifierService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
@@ -33,9 +37,12 @@ import org.trellisldp.api.NamespaceService;
 import org.trellisldp.api.RDFaWriterService;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.app.TrellisCache;
+import org.trellisldp.constraint.LdpConstraints;
 import org.trellisldp.file.FileBinaryService;
 import org.trellisldp.file.FileMementoService;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
+import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
 import org.trellisldp.namespaces.NamespacesJsonContext;
 import org.trellisldp.rdfa.HtmlSerializer;
@@ -57,6 +64,9 @@ public class TrellisServiceBundler implements ServiceBundler {
     private final AgentService agentService;
     private final IOService ioService;
     private final EventService eventService;
+    private final TimemapGenerator timemapGenerator;
+    private final EtagGenerator etagGenerator;
+    private final List<ConstraintService> constraintServices;
 
     /**
      * Create a new application service bundler.
@@ -66,6 +76,9 @@ public class TrellisServiceBundler implements ServiceBundler {
     public TrellisServiceBundler(final AppConfiguration config, final Environment environment) {
         agentService = new SimpleAgentService();
         mementoService = new FileMementoService(config.getMementos());
+        etagGenerator = new EtagGenerator() { };
+        timemapGenerator = new TimemapGenerator() { };
+        constraintServices = singletonList(new LdpConstraints());
         auditService = resourceService = buildResourceService(config, environment);
         binaryService = buildBinaryService(config);
         ioService = buildIoService(config);
@@ -105,6 +118,21 @@ public class TrellisServiceBundler implements ServiceBundler {
     @Override
     public EventService getEventService() {
         return eventService;
+    }
+
+    @Override
+    public TimemapGenerator getTimemapGenerator() {
+        return timemapGenerator;
+    }
+
+    @Override
+    public EtagGenerator getEtagGenerator() {
+        return etagGenerator;
+    }
+
+    @Override
+    public Iterable<ConstraintService> getConstraintServices() {
+        return constraintServices;
     }
 
     private static TriplestoreResourceService buildResourceService(final AppConfiguration config,

--- a/components/app/build.gradle
+++ b/components/app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testImplementation("org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
     testImplementation project(':trellis-triplestore')
+    testImplementation project(':trellis-constraint-rules')
     testImplementation project(':trellis-io-jena')
     testImplementation project(':trellis-file')
     testImplementation("io.dropwizard:dropwizard-client:$dropwizardVersion")

--- a/components/app/src/test/java/org/trellisldp/app/SimpleServiceBundler.java
+++ b/components/app/src/test/java/org/trellisldp/app/SimpleServiceBundler.java
@@ -15,13 +15,17 @@ package org.trellisldp.app;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
 import static org.apache.jena.query.DatasetFactory.createTxnMem;
 import static org.apache.jena.rdfconnection.RDFConnectionFactory.connect;
+
+import java.util.List;
 
 import org.trellisldp.agent.SimpleAgentService;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
+import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.DefaultIdentifierService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
@@ -30,8 +34,11 @@ import org.trellisldp.api.NoopEventService;
 import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.NoopNamespaceService;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.constraint.LdpConstraints;
 import org.trellisldp.file.FileBinaryService;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
+import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
 import org.trellisldp.io.NoopProfileCache;
 import org.trellisldp.triplestore.TriplestoreResourceService;
@@ -44,6 +51,9 @@ public class SimpleServiceBundler implements ServiceBundler {
     private final MementoService mementoService = new NoopMementoService();
     private final EventService eventService = new NoopEventService();
     private final AgentService agentService = new SimpleAgentService();
+    private final EtagGenerator etagGenerator = new EtagGenerator() { };
+    private final TimemapGenerator timemapGenerator = new TimemapGenerator() { };
+    private final List<ConstraintService> constraintServices = singletonList(new LdpConstraints());
     private final IOService ioService = new JenaIOService(new NoopNamespaceService(), null, new NoopProfileCache(),
             emptySet(), emptySet());
     private final BinaryService binaryService = new FileBinaryService(new DefaultIdentifierService(),
@@ -88,5 +98,20 @@ public class SimpleServiceBundler implements ServiceBundler {
     @Override
     public EventService getEventService() {
         return eventService;
+    }
+
+    @Override
+    public TimemapGenerator getTimemapGenerator() {
+        return timemapGenerator;
+    }
+
+    @Override
+    public EtagGenerator getEtagGenerator() {
+        return etagGenerator;
+    }
+
+    @Override
+    public Iterable<ConstraintService> getConstraintServices() {
+        return constraintServices;
     }
 }

--- a/components/webdav/src/test/java/org/trellisldp/webdav/AbstractWebDAVTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/AbstractWebDAVTest.java
@@ -93,6 +93,7 @@ import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.audit.DefaultAuditService;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
 import org.trellisldp.io.JenaIOService;
 import org.trellisldp.vocabulary.ACL;
@@ -822,6 +823,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
         when(mockBundler.getBinaryService()).thenReturn(mockBinaryService);
         when(mockBundler.getEventService()).thenReturn(new NoopEventService());
         when(mockBundler.getMementoService()).thenReturn(new NoopMementoService());
+        when(mockBundler.getEtagGenerator()).thenReturn(new EtagGenerator() { });
     }
 
     private void setUpBinaryService() {

--- a/components/webdav/src/test/java/org/trellisldp/webdav/TrellisWebDAVRequestFilterTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/TrellisWebDAVRequestFilterTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
 
 public class TrellisWebDAVRequestFilterTest {
@@ -79,6 +80,7 @@ public class TrellisWebDAVRequestFilterTest {
         initMocks(this);
 
         when(mockBundler.getResourceService()).thenReturn(mockResourceService);
+        when(mockBundler.getEtagGenerator()).thenReturn(new EtagGenerator() { });
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + PATH))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
         when(mockContext.getMethod()).thenReturn(PUT);

--- a/core/http/build.gradle
+++ b/core/http/build.gradle
@@ -5,7 +5,7 @@ description = 'Trellis HTTP API'
 
 ext {
     moduleName = 'org.trellisldp.http'
-    testModules = ['org.trellisldp.io', 'org.trellisldp.audit', 'org.trellisldp.agent', 'smallrye.config']
+    testModules = ['org.trellisldp.io', 'org.trellisldp.audit', 'org.trellisldp.agent', 'org.trellisldp.constraint', 'smallrye.config']
 }
 
 dependencies {

--- a/core/http/src/main/java/module-info.java
+++ b/core/http/src/main/java/module-info.java
@@ -29,8 +29,4 @@ module org.trellisldp.http {
     requires java.xml.bind;
     requires java.annotation;
     requires cdi.api;
-
-    uses org.trellisldp.api.ConstraintService;
-    uses org.trellisldp.http.core.TimemapGenerator;
-    uses org.trellisldp.http.core.EtagGenerator;
 }

--- a/core/http/src/main/java/org/trellisldp/http/core/ServiceBundler.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/ServiceBundler.java
@@ -16,6 +16,7 @@ package org.trellisldp.http.core;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
+import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.MementoService;
@@ -68,4 +69,22 @@ public interface ServiceBundler {
      * @return the service for emiting notifications.
      */
     EventService getEventService();
+
+    /**
+     * Get the constraint services for this application.
+     * @return an interator of the constraint service(s).
+     */
+    Iterable<ConstraintService> getConstraintServices();
+
+    /**
+     * Get the ETag generator for this application.
+     * @return the service for generating ETags
+     */
+    EtagGenerator getEtagGenerator();
+
+    /**
+     * Get the TimemapGenerator for this application.
+     * @return the service for generating TimeMaps.
+     */
+    TimemapGenerator getTimemapGenerator();
 }

--- a/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -20,14 +20,11 @@ import static javax.ws.rs.core.HttpHeaders.IF_UNMODIFIED_SINCE;
 import static org.trellisldp.api.TrellisUtils.getInstance;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.ws.rs.core.EntityTag;
 
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
-import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.http.core.ServiceBundler;
 import org.trellisldp.http.core.TrellisRequest;
@@ -38,8 +35,6 @@ import org.trellisldp.http.core.TrellisRequest;
 class BaseLdpHandler {
 
     protected static final RDF rdf = getInstance();
-
-    protected final List<ConstraintService> constraintServices = new ArrayList<>();
 
     private final String requestBaseUrl;
     private final TrellisRequest request;
@@ -58,7 +53,6 @@ class BaseLdpHandler {
         this.requestBaseUrl = getRequestBaseUrl(request, baseUrl);
         this.request = request;
         this.services = services;
-        services.getConstraintServices().forEach(constraintServices::add);
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -18,12 +18,10 @@ import static javax.ws.rs.core.HttpHeaders.IF_MODIFIED_SINCE;
 import static javax.ws.rs.core.HttpHeaders.IF_NONE_MATCH;
 import static javax.ws.rs.core.HttpHeaders.IF_UNMODIFIED_SINCE;
 import static org.trellisldp.api.TrellisUtils.getInstance;
-import static org.trellisldp.http.impl.HttpUtils.loadEtagGenerator;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ServiceLoader;
 
 import javax.ws.rs.core.EntityTag;
 
@@ -31,7 +29,6 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
 import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.Resource;
-import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
 import org.trellisldp.http.core.TrellisRequest;
 
@@ -42,12 +39,7 @@ class BaseLdpHandler {
 
     protected static final RDF rdf = getInstance();
 
-    protected static final EtagGenerator etagGenerator = loadEtagGenerator();
-    protected static final List<ConstraintService> constraintServices = new ArrayList<>();
-
-    static {
-        ServiceLoader.load(ConstraintService.class).forEach(constraintServices::add);
-    }
+    protected final List<ConstraintService> constraintServices = new ArrayList<>();
 
     private final String requestBaseUrl;
     private final TrellisRequest request;
@@ -66,6 +58,7 @@ class BaseLdpHandler {
         this.requestBaseUrl = getRequestBaseUrl(request, baseUrl);
         this.request = request;
         this.services = services;
+        services.getConstraintServices().forEach(constraintServices::add);
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -94,7 +94,7 @@ public class DeleteHandler extends MutatingLdpHandler {
         }
 
         // Check the cache
-        final EntityTag etag = new EntityTag(etagGenerator.getValue(resource));
+        final EntityTag etag = new EntityTag(getServices().getEtagGenerator().getValue(resource));
         checkCache(resource.getModified(), etag);
 
         setResource(resource);

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -294,7 +294,7 @@ public class GetHandler extends BaseLdpHandler {
                         .collect(toList()), null, null) : getRequest().getPrefer();
 
         // Check for a cache hit
-        final EntityTag etag = new EntityTag(etagGenerator.getValue(getResource()), weakEtags);
+        final EntityTag etag = new EntityTag(getServices().getEtagGenerator().getValue(getResource()), weakEtags);
         checkCache(getResource().getModified(), etag);
 
         builder.tag(etag);
@@ -345,7 +345,7 @@ public class GetHandler extends BaseLdpHandler {
 
     private ResponseBuilder getLdpNr(final ResponseBuilder builder) {
 
-        final EntityTag etag = new EntityTag(etagGenerator.getValue(getResource()));
+        final EntityTag etag = new EntityTag(getServices().getEtagGenerator().getValue(getResource()));
         checkCache(getResource().getModified(), etag);
 
         final IRI dsid = getResource().getBinaryMetadata().map(BinaryMetadata::getIdentifier).orElse(null);

--- a/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
@@ -18,7 +18,6 @@ import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Arrays.stream;
 import static java.util.Collections.unmodifiableSet;
-import static java.util.ServiceLoader.load;
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
@@ -38,7 +37,6 @@ import java.io.UncheckedIOException;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -63,7 +61,6 @@ import org.slf4j.Logger;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
-import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.Prefer;
 import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.Trellis;
@@ -380,15 +377,6 @@ public final class HttpUtils {
         } catch (final Exception ex) {
             throw new RuntimeTrellisException("Error closing dataset", ex);
         }
-    }
-
-    /**
-     * Load an Etag generator.
-     * @return the etag generator
-     */
-    public static EtagGenerator loadEtagGenerator() {
-        final Iterator<EtagGenerator> services = load(EtagGenerator.class).iterator();
-        return services.hasNext() ? services.next() : new EtagGenerator() { };
     }
 
     private HttpUtils() {

--- a/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
@@ -21,7 +21,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.ServiceLoader.load;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
@@ -68,7 +67,6 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFSyntax;
 import org.trellisldp.http.core.ServiceBundler;
-import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.http.core.TrellisRequest;
 
 /**
@@ -82,7 +80,6 @@ public final class MementoResource {
     private static final String NEXT = "next";
     private static final String TIMEMAP_PARAM = "?ext=timemap";
     private static final String VERSION_PARAM = "?version=";
-    private static final TimemapGenerator timemap = loadTimemapGenerator();
 
     private final ServiceBundler trellis;
     private final boolean includeMementoDates;
@@ -127,7 +124,8 @@ public final class MementoResource {
             final StreamingOutput stream = new StreamingOutput() {
                 @Override
                 public void write(final OutputStream out) throws IOException {
-                    trellis.getIOService().write(timemap.asRdf(identifier, allLinks), out, syntax, jsonldProfile);
+                    trellis.getIOService().write(trellis.getTimemapGenerator()
+                            .asRdf(identifier, allLinks), out, syntax, jsonldProfile);
                 }
             };
 
@@ -326,10 +324,5 @@ public final class MementoResource {
     private static boolean shouldAddPrevNextLinks(final SortedSet<Instant> mementos, final Instant time) {
         return time != null && !time.truncatedTo(SECONDS).isBefore(mementos.first().truncatedTo(SECONDS))
             && !time.truncatedTo(SECONDS).isAfter(mementos.last().truncatedTo(SECONDS));
-    }
-
-    private static TimemapGenerator loadTimemapGenerator() {
-        final Iterator<TimemapGenerator> services = load(TimemapGenerator.class).iterator();
-        return services.hasNext() ? services.next() : new TimemapGenerator() { };
     }
 }

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -28,6 +28,7 @@ import static org.trellisldp.http.impl.HttpUtils.skolemizeTriples;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
@@ -230,8 +231,8 @@ class MutatingLdpHandler extends BaseLdpHandler {
      */
     protected void checkConstraint(final Optional<Graph> graph, final IRI type, final RDFSyntax syntax) {
         graph.ifPresent(g -> {
-            final List<ConstraintViolation> violations = constraintServices.stream().parallel()
-                .flatMap(svc -> svc.constrainedBy(type, g)).collect(toList());
+            final List<ConstraintViolation> violations = new ArrayList<>();
+            getServices().getConstraintServices().forEach(svc -> svc.constrainedBy(type, g).forEach(violations::add));
             if (!violations.isEmpty()) {
                 final ResponseBuilder err = status(CONFLICT);
                 violations.forEach(v -> err.link(v.getConstraint().getIRIString(), LDP.constrainedBy.getIRIString()));

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -138,7 +138,7 @@ public class PatchHandler extends MutatingLdpHandler {
             throw new NotSupportedException();
         }
         // Check the cache headers
-        final EntityTag etag = new EntityTag(etagGenerator.getValue(resource));
+        final EntityTag etag = new EntityTag(getServices().getEtagGenerator().getValue(resource));
         checkCache(resource.getModified(), etag);
 
         setResource(resource);

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -41,9 +41,9 @@ import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.ws.rs.BadRequestException;
@@ -212,9 +212,10 @@ public class PatchHandler extends MutatingLdpHandler {
             .forEachOrdered(mutable::add);
 
         // Check any constraints on the resulting dataset
-        final List<ConstraintViolation> violations = constraintServices.stream()
-            .flatMap(handleConstraintViolations(mutable, graphName, getResource().getInteractionModel()))
-            .collect(toList());
+        final List<ConstraintViolation> violations = new ArrayList<>();
+        getServices().getConstraintServices()
+            .forEach(svc -> handleConstraintViolation(svc, mutable, graphName, getResource().getInteractionModel())
+                    .forEach(violations::add));
 
         // Short-ciruit if there is a constraint violation
         if (!violations.isEmpty()) {
@@ -261,10 +262,10 @@ public class PatchHandler extends MutatingLdpHandler {
         return getDefaultProfile(outputSyntax, getIdentifier(), defaultJsonLdProfile);
     }
 
-    private static Function<ConstraintService, Stream<ConstraintViolation>> handleConstraintViolations(
+    private static Stream<ConstraintViolation> handleConstraintViolation(final ConstraintService service,
             final Dataset dataset, final IRI graphName, final IRI interactionModel) {
         final IRI model = PreferAccessControl.equals(graphName) ? LDP.RDFSource : interactionModel;
-        return service -> dataset.getGraph(graphName).map(Stream::of).orElseGet(Stream::empty)
+        return dataset.getGraph(graphName).map(Stream::of).orElseGet(Stream::empty)
                 .flatMap(g -> service.constrainedBy(model, g));
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -117,7 +117,7 @@ public class PutHandler extends MutatingLdpHandler {
         // Check the cache
         if (getResource() != null) {
             final Instant modified = getResource().getModified();
-            final EntityTag etag = new EntityTag(etagGenerator.getValue(getResource()));
+            final EntityTag etag = new EntityTag(getServices().getEtagGenerator().getValue(getResource()));
 
             // Check the cache
             checkRequiredPreconditions(preconditionRequired, getRequest().getHeaders().getFirst(IF_MATCH),

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -18,6 +18,7 @@ import static java.time.Instant.MAX;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySortedSet;
+import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -70,7 +71,10 @@ import org.trellisldp.api.Metadata;
 import org.trellisldp.api.NoopAuditService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.constraint.LdpConstraints;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
+import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
 import org.trellisldp.vocabulary.ACL;
 import org.trellisldp.vocabulary.DC;
@@ -192,6 +196,9 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         when(mockBundler.getAgentService()).thenReturn(mockAgentService);
         when(mockBundler.getAuditService()).thenReturn(auditService);
         when(mockBundler.getEventService()).thenReturn(mockEventService);
+        when(mockBundler.getConstraintServices()).thenReturn(singletonList(new LdpConstraints()));
+        when(mockBundler.getEtagGenerator()).thenReturn(new EtagGenerator() { });
+        when(mockBundler.getTimemapGenerator()).thenReturn(new TimemapGenerator() { });
     }
 
     private void setUpResourceService() {

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -91,7 +91,10 @@ import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
+import org.trellisldp.constraint.LdpConstraints;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
+import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.http.core.TrellisRequest;
 import org.trellisldp.vocabulary.LDP;
 
@@ -249,6 +252,9 @@ abstract class BaseTestHandler {
         when(mockBundler.getMementoService()).thenReturn(mementoService);
         when(mockBundler.getAgentService()).thenReturn(agentService);
         when(mockBundler.getEventService()).thenReturn(mockEventService);
+        when(mockBundler.getConstraintServices()).thenReturn(singletonList(new LdpConstraints()));
+        when(mockBundler.getTimemapGenerator()).thenReturn(new TimemapGenerator() { });
+        when(mockBundler.getEtagGenerator()).thenReturn(new EtagGenerator() { });
     }
 
     private void setUpIoService() {

--- a/platform/osgi/src/main/java/org/trellisldp/osgi/TrellisServiceBundler.java
+++ b/platform/osgi/src/main/java/org/trellisldp/osgi/TrellisServiceBundler.java
@@ -13,14 +13,21 @@
  */
 package org.trellisldp.osgi;
 
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
+import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.MementoService;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
+import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.triplestore.TriplestoreResourceService;
 
 /**
@@ -35,6 +42,9 @@ public class TrellisServiceBundler implements ServiceBundler {
     private final IOService ioService;
     private final MementoService mementoService;
     private final ResourceService resourceService;
+    private final TimemapGenerator timemapGenerator;
+    private final EtagGenerator etagGenerator;
+    private final List<ConstraintService> constraintServices;
 
     /**
      * Create a Trellis service bundler with existing services.
@@ -55,6 +65,9 @@ public class TrellisServiceBundler implements ServiceBundler {
         this.eventService = eventService;
         this.auditService = service;
         this.resourceService = service;
+        this.constraintServices = emptyList();
+        this.etagGenerator = new EtagGenerator() { };
+        this.timemapGenerator = new TimemapGenerator() { };
     }
 
     @Override
@@ -90,5 +103,20 @@ public class TrellisServiceBundler implements ServiceBundler {
     @Override
     public EventService getEventService() {
         return eventService;
+    }
+
+    @Override
+    public TimemapGenerator getTimemapGenerator() {
+        return timemapGenerator;
+    }
+
+    @Override
+    public EtagGenerator getEtagGenerator() {
+        return etagGenerator;
+    }
+
+    @Override
+    public Iterable<ConstraintService> getConstraintServices() {
+        return constraintServices;
     }
 }

--- a/platform/webapp/src/main/java/org/trellisldp/webapp/WebappServiceBundler.java
+++ b/platform/webapp/src/main/java/org/trellisldp/webapp/WebappServiceBundler.java
@@ -14,24 +14,31 @@
 package org.trellisldp.webapp;
 
 import static com.google.common.cache.CacheBuilder.newBuilder;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 
 import com.google.common.cache.Cache;
 
+import java.util.List;
+
 import org.eclipse.microprofile.config.Config;
 import org.trellisldp.api.AgentService;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
+import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
 import org.trellisldp.api.MementoService;
 import org.trellisldp.api.NamespaceService;
 import org.trellisldp.api.NoopEventService;
 import org.trellisldp.api.ResourceService;
+import org.trellisldp.constraint.LdpConstraints;
 import org.trellisldp.file.FileBinaryService;
 import org.trellisldp.file.FileMementoService;
+import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
+import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
 import org.trellisldp.triplestore.TriplestoreResourceService;
 
@@ -51,6 +58,9 @@ public class WebappServiceBundler implements ServiceBundler {
     private final BinaryService binaryService;
     private final IOService ioService;
     private final EventService eventService;
+    private final TimemapGenerator timemapGenerator;
+    private final EtagGenerator etagGenerator;
+    private final List<ConstraintService> constraintServices;
 
     /**
      * Create a new application service bundler.
@@ -70,6 +80,9 @@ public class WebappServiceBundler implements ServiceBundler {
         mementoService = new FileMementoService();
         ioService = new JenaIOService(nsService, null, profileCache);
         auditService = resourceService = new TriplestoreResourceService();
+        constraintServices = singletonList(new LdpConstraints());
+        timemapGenerator = new TimemapGenerator() { };
+        etagGenerator = new EtagGenerator() { };
     }
 
     @Override
@@ -105,5 +118,20 @@ public class WebappServiceBundler implements ServiceBundler {
     @Override
     public EventService getEventService() {
         return eventService;
+    }
+
+    @Override
+    public EtagGenerator getEtagGenerator() {
+        return etagGenerator;
+    }
+
+    @Override
+    public TimemapGenerator getTimemapGenerator() {
+        return timemapGenerator;
+    }
+
+    @Override
+    public Iterable<ConstraintService> getConstraintServices() {
+        return constraintServices;
     }
 }


### PR DESCRIPTION
Addresses #441

This moves many of the internally-loaded services into the `ServiceBundler` interface.

With the exception of Commons-RDF, all of the services used in `./core` are now defined in the `ServiceBundler`.