### PR TITLE
Remove final keyword to no-op services

### DIFF
--- a/core/api/src/main/java/org/trellisldp/api/NoopAuditService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopAuditService.java
@@ -21,6 +21,6 @@ package org.trellisldp.api;
  *
  */
 @NoopImplementation
-public final class NoopAuditService implements AuditService {
+public class NoopAuditService implements AuditService {
 
 }

--- a/core/api/src/main/java/org/trellisldp/api/NoopEventService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopEventService.java
@@ -17,7 +17,7 @@ package org.trellisldp.api;
  * For use when an event service is not desired.
  */
 @NoopImplementation
-public final class NoopEventService implements EventService {
+public class NoopEventService implements EventService {
 
     @Override
     public void emit(final Event event) {


### PR DESCRIPTION
Quarkus doesn't like `@ApplicationScoped` beans that have the `final` keyword. This just removes those keywords.