### PR TITLE
Moves from ACL database initialization to a permissive default root ACL

### DIFF
--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/AbstractTrellisApplication.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/AbstractTrellisApplication.java
@@ -136,6 +136,7 @@ public abstract class AbstractTrellisApplication<T extends TrellisConfiguration>
         // Authorization
         getWebacCache(config).ifPresent(cache -> {
             final WebAcService webac = new WebAcService(getServiceBundler().getResourceService(), cache);
+            webac.initialize();
             final List<String> challenges = new ArrayList<>();
             of(config.getAuth().getJwt()).filter(JwtAuthConfiguration::getEnabled).map(x -> "Bearer")
                 .ifPresent(challenges::add);

--- a/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
@@ -23,7 +23,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
@@ -85,6 +84,7 @@ public class WebAcService {
     public static final String CONFIG_WEBAC_MEMBERSHIP_CHECK = "trellis.webac.membership.check";
 
     private static final Logger LOGGER = getLogger(WebAcService.class);
+    private static final CompletionStage<Void> DONE = CompletableFuture.completedFuture(null);
     private static final RDF rdf = getInstance();
     private static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
     private static final IRI rootAuth = rdf.createIRI(TRELLIS_DATA_PREFIX + "#auth");
@@ -150,7 +150,8 @@ public class WebAcService {
             }
             return this.resourceService.replace(Metadata.builder(res).build(), dataset);
         } else {
-            return runAsync(() -> { });
+            LOGGER.info("Root ACL is present, not initializing: {}", id);
+            return DONE;
         }
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -142,24 +142,6 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
     }
 
     @Test
-    public void testInitializeExistingLdpResourceWithNoACL() throws Exception {
-        final ResourceService mockService = mock(ResourceService.class);
-        when(mockBundler.getResourceService()).thenReturn(mockService);
-        when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(mockRootResource));
-        when(mockRootResource.hasAcl()).thenReturn(false);
-        when(mockService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
-
-        final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler);
-        matcher.initialize();
-
-        verify(mockService, never().description("When re-initializing the root ACL, create should not be called"))
-            .create(any(Metadata.class), any(Dataset.class));
-        verify(mockService, description("Use replace when re-initializing the root ACL"))
-            .replace(any(Metadata.class), any(Dataset.class));
-        verify(mockService, description("Verify that the root resource is fetched only once")).get(root);
-    }
-
-    @Test
     public void testInitializeoNoLdpResource() throws Exception {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);


### PR DESCRIPTION
Takes out database initialization of the root ACL, leaving WebAC considerations outside of persistence backend initialization. Instead there is a default ACL that permits all actions by all agents, i.e. no restrictions. This is a single Authorization that is held in a static variable.