### PR TITLE
Remove use of ServiceLoader

### DIFF
--- a/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/AppUtils.java
+++ b/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/AppUtils.java
@@ -30,10 +30,12 @@ import javax.jms.JMSException;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.slf4j.Logger;
+import org.trellisldp.api.ActivityStreamService;
 import org.trellisldp.api.EventService;
 import org.trellisldp.api.NoopEventService;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.app.config.NotificationsConfiguration;
+import org.trellisldp.event.EventSerializer;
 import org.trellisldp.jms.JmsPublisher;
 import org.trellisldp.kafka.KafkaPublisher;
 
@@ -42,6 +44,7 @@ final class AppUtils {
     private static final String UN_KEY = "username";
     private static final String PW_KEY = "password";
     private static final Logger LOGGER = getLogger(AppUtils.class);
+    private static final ActivityStreamService serializer = new EventSerializer();
 
     public static Properties getKafkaProperties(final NotificationsConfiguration config) {
         final Properties p = new Properties();
@@ -72,7 +75,7 @@ final class AppUtils {
         LOGGER.info("Connecting to Kafka broker at {}", config.getConnectionString());
         final KafkaProducer<String, String> kafkaProducer = new KafkaProducer<>(getKafkaProperties(config));
         environment.lifecycle().manage(new AutoCloseableManager(kafkaProducer));
-        return new KafkaPublisher(kafkaProducer, config.getTopicName());
+        return new KafkaPublisher(serializer, kafkaProducer, config.getTopicName());
     }
 
     private static EventService buildJmsPublisher(final NotificationsConfiguration config,
@@ -82,7 +85,8 @@ final class AppUtils {
         environment.lifecycle().manage(new AutoCloseableManager(jmsConnection));
         final boolean useQueue = parseBoolean(config.any().getOrDefault("use.queue", "true"));
 
-        return new JmsPublisher(jmsConnection.createSession(false, AUTO_ACKNOWLEDGE), config.getTopicName(), useQueue);
+        return new JmsPublisher(serializer, jmsConnection.createSession(false, AUTO_ACKNOWLEDGE), config.getTopicName(),
+                useQueue);
     }
 
     public static EventService getNotificationService(final NotificationsConfiguration config,

--- a/components/file/src/main/java/module-info.java
+++ b/components/file/src/main/java/module-info.java
@@ -29,6 +29,4 @@ module org.trellisldp.file {
         with org.trellisldp.file.FileBinaryService;
     provides org.trellisldp.api.MementoService
         with org.trellisldp.file.FileMementoService;
-
-    uses org.trellisldp.api.IdentifierService;
 }

--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -17,7 +17,6 @@ import static java.nio.file.Files.copy;
 import static java.nio.file.Files.delete;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.Objects.requireNonNull;
-import static java.util.ServiceLoader.load;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -26,7 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.util.Iterator;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
@@ -66,9 +64,8 @@ public class FileBinaryService implements BinaryService {
     /**
      * Create a File-based Binary service.
      */
-    @Inject
     public FileBinaryService() {
-        this(getDefaultIdentifierService());
+        this(new DefaultIdentifierService());
     }
 
     /**
@@ -76,6 +73,7 @@ public class FileBinaryService implements BinaryService {
      *
      * @param idService an identifier service
      */
+    @Inject
     public FileBinaryService(final IdentifierService idService) {
         this(idService, ConfigProvider.getConfig());
     }
@@ -154,13 +152,5 @@ public class FileBinaryService implements BinaryService {
             return trimStart(str.substring(trim.length()), trim);
         }
         return str;
-    }
-
-    private static IdentifierService getDefaultIdentifierService() {
-        final Iterator<IdentifierService> services = load(IdentifierService.class).iterator();
-        if (services.hasNext()) {
-            return services.next();
-        }
-        return new DefaultIdentifierService();
     }
 }

--- a/components/io-jena/bnd.bnd
+++ b/components/io-jena/bnd.bnd
@@ -14,14 +14,6 @@ Bundle-SCM:             url=https://github.com/trellis-ldp/trellis, \
 
 Require-Capability:     osgi.extender; \
                             filter:="(osgi.extender=osgi.serviceloader.registrar)"; \
-                            resolution:=optional, \
-                        osgi.extender; \
-                            filter:="(osgi.extender=osgi.serviceloader.processor)", \
-                        osgi.serviceloader; \
-                            filter:="(osgi.serviceloader=org.trellisldp.api.RDFaWriterService)"; \
-                            resolution:=optional, \
-                        osgi.serviceloader; \
-                            filter:="(osgi.serviceloader=org.trellisldp.api.NamespaceService)"; \
                             resolution:=optional
 Provide-Capability:     osgi.serviceloader; \
                             osgi.serviceloader=org.trellisldp.api.IOService

--- a/components/io-jena/src/main/java/module-info.java
+++ b/components/io-jena/src/main/java/module-info.java
@@ -27,7 +27,4 @@ module org.trellisldp.io {
 
     provides org.trellisldp.api.IOService
         with org.trellisldp.io.JenaIOService;
-
-    uses org.trellisldp.api.NamespaceService;
-    uses org.trellisldp.api.RDFaWriterService;
 }

--- a/components/io-jena/src/main/java/org/trellisldp/io/JenaIOService.java
+++ b/components/io-jena/src/main/java/org/trellisldp/io/JenaIOService.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.stream;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
-import static java.util.ServiceLoader.load;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
@@ -48,11 +47,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -125,9 +122,8 @@ public class JenaIOService implements IOService {
     /**
      * Create a serialization service.
      */
-    @Inject
     public JenaIOService() {
-        this(getDefaultService(NamespaceService.class, NoopNamespaceService::new));
+        this(new NoopNamespaceService());
     }
 
     /**
@@ -135,7 +131,7 @@ public class JenaIOService implements IOService {
      * @param namespaceService the namespace service
      */
     public JenaIOService(final NamespaceService namespaceService) {
-        this(namespaceService, getDefaultService(RDFaWriterService.class));
+        this(namespaceService, null);
     }
 
     /**
@@ -155,6 +151,7 @@ public class JenaIOService implements IOService {
      * @param htmlSerializer the HTML serializer service
      * @param cache a cache for custom JSON-LD profile resolution
      */
+    @Inject
     public JenaIOService(final NamespaceService namespaceService,
             final RDFaWriterService htmlSerializer,
             @TrellisProfileCache final CacheService<String, String> cache) {
@@ -387,21 +384,5 @@ public class JenaIOService implements IOService {
 
     private static RDFFormat getJsonLdProfile(final IRI... profiles) {
         return JSONLD_FORMATS.get(mergeProfiles(profiles));
-    }
-
-    private static <T> T getDefaultService(final Class<T> service) {
-        final Iterator<T> services = load(service).iterator();
-        if (services.hasNext()) {
-            return services.next();
-        }
-        return null;
-    }
-
-    private static <T> T getDefaultService(final Class<T> service, final Supplier<T> supplier) {
-        final Iterator<T> services = load(service).iterator();
-        if (services.hasNext()) {
-            return services.next();
-        }
-        return supplier.get();
     }
 }

--- a/components/rdfa/src/main/java/org/trellisldp/rdfa/HtmlSerializer.java
+++ b/components/rdfa/src/main/java/org/trellisldp/rdfa/HtmlSerializer.java
@@ -17,7 +17,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
-import static java.util.ServiceLoader.load;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 
@@ -33,7 +32,6 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.io.Writer;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -73,9 +71,8 @@ public class HtmlSerializer implements RDFaWriterService {
     /**
      * Create an HTML Serializer object.
      */
-    @Inject
     public HtmlSerializer() {
-        this(getDefaultNamespaceService());
+        this(new NoopNamespaceService());
     }
 
     /**
@@ -83,6 +80,7 @@ public class HtmlSerializer implements RDFaWriterService {
      *
      * @param namespaceService a namespace service
      */
+    @Inject
     public HtmlSerializer(final NamespaceService namespaceService) {
         this(namespaceService, getConfig());
     }
@@ -163,13 +161,5 @@ public class HtmlSerializer implements RDFaWriterService {
             return stream(property.split(",")).map(String::trim).filter(x -> !x.isEmpty()).collect(toList());
         }
         return emptyList();
-    }
-
-    private static NamespaceService getDefaultNamespaceService() {
-        final Iterator<NamespaceService> services = load(NamespaceService.class).iterator();
-        if (services.hasNext()) {
-            return services.next();
-        }
-        return new NoopNamespaceService();
     }
 }

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -19,8 +19,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.synchronizedList;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
-import static java.util.Optional.of;
-import static java.util.ServiceLoader.load;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.builder;
@@ -48,8 +46,6 @@ import static org.trellisldp.vocabulary.Trellis.PreferUserManaged;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
@@ -114,7 +110,6 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
     /**
      * Create a triplestore-backed resource service.
      */
-    @Inject
     public TriplestoreResourceService() {
         this(buildRDFConnection(getConfig().getOptionalValue(CONFIG_TRIPLESTORE_RDF_LOCATION, String.class)
                     .orElse(null)));
@@ -125,8 +120,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
      * @param rdfConnection the connection to an RDF datastore
      */
     public TriplestoreResourceService(final RDFConnection rdfConnection) {
-        this(rdfConnection, of(load(IdentifierService.class)).map(ServiceLoader::iterator).filter(Iterator::hasNext)
-                .map(Iterator::next).orElseGet(DefaultIdentifierService::new));
+        this(rdfConnection, new DefaultIdentifierService());
     }
 
     /**
@@ -134,6 +128,7 @@ public class TriplestoreResourceService extends DefaultAuditService implements R
      * @param rdfConnection the connection to an RDF datastore
      * @param identifierService an ID supplier service
      */
+    @Inject
     public TriplestoreResourceService(final RDFConnection rdfConnection, final IdentifierService identifierService) {
         super();
         this.includeLdpType = getConfig().getOptionalValue(CONFIG_TRIPLESTORE_LDP_TYPE, Boolean.class)

--- a/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
@@ -21,7 +21,6 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
-import static java.util.ServiceLoader.load;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
@@ -34,7 +33,6 @@ import static org.trellisldp.api.TrellisUtils.getInstance;
 import static org.trellisldp.api.TrellisUtils.toGraph;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -99,7 +97,7 @@ public class WebAcService {
      * Create a WebAC-based authorization service.
      */
     public WebAcService() {
-        this(getDefaultResourceService());
+        this(new NoopResourceService());
     }
 
     /**
@@ -107,7 +105,6 @@ public class WebAcService {
      *
      * @param resourceService the resource service
      */
-    @Inject
     public WebAcService(final ResourceService resourceService) {
         this(resourceService, new NoopAuthorizationCache());
     }
@@ -118,6 +115,7 @@ public class WebAcService {
      * @param resourceService the resource service
      * @param cache a cache
      */
+    @Inject
     public WebAcService(final ResourceService resourceService,
             @TrellisAuthorizationCache final CacheService<String, Set<IRI>> cache) {
         this(resourceService, cache, getConfig()
@@ -292,14 +290,6 @@ public class WebAcService {
      */
     private static IRI cleanIdentifier(final IRI identifier) {
         return rdf.createIRI(cleanIdentifier(identifier.getIRIString()));
-    }
-
-    private static ResourceService getDefaultResourceService() {
-        final Iterator<ResourceService> services = load(ResourceService.class).iterator();
-        if (services.hasNext()) {
-            return services.next();
-        }
-        return new NoopResourceService();
     }
 
     @TrellisAuthorizationCache

--- a/core/api/src/main/java/org/trellisldp/api/DefaultIdentifierService.java
+++ b/core/api/src/main/java/org/trellisldp/api/DefaultIdentifierService.java
@@ -20,11 +20,14 @@ import static java.util.stream.IntStream.rangeClosed;
 import java.util.StringJoiner;
 import java.util.function.Supplier;
 
+import javax.enterprise.inject.Alternative;
+
 /**
  * The IdentifierService provides a mechanism for creating new identifiers.
  *
  * @author acoburn
  */
+@Alternative
 public class DefaultIdentifierService implements IdentifierService {
 
     private final String defaultPrefix;

--- a/notifications/amqp/bnd.bnd
+++ b/notifications/amqp/bnd.bnd
@@ -12,8 +12,3 @@ Bundle-SCM:             url=https://github.com/trellis-ldp/trellis, \
                         connection=scm:git:https://github.com/trellis-ldp/trellis.git, \
                         developerConnection=scm:git:git@github.com:trellis-ldp/trellis.git
 
-Require-Capability:     osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", \
-                        osgi.serviceloader; \
-                            filter:="(osgi.serviceloader=org.trellisldp.api.ActivityStreamService)"; \
-                            resolution:=mandatory
-

--- a/notifications/amqp/src/main/java/module-info.java
+++ b/notifications/amqp/src/main/java/module-info.java
@@ -19,9 +19,4 @@ module org.trellisldp.amqp {
     requires javax.inject;
     requires microprofile.config.api;
     requires slf4j.api;
-
-    provides org.trellisldp.api.EventService
-        with org.trellisldp.amqp.AmqpPublisher;
-
-    uses org.trellisldp.api.ActivityStreamService;
 }

--- a/notifications/amqp/src/main/resources/META-INF/services/org.trellisldp.api.EventService
+++ b/notifications/amqp/src/main/resources/META-INF/services/org.trellisldp.api.EventService
@@ -1,1 +1,0 @@
-org.trellisldp.amqp.AmqpPublisher

--- a/notifications/jms/bnd.bnd
+++ b/notifications/jms/bnd.bnd
@@ -12,8 +12,3 @@ Bundle-SCM:             url=https://github.com/trellis-ldp/trellis, \
                         connection=scm:git:https://github.com/trellis-ldp/trellis.git, \
                         developerConnection=scm:git:git@github.com:trellis-ldp/trellis.git
 
-Require-Capability:     osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", \
-                        osgi.serviceloader; \
-                            filter:="(osgi.serviceloader=org.trellisldp.api.ActivityStreamService)"; \
-                            resolution:=mandatory
-

--- a/notifications/jms/build.gradle
+++ b/notifications/jms/build.gradle
@@ -17,10 +17,10 @@ dependencies {
     api("org.glassfish.hk2.external:javax.inject:$javaxInjectVersion")
     api project(':trellis-api')
 
-    implementation("org.apache.activemq:activemq-client:$activeMqVersion")
     implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
     implementation("org.slf4j:slf4j-api:$slf4jVersion")
 
+    testImplementation("org.apache.activemq:activemq-client:$activeMqVersion")
     testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
     testImplementation("io.smallrye:smallrye-config:$smallryeVersion")
     testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")

--- a/notifications/jms/src/main/java/module-info.java
+++ b/notifications/jms/src/main/java/module-info.java
@@ -16,15 +16,9 @@ module org.trellisldp.jms {
 
     requires org.trellisldp.api;
     requires org.apache.commons.rdf.api;
-    requires activemq.client;
     requires java.naming;
     requires javax.jms.api;
     requires javax.inject;
     requires microprofile.config.api;
     requires slf4j.api;
-
-    provides org.trellisldp.api.EventService
-        with org.trellisldp.jms.JmsPublisher;
-
-    uses org.trellisldp.api.ActivityStreamService;
 }

--- a/notifications/jms/src/main/java/org/trellisldp/jms/JmsPublisher.java
+++ b/notifications/jms/src/main/java/org/trellisldp/jms/JmsPublisher.java
@@ -14,12 +14,9 @@
 package org.trellisldp.jms;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.ServiceLoader.load;
 import static javax.jms.Session.AUTO_ACKNOWLEDGE;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 import static org.slf4j.LoggerFactory.getLogger;
-
-import java.util.Iterator;
 
 import javax.inject.Inject;
 import javax.jms.Connection;
@@ -28,13 +25,10 @@ import javax.jms.Message;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.trellisldp.api.ActivityStreamService;
 import org.trellisldp.api.Event;
 import org.trellisldp.api.EventService;
-import org.trellisldp.api.RuntimeTrellisException;
 
 /**
  * A JMS message producer capable of publishing messages to a JMS broker such as ActiveMQ.
@@ -59,55 +53,48 @@ public class JmsPublisher implements EventService {
     public static final String CONFIG_JMS_USE_QUEUE = "trellis.jms.use.queue";
 
     private static final Logger LOGGER = getLogger(JmsPublisher.class);
-    private static final ActivityStreamService service = getService(ActivityStreamService.class);
 
+    private final ActivityStreamService serializer;
     private final MessageProducer producer;
     private final Session session;
 
     /**
      * Create a new JMS Publisher.
-     * @throws JMSException when there is a connection error
-     */
-    @Inject
-    public JmsPublisher() throws JMSException {
-        this(getConfig());
-    }
-
-    private JmsPublisher(final Config config) throws JMSException {
-        this(buildJmsConnection(config).createSession(false, AUTO_ACKNOWLEDGE),
-                config.getValue(CONFIG_JMS_QUEUE_NAME, String.class),
-                config.getOptionalValue(CONFIG_JMS_USE_QUEUE, Boolean.class).orElse(Boolean.TRUE));
-    }
-
-    /**
-     * Create a new JMS Publisher.
+     * @param serializer the event serializer
      * @param conn the connection
      * @throws JMSException when there is a connection error
      */
-    public JmsPublisher(final Connection conn) throws JMSException {
-        this(conn.createSession(false, AUTO_ACKNOWLEDGE), getConfig().getValue(CONFIG_JMS_QUEUE_NAME, String.class),
+    @Inject
+    public JmsPublisher(final ActivityStreamService serializer, final Connection conn) throws JMSException {
+        this(serializer, conn.createSession(false, AUTO_ACKNOWLEDGE),
+                getConfig().getValue(CONFIG_JMS_QUEUE_NAME, String.class),
                 getConfig().getOptionalValue(CONFIG_JMS_USE_QUEUE, Boolean.class).orElse(Boolean.TRUE));
     }
 
     /**
      * Create a new JMS Publisher.
+     * @param serializer the event serializer
      * @param session the JMS session
      * @param queueName the name of the queue
      * @throws JMSException when there is a connection error
      */
-    public JmsPublisher(final Session session, final String queueName) throws JMSException {
-        this(session, queueName, true);
+    public JmsPublisher(final ActivityStreamService serializer, final Session session, final String queueName)
+            throws JMSException {
+        this(serializer, session, queueName, true);
     }
 
     /**
      * Create a new JMS Publisher.
+     * @param serializer the event serializer
      * @param session the JMS session
      * @param queueName the name of the queue
      * @param useQueue whether to use a queue or a topic
      * @throws JMSException when there is a connection error
      */
-    public JmsPublisher(final Session session, final String queueName, final boolean useQueue) throws JMSException {
+    public JmsPublisher(final ActivityStreamService serializer, final Session session, final String queueName,
+            final boolean useQueue) throws JMSException {
         requireNonNull(queueName, "JMS Queue name may not be null!");
+        this.serializer = requireNonNull(serializer, "Event serializer may not be null!");
         this.session = requireNonNull(session, "JMS Session may not be null!");
         if (useQueue) {
             this.producer = session.createProducer(session.createQueue(queueName));
@@ -120,7 +107,7 @@ public class JmsPublisher implements EventService {
     public void emit(final Event event) {
         requireNonNull(event, "Cannot emit a null event!");
 
-        service.serialize(event).ifPresent(json -> {
+        serializer.serialize(event).ifPresent(json -> {
             try {
                 final Message message = session.createTextMessage(json);
                 message.setStringProperty("Content-Type", "application/ld+json");
@@ -129,25 +116,5 @@ public class JmsPublisher implements EventService {
                 LOGGER.error("Error writing to broker: {}", ex.getMessage());
             }
         });
-    }
-
-    private static Connection buildJmsConnection(final Config config) throws JMSException {
-        final ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(
-                config.getValue(CONFIG_JMS_URL, String.class));
-        if (config.getOptionalValue(CONFIG_JMS_USERNAME, String.class).isPresent()
-                && config.getOptionalValue(CONFIG_JMS_PASSWORD, String.class).isPresent()) {
-            factory.setUserName(config.getValue(CONFIG_JMS_USERNAME, String.class));
-            factory.setPassword(config.getValue(CONFIG_JMS_PASSWORD, String.class));
-        }
-        return factory.createConnection();
-    }
-
-    /** Package-private. **/
-    static <T> T getService(final Class<T> service) {
-        final Iterator<T> services = load(service).iterator();
-        if (services.hasNext()) {
-            return services.next();
-        }
-        throw new RuntimeTrellisException("No ActivityStream service available!");
     }
 }

--- a/notifications/jms/src/main/resources/META-INF/services/org.trellisldp.api.EventService
+++ b/notifications/jms/src/main/resources/META-INF/services/org.trellisldp.api.EventService
@@ -1,1 +1,0 @@
-org.trellisldp.jms.JmsPublisher

--- a/notifications/kafka/bnd.bnd
+++ b/notifications/kafka/bnd.bnd
@@ -11,9 +11,3 @@ Bundle-SymbolicName:    ${project.group}.${project.name}
 Bundle-SCM:             url=https://github.com/trellis-ldp/trellis, \
                         connection=scm:git:https://github.com/trellis-ldp/trellis.git, \
                         developerConnection=scm:git:git@github.com:trellis-ldp/trellis.git
-
-Require-Capability:     osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)", \
-                        osgi.serviceloader; \
-                            filter:="(osgi.serviceloader=org.trellisldp.api.ActivityStreamService)"; \
-                            resolution:=mandatory
-

--- a/notifications/kafka/src/main/java/module-info.java
+++ b/notifications/kafka/src/main/java/module-info.java
@@ -20,9 +20,4 @@ module org.trellisldp.kafka {
     requires javax.inject;
     requires microprofile.config.api;
     requires slf4j.api;
-
-    provides org.trellisldp.api.EventService
-        with org.trellisldp.kafka.KafkaPublisher;
-
-    uses org.trellisldp.api.ActivityStreamService;
 }

--- a/notifications/kafka/src/main/resources/META-INF/services/org.trellisldp.api.EventService
+++ b/notifications/kafka/src/main/resources/META-INF/services/org.trellisldp.api.EventService
@@ -1,1 +1,0 @@
-org.trellisldp.kafka.KafkaPublisher

--- a/notifications/kafka/src/test/java/org/trellisldp/kafka/KafkaPublisherTest.java
+++ b/notifications/kafka/src/test/java/org/trellisldp/kafka/KafkaPublisherTest.java
@@ -18,11 +18,9 @@ import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.condition.JRE.JAVA_8;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
 
@@ -33,12 +31,11 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.mockito.Mock;
 import org.trellisldp.api.ActivityStreamService;
 import org.trellisldp.api.Event;
 import org.trellisldp.api.EventService;
-import org.trellisldp.api.RuntimeTrellisException;
+import org.trellisldp.event.EventSerializer;
 import org.trellisldp.vocabulary.AS;
 import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.Trellis;
@@ -49,6 +46,7 @@ import org.trellisldp.vocabulary.Trellis;
 public class KafkaPublisherTest {
 
     private static final RDF rdf = new SimpleRDF();
+    private static final ActivityStreamService serializer = new EventSerializer();
 
     private final String queueName = "queue";
 
@@ -74,7 +72,7 @@ public class KafkaPublisherTest {
 
     @Test
     public void testKafka() {
-        final EventService svc = new KafkaPublisher(producer);
+        final EventService svc = new KafkaPublisher(serializer, producer);
         svc.emit(mockEvent);
 
         final List<ProducerRecord<String, String>> records = producer.history();
@@ -84,13 +82,6 @@ public class KafkaPublisherTest {
 
     @Test
     public void testDefaultKafka() {
-        assertDoesNotThrow(() -> new KafkaPublisher());
-    }
-
-    @Test
-    @EnabledOnJre(JAVA_8)
-    public void testGetService() {
-        assertThrows(RuntimeTrellisException.class, () -> KafkaPublisher.getService(InputStream.class));
-        assertDoesNotThrow(() -> KafkaPublisher.getService(ActivityStreamService.class));
+        assertDoesNotThrow(() -> new KafkaPublisher(serializer));
     }
 }


### PR DESCRIPTION
Resolves #441

This removes the use of the `ServiceLoader` from all of the component libraries in favor of ctor injection. This has resulted in changes to the ctors for the various notification services, which will affect any downstream projects.

One question is whether the notification services should be annotated with `@ApplicationScoped` -- if so, we'll need those no-arg constructors back in place for use with CDI proxies, and we may want to discuss what that would look like.

For the non-notification projects, this was really just a matter of moving the `@Inject` annotation to a different, existing ctor.