### PR TITLE
Add delete method to FileMementoService

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
@@ -118,6 +118,23 @@ public class FileMementoService implements MementoService {
         return supplyAsync(() -> listMementos(identifier));
     }
 
+    /**
+     * Delete a memento at the given time.
+     *
+     * @param identifier the resource identifier
+     * @param time the memento time
+     * @return the next stage of completion
+     */
+    public CompletionStage<Void> delete(final IRI identifier, final Instant time) {
+        return runAsync(() -> {
+            final File resourceDir = FileUtils.getResourceDirectory(directory, identifier);
+            final File file = FileUtils.getNquadsFile(resourceDir, time.truncatedTo(SECONDS));
+            if (FileUtils.uncheckedDeleteIfExists(file.toPath())) {
+                LOGGER.debug("Deleted Memento {} at {}", identifier, file);
+            }
+        });
+    }
+
     private void init() {
         if (!directory.exists()) {
             directory.mkdirs();

--- a/components/file/src/main/java/org/trellisldp/file/FileUtils.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileUtils.java
@@ -122,6 +122,19 @@ public final class FileUtils {
     }
 
     /**
+     * Try to delete a file if it exists or throw an unchecked exception.
+     * @param path the file path
+     * @return true if the file existed and was deleted; false otherwise
+     */
+    public static boolean uncheckedDeleteIfExists(final Path path) {
+        try {
+            return Files.deleteIfExists(path);
+        } catch (final IOException ex) {
+            throw new UncheckedIOException("Error deleting file", ex);
+        }
+    }
+
+    /**
      * Fetch a stream of files in the provided directory path.
      * @param path the directory path
      * @return a stream of filenames

--- a/components/file/src/test/java/org/trellisldp/file/FileUtilsTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileUtilsTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import org.apache.commons.rdf.api.IRI;
@@ -122,6 +123,14 @@ public class FileUtilsTest {
                 throw new IOException("Expected exception");
             });
         assertThrows(IOException.class, () -> FileUtils.getBoundedStream(badInput, 4, 10));
+    }
+
+    @Test
+    public void testDeleteException() throws IOException {
+        final Path badPath = mock(Path.class, inv -> {
+                throw new IOException("Expected exception");
+            });
+        assertThrows(UncheckedIOException.class, () -> FileUtils.uncheckedDeleteIfExists(badPath));
     }
 
     @Test


### PR DESCRIPTION
Resolves #496

This method is not used in the HTTP layer, but it provides a mechanism
for someone to use it in a separate JAX-RS component. The existing
MementoService methods remain unchanged.