### PR TITLE
Add a delegatedBy identifier to admin sessions

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/AgentAuthorizationFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/AgentAuthorizationFilter.java
@@ -98,17 +98,15 @@ public class AgentAuthorizationFilter implements ContainerRequestFilter {
         final SecurityContext sec = ctx.getSecurityContext();
         final String name = getPrincipalName(sec.getUserPrincipal());
         LOGGER.debug("Checking security context: {}", name);
+        final IRI webid = agentService.asAgent(name);
         if (adminUsers.contains(name)) {
             LOGGER.info("{} acting as administrator user", name);
-            ctx.setProperty(SESSION_PROPERTY, new HttpSession(AdministratorAgent));
+            ctx.setProperty(SESSION_PROPERTY, new HttpSession(AdministratorAgent, webid));
+        // don't permit admin agent to be generated from the agent service
+        } else if (AdministratorAgent.equals(webid)) {
+            ctx.setProperty(SESSION_PROPERTY, new HttpSession());
         } else {
-            final IRI webid = agentService.asAgent(name);
-            // don't permit admin agent to be generated from the agent service
-            if (AdministratorAgent.equals(webid)) {
-                ctx.setProperty(SESSION_PROPERTY, new HttpSession());
-            } else {
-                ctx.setProperty(SESSION_PROPERTY, new HttpSession(webid));
-            }
+            ctx.setProperty(SESSION_PROPERTY, new HttpSession(webid));
         }
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/AgentAuthorizationFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AgentAuthorizationFilterTest.java
@@ -84,10 +84,6 @@ public class AgentAuthorizationFilterTest {
 
     @Test
     public void testNoParamCtor() throws Exception {
-        when(mockPrincipal.getName()).thenReturn("https://example.com/admin");
-        final AgentAuthorizationFilter filter = new AgentAuthorizationFilter();
-        filter.filter(mockContext);
-        verify(mockContext).setProperty(eq(SESSION_PROPERTY), sessionArgument.capture());
-        assertEquals(Trellis.AdministratorAgent, sessionArgument.getValue().getAgent(), "Unexpected agent IRI!");
+        assertDoesNotThrow(() -> new AgentAuthorizationFilter());
     }
 }


### PR DESCRIPTION
When a user assumes the role of a super admin, this change adds the user's own webid to the `delegatedBy` property of the session. This means that the audit log will contain some additional (very useful) information.