### PR TITLE
Start using the BaseServiceBundler class

### DIFF
--- a/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
+++ b/components/app-triplestore/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
@@ -21,21 +21,15 @@ import com.google.common.cache.Cache;
 
 import io.dropwizard.setup.Environment;
 
-import java.util.List;
-
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.trellisldp.agent.SimpleAgentService;
-import org.trellisldp.api.AgentService;
-import org.trellisldp.api.AuditService;
 import org.trellisldp.api.BinaryService;
-import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.DefaultIdentifierService;
-import org.trellisldp.api.EventService;
 import org.trellisldp.api.IOService;
-import org.trellisldp.api.MementoService;
 import org.trellisldp.api.NamespaceService;
 import org.trellisldp.api.RDFaWriterService;
-import org.trellisldp.api.ResourceService;
+import org.trellisldp.app.BaseServiceBundler;
+import org.trellisldp.app.DefaultConstraintServices;
 import org.trellisldp.app.TrellisCache;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.constraint.LdpConstraints;
@@ -43,9 +37,6 @@ import org.trellisldp.file.FileBinaryService;
 import org.trellisldp.file.FileMementoService;
 import org.trellisldp.http.core.DefaultEtagGenerator;
 import org.trellisldp.http.core.DefaultTimemapGenerator;
-import org.trellisldp.http.core.EtagGenerator;
-import org.trellisldp.http.core.ServiceBundler;
-import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
 import org.trellisldp.namespaces.NamespacesJsonContext;
 import org.trellisldp.rdfa.HtmlSerializer;
@@ -58,18 +49,7 @@ import org.trellisldp.triplestore.TriplestoreResourceService;
  * It combines a Triplestore-based resource service along with file-based binary and
  * memento storage. RDF processing is handled with Apache Jena.
  */
-public class TrellisServiceBundler implements ServiceBundler {
-
-    private final MementoService mementoService;
-    private final AuditService auditService;
-    private final ResourceService resourceService;
-    private final BinaryService binaryService;
-    private final AgentService agentService;
-    private final IOService ioService;
-    private final EventService eventService;
-    private final TimemapGenerator timemapGenerator;
-    private final EtagGenerator etagGenerator;
-    private final List<ConstraintService> constraintServices;
+public class TrellisServiceBundler extends BaseServiceBundler {
 
     /**
      * Create a new application service bundler.
@@ -82,61 +62,11 @@ public class TrellisServiceBundler implements ServiceBundler {
         mementoService = new FileMementoService(config.getMementos());
         etagGenerator = new DefaultEtagGenerator();
         timemapGenerator = new DefaultTimemapGenerator();
-        constraintServices = singletonList(new LdpConstraints());
+        constraintServices = new DefaultConstraintServices(singletonList(new LdpConstraints()));
         resourceService = buildResourceService(config, environment);
         binaryService = buildBinaryService(config);
         ioService = buildIoService(config);
         eventService = AppUtils.getNotificationService(config.getNotifications(), environment);
-    }
-
-    @Override
-    public ResourceService getResourceService() {
-        return resourceService;
-    }
-
-    @Override
-    public IOService getIOService() {
-        return ioService;
-    }
-
-    @Override
-    public BinaryService getBinaryService() {
-        return binaryService;
-    }
-
-    @Override
-    public MementoService getMementoService() {
-        return mementoService;
-    }
-
-    @Override
-    public AuditService getAuditService() {
-        return auditService;
-    }
-
-    @Override
-    public AgentService getAgentService() {
-        return agentService;
-    }
-
-    @Override
-    public EventService getEventService() {
-        return eventService;
-    }
-
-    @Override
-    public TimemapGenerator getTimemapGenerator() {
-        return timemapGenerator;
-    }
-
-    @Override
-    public EtagGenerator getEtagGenerator() {
-        return etagGenerator;
-    }
-
-    @Override
-    public Iterable<ConstraintService> getConstraintServices() {
-        return constraintServices;
     }
 
     private static TriplestoreResourceService buildResourceService(final AppConfiguration config,

--- a/components/app/src/main/java/org/trellisldp/app/DefaultConstraintServices.java
+++ b/components/app/src/main/java/org/trellisldp/app/DefaultConstraintServices.java
@@ -19,7 +19,7 @@ import java.util.Iterator;
 import org.trellisldp.api.ConstraintService;
 
 /**
- * A default ConstraintServices implementation, using a backing {@link List}.
+ * A default ConstraintServices implementation, using a backing {@link Collection}.
  */
 public class DefaultConstraintServices implements ConstraintServices {
 

--- a/components/app/src/main/java/org/trellisldp/app/DefaultConstraintServices.java
+++ b/components/app/src/main/java/org/trellisldp/app/DefaultConstraintServices.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.app;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.trellisldp.api.ConstraintService;
+
+/**
+ * A default ConstraintServices implementation, using a backing {@link List}.
+ */
+public class DefaultConstraintServices implements ConstraintServices {
+
+    private final Collection<ConstraintService> services;
+
+    /**
+     * Create a ConstraintServices object.
+     * @param services the constraint services.
+     */
+    public DefaultConstraintServices(final Collection<ConstraintService> services) {
+        this.services = services;
+    }
+
+    @Override
+    public Iterator<ConstraintService> iterator() {
+        return services.iterator();
+    }
+}
+

--- a/components/app/src/test/java/org/trellisldp/app/DefaultConstraintServicesTest.java
+++ b/components/app/src/test/java/org/trellisldp/app/DefaultConstraintServicesTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.app;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.trellisldp.constraint.LdpConstraints;
+
+public class DefaultConstraintServicesTest {
+
+    @Test
+    public void testEmptyServices() {
+        final ConstraintServices svcs = new DefaultConstraintServices(emptyList());
+        assertFalse(svcs.iterator().hasNext());
+    }
+
+    @Test
+    public void testSingleServices() {
+        final ConstraintServices svcs = new DefaultConstraintServices(singletonList(new LdpConstraints()));
+        assertTrue(svcs.iterator().hasNext());
+    }
+}

--- a/components/app/src/test/java/org/trellisldp/app/SimpleServiceBundler.java
+++ b/components/app/src/test/java/org/trellisldp/app/SimpleServiceBundler.java
@@ -19,29 +19,16 @@ import static java.util.Collections.singletonList;
 import static org.apache.jena.query.DatasetFactory.createTxnMem;
 import static org.apache.jena.rdfconnection.RDFConnectionFactory.connect;
 
-import java.util.List;
-
 import org.trellisldp.agent.SimpleAgentService;
-import org.trellisldp.api.AgentService;
-import org.trellisldp.api.AuditService;
-import org.trellisldp.api.BinaryService;
-import org.trellisldp.api.ConstraintService;
 import org.trellisldp.api.DefaultIdentifierService;
-import org.trellisldp.api.EventService;
-import org.trellisldp.api.IOService;
-import org.trellisldp.api.MementoService;
 import org.trellisldp.api.NoopEventService;
 import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.NoopNamespaceService;
-import org.trellisldp.api.ResourceService;
 import org.trellisldp.audit.DefaultAuditService;
 import org.trellisldp.constraint.LdpConstraints;
 import org.trellisldp.file.FileBinaryService;
 import org.trellisldp.http.core.DefaultEtagGenerator;
 import org.trellisldp.http.core.DefaultTimemapGenerator;
-import org.trellisldp.http.core.EtagGenerator;
-import org.trellisldp.http.core.ServiceBundler;
-import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
 import org.trellisldp.io.NoopProfileCache;
 import org.trellisldp.triplestore.TriplestoreResourceService;
@@ -49,73 +36,25 @@ import org.trellisldp.triplestore.TriplestoreResourceService;
 /**
  * A simple service bundler for testing.
  */
-public class SimpleServiceBundler implements ServiceBundler {
+public class SimpleServiceBundler extends BaseServiceBundler {
 
-    private final AuditService auditService = new DefaultAuditService();
-    private final MementoService mementoService = new NoopMementoService();
-    private final EventService eventService = new NoopEventService();
-    private final AgentService agentService = new SimpleAgentService();
-    private final EtagGenerator etagGenerator = new DefaultEtagGenerator();
-    private final TimemapGenerator timemapGenerator = new DefaultTimemapGenerator();
-    private final List<ConstraintService> constraintServices = singletonList(new LdpConstraints());
-    private final IOService ioService = new JenaIOService(new NoopNamespaceService(), null, new NoopProfileCache(),
-            emptySet(), emptySet());
-    private final BinaryService binaryService = new FileBinaryService(new DefaultIdentifierService(),
-            resourceFilePath("data") + "/binaries", 2, 2);
     private final TriplestoreResourceService triplestoreService
         = new TriplestoreResourceService(connect(createTxnMem()));
 
     public SimpleServiceBundler() {
+        auditService = new DefaultAuditService();
+        mementoService = new NoopMementoService();
+        eventService = new NoopEventService();
+        agentService = new SimpleAgentService();
+        etagGenerator = new DefaultEtagGenerator();
+        timemapGenerator = new DefaultTimemapGenerator();
+        constraintServices = new DefaultConstraintServices(singletonList(new LdpConstraints()));
+        ioService = new JenaIOService(new NoopNamespaceService(), null, new NoopProfileCache(),
+                emptySet(), emptySet());
+        binaryService = new FileBinaryService(new DefaultIdentifierService(),
+                resourceFilePath("data") + "/binaries", 2, 2);
+
         triplestoreService.initialize();
-    }
-
-    @Override
-    public AgentService getAgentService() {
-        return agentService;
-    }
-
-    @Override
-    public ResourceService getResourceService() {
-        return triplestoreService;
-    }
-
-    @Override
-    public IOService getIOService() {
-        return ioService;
-    }
-
-    @Override
-    public BinaryService getBinaryService() {
-        return binaryService;
-    }
-
-    @Override
-    public AuditService getAuditService() {
-        return auditService;
-    }
-
-    @Override
-    public MementoService getMementoService() {
-        return mementoService;
-    }
-
-    @Override
-    public EventService getEventService() {
-        return eventService;
-    }
-
-    @Override
-    public TimemapGenerator getTimemapGenerator() {
-        return timemapGenerator;
-    }
-
-    @Override
-    public EtagGenerator getEtagGenerator() {
-        return etagGenerator;
-    }
-
-    @Override
-    public Iterable<ConstraintService> getConstraintServices() {
-        return constraintServices;
+        resourceService = triplestoreService;
     }
 }


### PR DESCRIPTION
This PR starts using the new `BaseServiceBundler`. It also introduces a `DefaultConstraintServices` class that can be used for `java.util.Collection`-based `ConstraintService` groups.