### PR TITLE
Fix TimeGate/Memento handling

### DIFF
--- a/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
@@ -79,8 +79,9 @@ public class FileMementoServiceTest {
                 .toCompletableFuture().join();
             svc.get(identifier, time).thenAccept(res -> assertEquals(time, res.getModified(), "Incorrect date!"))
                 .toCompletableFuture().join();
-            assertEquals(MISSING_RESOURCE, svc.get(identifier, parse("2015-02-16T10:00:00Z"))
-                .toCompletableFuture().join(), "Wrong response for a missing resource!");
+            svc.get(identifier, parse("2015-02-16T10:00:00Z"))
+                .thenAccept(res -> assertEquals(time, res.getModified(), "Incorrect date!"))
+                .toCompletableFuture().join();
             svc.get(identifier, time2).thenAccept(res -> assertEquals(time2, res.getModified(), "Incorrect date!"))
                 .toCompletableFuture().join();
             svc.get(identifier, MAX).thenAccept(res -> assertEquals(time2, res.getModified(), "Incorrect date!"))


### PR DESCRIPTION
Resovles #465

For datetime negotiation requests that ask for a memento that predates
any existing memento, the Memento specification requires that the first
available Memento resource be returned.

https://tools.ietf.org/html/rfc7089#section-4.5.3