### PR TITLE
Allow a small allowance for rounding discrepancies

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
@@ -14,6 +14,7 @@
 package org.trellisldp.test;
 
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.Response.Status.Family.REDIRECTION;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
@@ -112,9 +113,11 @@ public interface MementoResourceTests extends MementoCommonTests {
             try (final Response res = target(location).request().header(ACCEPT_DATETIME, date).head()) {
                 assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(),
                                 "Check for a successful memento request");
-                final ZonedDateTime zdt = ZonedDateTime.parse(date, RFC_1123_DATE_TIME);
-                assertEquals(zdt, ZonedDateTime.parse(res.getHeaderString(MEMENTO_DATETIME), RFC_1123_DATE_TIME),
-                                "Check that the memento-datetime header is correct");
+                final ZonedDateTime zdt1 = ZonedDateTime.parse(date, RFC_1123_DATE_TIME);
+                final ZonedDateTime zdt2 = ZonedDateTime.parse(res.getHeaderString(MEMENTO_DATETIME),
+                        RFC_1123_DATE_TIME);
+                final long diff = Math.abs(zdt1.until(zdt2, SECONDS));
+                assertTrue(diff <= 1, "Check that the memento-datetime header is correct, within on second");
             }
         });
     }


### PR DESCRIPTION
The Memento resources have headers with a precision of one second,
but there can be rounding issues that lead to a small epsilon of
difference in the various format conversions. This relaxes the memento
datetime tests such that it allows up to 1 second in time discrepancies.