### PR TITLE
Add several requires to module-infos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
     dropwizardVersion = '1.3.13'
     guavaVersion = '28.0-jre'
     jacksonVersion = '2.9.9'
-    jaxbVersion = '2.3.1'
+    jaxbVersion = '2.4.0-b180830.0359'
     jenaVersion = '3.12.0'
     // version 2.28+ uses the jakarta-based jax-rs API
     jerseyVersion = '2.27'
@@ -171,6 +171,7 @@ allprojects { subproj ->
             substitute module("org.apache.geronimo.specs:geronimo-annotation_1.2_spec") with module ("javax.annotation:javax.annotation-api:$javaxAnnotationsVersion")
             substitute module("org.apache.geronimo.specs:geronimo-jms_1.1_spec") with module("javax.jms:javax.jms-api:$javaxJmsVersion")
             substitute module("org.apache.geronimo.specs:geronimo-j2ee-management_1.1_spec") with module("javax.management.j2ee:javax.management.j2ee-api:$javaxManagementVersion")
+            substitute module("jakarta.xml.bind:jakarta.xml.bind-api") with module("javax.xml-bind:jaxb.api:$jaxbVersion")
         }
         /*
         resolutionStrategy.eachDependency { DependencyResolveDetails details ->

--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ allprojects { subproj ->
             substitute module("org.apache.geronimo.specs:geronimo-annotation_1.2_spec") with module ("javax.annotation:javax.annotation-api:$javaxAnnotationsVersion")
             substitute module("org.apache.geronimo.specs:geronimo-jms_1.1_spec") with module("javax.jms:javax.jms-api:$javaxJmsVersion")
             substitute module("org.apache.geronimo.specs:geronimo-j2ee-management_1.1_spec") with module("javax.management.j2ee:javax.management.j2ee-api:$javaxManagementVersion")
-            substitute module("jakarta.xml.bind:jakarta.xml.bind-api") with module("javax.xml-bind:jaxb.api:$jaxbVersion")
+            substitute module("jakarta.xml.bind:jakarta.xml.bind-api") with module("javax.xml.bind:jaxb-api:$jaxbVersion")
         }
         /*
         resolutionStrategy.eachDependency { DependencyResolveDetails details ->

--- a/components/agent/src/main/java/module-info.java
+++ b/components/agent/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.trellisldp.agent {
     requires transitive org.trellisldp.vocabulary;
 
     requires org.apache.commons.rdf.api;
+    requires cdi.api;
 
     provides org.trellisldp.api.AgentService
         with org.trellisldp.agent.DefaultAgentService;

--- a/components/audit/src/main/java/module-info.java
+++ b/components/audit/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.trellisldp.audit {
     requires transitive org.trellisldp.vocabulary;
 
     requires org.apache.commons.rdf.api;
+    requires cdi.api;
 
     provides org.trellisldp.api.AuditService
         with org.trellisldp.audit.DefaultAuditService;

--- a/components/constraint-rules/src/main/java/module-info.java
+++ b/components/constraint-rules/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.trellisldp.constraint {
     requires transitive org.trellisldp.vocabulary;
 
     requires org.apache.commons.rdf.api;
+    requires cdi.api;
 
     provides org.trellisldp.api.ConstraintService
         with org.trellisldp.constraint.LdpConstraintService;

--- a/components/event-serialization/build.gradle
+++ b/components/event-serialization/build.gradle
@@ -11,6 +11,7 @@ ext {
 dependencies {
     api project(':trellis-api')
 
+    implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
     implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")

--- a/components/event-serialization/src/main/java/module-info.java
+++ b/components/event-serialization/src/main/java/module-info.java
@@ -21,6 +21,8 @@ module org.trellisldp.event {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.datatype.jsr310;
+    requires jackson.annotations;
+    requires cdi.api;
 
     opens org.trellisldp.event to com.fasterxml.jackson.databind;
 

--- a/components/event-serialization/src/main/java/module-info.java
+++ b/components/event-serialization/src/main/java/module-info.java
@@ -21,7 +21,7 @@ module org.trellisldp.event {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.datatype.jsr310;
-    requires jackson.annotations;
+    requires com.fasterxml.jackson.annotation;
     requires cdi.api;
 
     opens org.trellisldp.event to com.fasterxml.jackson.databind;

--- a/components/file/src/main/java/module-info.java
+++ b/components/file/src/main/java/module-info.java
@@ -24,6 +24,8 @@ module org.trellisldp.file {
     requires org.slf4j;
     requires javax.inject;
     requires microprofile.config.api;
+    requires org.apache.commons.codec;
+    requires org.apache.jena.core;
 
     provides org.trellisldp.api.BinaryService
         with org.trellisldp.file.FileBinaryService;

--- a/components/io-jena/src/main/java/module-info.java
+++ b/components/io-jena/src/main/java/module-info.java
@@ -28,6 +28,6 @@ module org.trellisldp.io {
     requires org.apache.jena.core;
     requires org.apache.jena.base;
 
-  provides org.trellisldp.api.IOService
+    provides org.trellisldp.api.IOService
         with org.trellisldp.io.JenaIOService;
 }

--- a/components/io-jena/src/main/java/module-info.java
+++ b/components/io-jena/src/main/java/module-info.java
@@ -24,7 +24,10 @@ module org.trellisldp.io {
     requires javax.inject;
     requires microprofile.config.api;
     requires org.slf4j;
+    requires cdi.api;
+    requires org.apache.jena.core;
+    requires org.apache.jena.base;
 
-    provides org.trellisldp.api.IOService
+  provides org.trellisldp.api.IOService
         with org.trellisldp.io.JenaIOService;
 }

--- a/components/namespaces/src/main/java/module-info.java
+++ b/components/namespaces/src/main/java/module-info.java
@@ -21,7 +21,8 @@ module org.trellisldp.namespaces {
     requires com.fasterxml.jackson.databind;
     requires javax.inject;
     requires microprofile.config.api;
+    requires org.slf4j;
 
-    provides org.trellisldp.api.NamespaceService
+  provides org.trellisldp.api.NamespaceService
         with org.trellisldp.namespaces.JsonNamespaceService;
 }

--- a/components/namespaces/src/main/java/module-info.java
+++ b/components/namespaces/src/main/java/module-info.java
@@ -23,6 +23,6 @@ module org.trellisldp.namespaces {
     requires microprofile.config.api;
     requires org.slf4j;
 
-  provides org.trellisldp.api.NamespaceService
+    provides org.trellisldp.api.NamespaceService
         with org.trellisldp.namespaces.JsonNamespaceService;
 }

--- a/components/rdfa/src/main/java/module-info.java
+++ b/components/rdfa/src/main/java/module-info.java
@@ -22,8 +22,10 @@ module org.trellisldp.rdfa {
     requires org.apache.jena.arq;
     requires javax.inject;
     requires microprofile.config.api;
+    requires cdi.api;
+    requires org.apache.jena.core;
 
-    uses org.trellisldp.api.NamespaceService;
+  uses org.trellisldp.api.NamespaceService;
 
     opens org.trellisldp.rdfa to com.github.mustachejava;
 

--- a/components/rdfa/src/main/java/module-info.java
+++ b/components/rdfa/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module org.trellisldp.rdfa {
     requires cdi.api;
     requires org.apache.jena.core;
 
-  uses org.trellisldp.api.NamespaceService;
+    uses org.trellisldp.api.NamespaceService;
 
     opens org.trellisldp.rdfa to com.github.mustachejava;
 

--- a/components/triplestore/src/main/java/module-info.java
+++ b/components/triplestore/src/main/java/module-info.java
@@ -25,6 +25,12 @@ module org.trellisldp.triplestore {
 
     requires javax.inject;
     requires microprofile.config.api;
+    requires microprofile.health.api;
+    requires cdi.api;
+    requires org.apache.jena.rdfconnection;
+    requires org.apache.jena.core;
+    requires org.apache.jena.tdb2;
+    requires java.annotation;
 
     provides org.trellisldp.api.ResourceService
         with org.trellisldp.triplestore.TriplestoreResourceService;

--- a/components/webac/src/main/java/module-info.java
+++ b/components/webac/src/main/java/module-info.java
@@ -25,6 +25,8 @@ module org.trellisldp.webac {
     requires java.ws.rs;
     requires java.xml.bind;
     requires microprofile.config.api;
+    requires java.annotation;
+    requires cdi.api;
 
     uses org.trellisldp.api.ResourceService;
 }

--- a/core/api/src/main/java/module-info.java
+++ b/core/api/src/main/java/module-info.java
@@ -18,5 +18,5 @@ module org.trellisldp.api {
     requires javax.inject;
     requires cdi.api;
 
-  uses org.apache.commons.rdf.api.RDF;
+    uses org.apache.commons.rdf.api.RDF;
 }

--- a/core/api/src/main/java/module-info.java
+++ b/core/api/src/main/java/module-info.java
@@ -15,6 +15,8 @@ module org.trellisldp.api {
     exports org.trellisldp.api;
 
     requires org.apache.commons.rdf.api;
+    requires javax.inject;
+    requires cdi.api;
 
-    uses org.apache.commons.rdf.api.RDF;
+  uses org.apache.commons.rdf.api.RDF;
 }

--- a/core/http/src/main/java/module-info.java
+++ b/core/http/src/main/java/module-info.java
@@ -29,5 +29,5 @@ module org.trellisldp.http {
     requires java.xml.bind;
     requires java.annotation;
     requires cdi.api;
-  requires microprofile.metrics.api;
+    requires microprofile.metrics.api;
 }

--- a/core/http/src/main/java/module-info.java
+++ b/core/http/src/main/java/module-info.java
@@ -29,4 +29,5 @@ module org.trellisldp.http {
     requires java.xml.bind;
     requires java.annotation;
     requires cdi.api;
+  requires microprofile.metrics.api;
 }

--- a/notifications/amqp/src/main/java/module-info.java
+++ b/notifications/amqp/src/main/java/module-info.java
@@ -19,4 +19,5 @@ module org.trellisldp.amqp {
     requires javax.inject;
     requires microprofile.config.api;
     requires org.slf4j;
+    requires com.rabbitmq.client;
 }


### PR DESCRIPTION
resolves #498
 
adds several missing requires to module-infos
corrects split package for javax.xml.bind by substituting jakarta.xml.bind-api with jaxb.api and updates jaxb.api version