### PR TITLE
Less asynchrony for Binary::getContent

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileBinary.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinary.java
@@ -14,15 +14,12 @@
 
 package org.trellisldp.file;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.util.concurrent.CompletionStage;
 
 import org.trellisldp.api.Binary;
 
@@ -43,18 +40,18 @@ public class FileBinary implements Binary {
 
     @SuppressWarnings("resource")
     @Override
-    public CompletionStage<InputStream> getContent() {
+    public InputStream getContent() {
         try {
-            return completedFuture(new FileInputStream(file));
+            return new FileInputStream(file);
         } catch (FileNotFoundException e) {
             throw new UncheckedIOException(e);
         }
     }
 
     @Override
-    public CompletionStage<InputStream> getContent(final int from, final int to) {
+    public InputStream getContent(final int from, final int to) {
         try {
-            return completedFuture(FileUtils.getBoundedStream(new FileInputStream(file), from, to));
+            return FileUtils.getBoundedStream(new FileInputStream(file), from, to);
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);
         }

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -24,8 +24,6 @@ import java.io.InputStream;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.rdf.api.IRI;
@@ -173,15 +171,11 @@ public class FileBinaryServiceTest {
         return false;
     }
 
-    private String uncheckedToString(final CompletionStage<InputStream> is) {
+    private String uncheckedToString(final InputStream is) {
         try {
-            return IOUtils.toString(is.toCompletableFuture().get(), UTF_8);
+            return IOUtils.toString(is, UTF_8);
         } catch (final IOException ex) {
             return null;
-        } catch (InterruptedException e) {
-            throw new AssertionError(e);
-        } catch (ExecutionException e) {
-            throw new AssertionError(e);
         }
     }
 

--- a/components/test/src/main/java/org/trellisldp/test/InMemoryBinaryService.java
+++ b/components/test/src/main/java/org/trellisldp/test/InMemoryBinaryService.java
@@ -86,14 +86,14 @@ public class InMemoryBinaryService implements BinaryService {
         }
 
         @Override
-        public CompletionStage<InputStream> getContent() {
-            return completedFuture(new ByteArrayInputStream(data));
+        public InputStream getContent() {
+            return new ByteArrayInputStream(data);
         }
 
         @Override
-        public CompletionStage<InputStream> getContent(final int from, final int to) {
+        public InputStream getContent(final int from, final int to) {
             final byte[] slice = copyOfRange(data, from, to + 1); // to is inclusive
-            return completedFuture(new ByteArrayInputStream(slice));
+            return new ByteArrayInputStream(slice);
         }
     }
 }

--- a/components/test/src/test/java/org/trellisldp/test/InMemoryBinaryServiceTest.java
+++ b/components/test/src/test/java/org/trellisldp/test/InMemoryBinaryServiceTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
@@ -37,32 +36,32 @@ class InMemoryBinaryServiceTest {
     private final BinaryService testService = new InMemoryBinaryService();
 
     @Test
-    void storeAndRetrieve() throws InterruptedException, ExecutionException, IOException {
+    void storeAndRetrieve() throws IOException {
         final String uuid = testService.generateIdentifier();
         final IRI id = rdfFactory.createIRI(uuid);
         final BinaryMetadata metadata = BinaryMetadata.builder(id).mimeType("mime/type").build();
         final byte[] answer = new byte[] { 1, 2, 3 };
         final InputStream stream = new ByteArrayInputStream(answer);
         testService.setContent(metadata, stream);
-        final Binary binary = testService.get(id).toCompletableFuture().get();
+        final Binary binary = testService.get(id).toCompletableFuture().join();
         final byte[] result;
-        try (InputStream bytes = binary.getContent().toCompletableFuture().get()) {
+        try (InputStream bytes = binary.getContent()) {
             result = toByteArray(bytes);
         }
         assertArrayEquals(answer, result);
     }
 
     @Test
-    void storeAndRetrievePart() throws InterruptedException, ExecutionException, IOException {
+    void storeAndRetrievePart() throws IOException {
         final String uuid = testService.generateIdentifier();
         final IRI id = rdfFactory.createIRI(uuid);
         final BinaryMetadata metadata = BinaryMetadata.builder(id).mimeType("mime/type").build();
         final byte[] fullAnswer = new byte[] { 1, 2, 3 };
         final InputStream stream = new ByteArrayInputStream(fullAnswer);
         testService.setContent(metadata, stream);
-        final Binary binary = testService.get(id).toCompletableFuture().get();
+        final Binary binary = testService.get(id).toCompletableFuture().join();
         final byte[] result;
-        try (InputStream bytes = binary.getContent(0, 1).toCompletableFuture().get()) {
+        try (InputStream bytes = binary.getContent(0, 1)) {
             result = toByteArray(bytes);
         }
         final byte[] answer = new byte[] { 1, 2 };

--- a/core/api/src/main/java/org/trellisldp/api/Binary.java
+++ b/core/api/src/main/java/org/trellisldp/api/Binary.java
@@ -15,7 +15,6 @@
 package org.trellisldp.api;
 
 import java.io.InputStream;
-import java.util.concurrent.CompletionStage;
 
 /**
  * The non-RDF content of an LDP NonRDFSource.
@@ -26,13 +25,13 @@ public interface Binary {
     /**
      * @return the content of this {@link Binary}
      */
-    CompletionStage<InputStream> getContent();
+    InputStream getContent();
 
     /**
      * @param from the point in bytes from which to begin content
      * @param to the point in bytes at which to end content
      * @return content from {@code from} to {@code to} inclusive
      */
-    CompletionStage<InputStream> getContent(int from, int to);
+    InputStream getContent(int from, int to);
 
 }

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -56,9 +56,9 @@ public class BinaryServiceTest {
     public void testGetContent() throws IOException {
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("FooBar".getBytes(UTF_8));
         when(mockBinaryService.get(eq(identifier))).thenAnswer(inv -> completedFuture(mockBinary));
-        when(mockBinary.getContent(anyInt(), anyInt())).thenReturn(completedFuture(inputStream));
+        when(mockBinary.getContent(anyInt(), anyInt())).thenReturn(inputStream);
         try (final InputStream content = mockBinaryService.get(identifier)
-                .thenCompose(b -> b.getContent(0, 6)).toCompletableFuture().join()) {
+                .thenApply(b -> b.getContent(0, 6)).toCompletableFuture().join()) {
             assertEquals("FooBar", IOUtils.toString(content, UTF_8), "Binary content did not match");
         }
     }

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -390,7 +390,7 @@ public class TrellisHttpResource {
             return trellis.getMementoService().get(identifier, req.getVersion().getInstant())
                 .thenApply(getHandler::initialize).thenApply(getHandler::standardHeaders)
                 .thenCombine(trellis.getMementoService().mementos(identifier), getHandler::addMementoHeaders)
-                .thenApply(getHandler::getRepresentation);
+                .thenCompose(getHandler::getRepresentation);
 
         // Fetch a timemap
         } else if (TIMEMAP.equals(req.getExt())) {
@@ -420,7 +420,7 @@ public class TrellisHttpResource {
         return trellis.getResourceService().get(identifier).thenApply(getHandler::initialize)
             .thenApply(getHandler::standardHeaders)
             .thenCombine(trellis.getMementoService().mementos(identifier), getHandler::addMementoHeaders)
-            .thenApply(getHandler::getRepresentation);
+            .thenCompose(getHandler::getRepresentation);
     }
 
     private String getIdentifier(final TrellisRequest req) {

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -360,10 +360,15 @@ public class GetHandler extends BaseLdpHandler {
         }
 
         // Stream the binary content
-        // TODO -- with JDK 9 use InputStream::transferTo instead of IOUtils::copy
         return getBinaryStream(dsid, getRequest())
-                        .thenApply(in -> (StreamingOutput) out -> IOUtils.copy(in, out))
+                        .thenApply(in -> (StreamingOutput) out -> copy(in, out))
                         .thenApply(builder::entity);
+    }
+
+    // TODO -- with JDK 9 use InputStream::transferTo instead of IOUtils::copy
+    private static void copy(final InputStream from, final OutputStream to) throws IOException {
+        IOUtils.copy(from, to);
+        from.close();
     }
 
     private CompletionStage<InputStream> getBinaryStream(final IRI dsid, final TrellisRequest req) {

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -401,7 +401,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     @Test
     public void testGetBinaryErrorSkip() throws IOException {
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
-        when(mockBinary.getContent()).thenReturn(completedFuture(mockInputStream));
+        when(mockBinary.getContent()).thenReturn(mockInputStream);
         when(mockInputStream.skip(anyLong())).thenThrow(new IOException());
         final Response res = target(BINARY_PATH).request().header(RANGE, "bytes=300-400").get();
         assertEquals(SC_INTERNAL_SERVER_ERROR, res.getStatus(), "Unexpected response code!");

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -267,9 +267,9 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     private void setUpBinaryService() throws Exception {
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent(eq(3), eq(10)))
-                        .thenReturn(completedFuture(new ByteArrayInputStream("e input".getBytes(UTF_8))));
+                        .thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
         when(mockBinary.getContent())
-                        .thenReturn(completedFuture(new ByteArrayInputStream("Some input stream".getBytes(UTF_8))));
+                        .thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
         when(mockBinaryService.setContent(any(BinaryMetadata.class), any(InputStream.class)))
         .thenAnswer(inv -> {
             readLines((InputStream) inv.getArguments()[1], UTF_8);

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -231,9 +231,9 @@ abstract class BaseTestHandler {
 
     private void setUpBinaryService() throws Exception {
         when(mockBinary.getContent(eq(3), eq(10)))
-                        .thenReturn(completedFuture(new ByteArrayInputStream("e input".getBytes(UTF_8))));
+                        .thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));
         when(mockBinary.getContent())
-                        .thenReturn(completedFuture(new ByteArrayInputStream("Some input stream".getBytes(UTF_8))));
+                        .thenReturn(new ByteArrayInputStream("Some input stream".getBytes(UTF_8)));
         when(mockBinaryService.generateIdentifier()).thenReturn("file:///" + randomUUID());
         when(mockBinaryService.get(any(IRI.class))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinaryService.purgeContent(any(IRI.class))).thenReturn(completedFuture(null));

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -101,7 +101,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+            .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response type!");
         assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
@@ -132,7 +132,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response status!");
         assertEquals("text/ldpatch", res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
@@ -149,7 +149,7 @@ public class GetHandlerTest extends BaseTestHandler {
     public void testGetVersionedLdprs() {
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, true, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(from(time), res.getLastModified(), "Incorrect modified date!");
@@ -186,7 +186,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertTrue(res.getLinks().stream().anyMatch(hasType(SKOS.Concept)), "Missing extra type link header!");
@@ -214,7 +214,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(from(time), res.getLastModified(), "Incorrect modified date!");
@@ -247,7 +247,7 @@ public class GetHandlerTest extends BaseTestHandler {
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
 
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code");
         assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
         assertEquals(from(time), res.getLastModified(), "Incorrect modified date!");
@@ -288,7 +288,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
@@ -306,7 +306,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertAll("Check binary description", checkBinaryDescription(res));
     }
@@ -319,7 +319,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertAll("Check binary description", checkBinaryDescription(res));
     }
@@ -347,7 +347,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertEquals(-1, res.getLength(), "Incorrect response length!");
@@ -370,7 +370,7 @@ public class GetHandlerTest extends BaseTestHandler {
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-            .build();
+                        .toCompletableFuture().join().build();
 
         assertEquals(OK, res.getStatusInfo(), "Incorrect response code!");
         assertAll("Check LDP type link headers", checkLdpType(res, LDP.RDFSource));


### PR DESCRIPTION
This changeset removes one level of asynchrony from the path between binary data and HTTP by switching the signatures of `Binary::getContent` from `CompletionStage<InputStream>` to `InputStream`. This is appropriate because the only use `trellis-http` makes use of the `CompletionStage<InputStream>` is to immediately call `toCompletableFuture().join()` on it, which is absurd. We should rely going forward on the practice we've developed of answering HTTP requests using `@Suspended` by getting a `CompletionStage` from one or more of `ResourceService`, `MementoService`, `BinaryService`, etc.. The types _inside_ those `CompletionStage`s would themselves feature methods that return ordinary (non-promise/future) types. This changeset causes that to be the case.