### PR TITLE
Update slf4j module definition

### DIFF
--- a/auth/basic/src/main/java/module-info.java
+++ b/auth/basic/src/main/java/module-info.java
@@ -14,10 +14,10 @@
 module org.trellisldp.auth.basic {
     exports org.trellisldp.auth.basic;
 
-    requires slf4j.api;
-    requires microprofile.config.api;
     requires javax.inject;
     requires java.ws.rs;
     requires java.xml.bind;
     requires java.annotation;
+    requires microprofile.config.api;
+    requires org.slf4j;
 }

--- a/components/file/src/main/java/module-info.java
+++ b/components/file/src/main/java/module-info.java
@@ -21,9 +21,9 @@ module org.trellisldp.file {
     requires org.apache.commons.rdf.api;
     requires org.apache.commons.rdf.jena;
     requires org.apache.jena.arq;
+    requires org.slf4j;
     requires javax.inject;
     requires microprofile.config.api;
-    requires slf4j.api;
 
     provides org.trellisldp.api.BinaryService
         with org.trellisldp.file.FileBinaryService;

--- a/components/io-jena/src/main/java/module-info.java
+++ b/components/io-jena/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module org.trellisldp.io {
     requires org.apache.jena.arq;
     requires javax.inject;
     requires microprofile.config.api;
-    requires slf4j.api;
+    requires org.slf4j;
 
     provides org.trellisldp.api.IOService
         with org.trellisldp.io.JenaIOService;

--- a/components/test/src/main/java/module-info.java
+++ b/components/test/src/main/java/module-info.java
@@ -30,5 +30,5 @@ module org.trellisldp.test {
     requires java.ws.rs;
     requires java.xml.bind;
     requires javax.inject;
-    requires slf4j.api;
+    requires org.slf4j;
 }

--- a/components/triplestore/src/main/java/module-info.java
+++ b/components/triplestore/src/main/java/module-info.java
@@ -21,9 +21,9 @@ module org.trellisldp.triplestore {
     requires org.apache.commons.rdf.api;
     requires org.apache.commons.rdf.jena;
     requires org.apache.jena.arq;
+    requires org.slf4j;
 
     requires javax.inject;
-    requires slf4j.api;
     requires microprofile.config.api;
 
     provides org.trellisldp.api.ResourceService

--- a/components/webac/src/main/java/module-info.java
+++ b/components/webac/src/main/java/module-info.java
@@ -19,11 +19,11 @@ module org.trellisldp.webac {
     requires transitive org.trellisldp.vocabulary;
 
     requires org.apache.commons.rdf.api;
+    requires org.slf4j;
 
     requires javax.inject;
     requires java.ws.rs;
     requires java.xml.bind;
-    requires slf4j.api;
     requires microprofile.config.api;
 
     uses org.trellisldp.api.ResourceService;

--- a/components/webdav/src/main/java/module-info.java
+++ b/components/webdav/src/main/java/module-info.java
@@ -22,9 +22,9 @@ module org.trellisldp.webdav {
     requires org.apache.commons.rdf.api;
     requires org.apache.commons.lang3;
     requires org.apache.jena.arq;
+    requires org.slf4j;
     requires microprofile.metrics.api;
 
-    requires slf4j.api;
     requires microprofile.config.api;
     requires javax.inject;
     requires java.ws.rs;

--- a/core/http/src/main/java/module-info.java
+++ b/core/http/src/main/java/module-info.java
@@ -21,8 +21,8 @@ module org.trellisldp.http {
     requires org.apache.commons.codec;
     requires org.apache.commons.io;
     requires org.apache.commons.rdf.api;
+    requires org.slf4j;
 
-    requires slf4j.api;
     requires microprofile.config.api;
     requires javax.inject;
     requires java.ws.rs;

--- a/notifications/amqp/src/main/java/module-info.java
+++ b/notifications/amqp/src/main/java/module-info.java
@@ -18,5 +18,5 @@ module org.trellisldp.amqp {
     requires org.apache.commons.rdf.api;
     requires javax.inject;
     requires microprofile.config.api;
-    requires slf4j.api;
+    requires org.slf4j;
 }

--- a/notifications/jms/src/main/java/module-info.java
+++ b/notifications/jms/src/main/java/module-info.java
@@ -20,5 +20,5 @@ module org.trellisldp.jms {
     requires javax.jms.api;
     requires javax.inject;
     requires microprofile.config.api;
-    requires slf4j.api;
+    requires org.slf4j;
 }

--- a/notifications/kafka/src/main/java/module-info.java
+++ b/notifications/kafka/src/main/java/module-info.java
@@ -19,5 +19,5 @@ module org.trellisldp.kafka {
     requires kafka.clients;
     requires javax.inject;
     requires microprofile.config.api;
-    requires slf4j.api;
+    requires org.slf4j;
 }


### PR DESCRIPTION
The SLF4J project now publishes the `Automatic-Module-Name` header, so we can adjust the JDK11 configurations to use that.