### PR TITLE
Adjust test visibility

### DIFF
--- a/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthFilterTest.java
+++ b/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthFilterTest.java
@@ -18,7 +18,6 @@ import static java.util.Collections.singleton;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.SecurityContext.BASIC_AUTH;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -35,7 +34,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
-public class BasicAuthFilterTest {
+class BasicAuthFilterTest {
 
     @Mock
     private ContainerRequestContext mockContext;
@@ -47,13 +46,13 @@ public class BasicAuthFilterTest {
     private ArgumentCaptor<SecurityContext> securityArgument;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockContext.getSecurityContext()).thenReturn(mockSecurityContext);
     }
 
     @Test
-    public void testCredentials() throws Exception {
+    void testCredentials() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         final String webid = "https://people.apache.org/~acoburn/#i";
         final String token = encodeCredentials("acoburn", "secret");
@@ -68,7 +67,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testAdminCredentials() throws Exception {
+    void testAdminCredentials() {
         final String webid = "https://people.apache.org/~acoburn/#i";
         final BasicAuthFilter filter = new BasicAuthFilter(new File(getAuthFile()), "trellis", singleton(webid));
         final String token = encodeCredentials("acoburn", "secret");
@@ -83,7 +82,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testNoHeader() throws Exception {
+    void testNoHeader() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn(null);
         filter.filter(mockContext);
@@ -91,7 +90,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testOtherCredentials() throws Exception {
+    void testOtherCredentials() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         when(mockContext.getHeaderString(AUTHORIZATION))
             .thenReturn("Basic " + encodeCredentials("user", "password"));
@@ -105,7 +104,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testSecureCredentials() throws Exception {
+    void testSecureCredentials() {
         when(mockSecurityContext.isSecure()).thenReturn(true);
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         final String webid = "https://people.apache.org/~acoburn/#i";
@@ -120,7 +119,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testNoSecurityContext() throws Exception {
+    void testNoSecurityContext() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         when(mockContext.getSecurityContext()).thenReturn(null);
         when(mockContext.getHeaderString(AUTHORIZATION))
@@ -135,7 +134,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testCredentialsViaConfiguration() throws Exception {
+    void testCredentialsViaConfiguration() {
         try {
             System.setProperty(BasicAuthFilter.CONFIG_AUTH_BASIC_CREDENTIALS, getAuthFile());
             final BasicAuthFilter filter = new BasicAuthFilter();
@@ -154,7 +153,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testNoCredentials() throws Exception {
+    void testNoCredentials() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         final String token = encodeCredentials("acoburn", "secret");
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
@@ -163,7 +162,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testBadCredentials() throws Exception {
+    void testBadCredentials() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         final String token = encodeCredentials("acoburn", "wrong");
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Basic " + token);
@@ -171,7 +170,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testBadCredentialsFile() throws Exception {
+    void testBadCredentialsFile() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile() + ".non-existent");
         final String token = encodeCredentials("acoburn", "secret");
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Basic " + token);
@@ -179,7 +178,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testNoToken() throws Exception {
+    void testNoToken() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("BASIC");
         filter.filter(mockContext);
@@ -187,7 +186,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testBadToken() throws Exception {
+    void testBadToken() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         final String token = "blahblah";
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Basic " + token);
@@ -195,7 +194,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testTokenWithBadChars() throws Exception {
+    void testTokenWithBadChars() {
         final BasicAuthFilter filter = new BasicAuthFilter(getAuthFile());
         final String token = "&=!*#$";
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Basic " + token);
@@ -203,7 +202,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testUnreadableFile() throws Exception {
+    void testUnreadableFile() {
         final File file = new File(getAuthFile(), "nonexistent");
         final BasicAuthFilter filter = new BasicAuthFilter(file);
         final String token = encodeCredentials("acoburn", "secret");
@@ -212,7 +211,7 @@ public class BasicAuthFilterTest {
     }
 
     @Test
-    public void testCredentialsObject() {
+    void testCredentialsObject() {
         final Credentials credentials = new Credentials("acoburn", "secret");
         assertFalse(credentials.toString().contains("secret"));
         assertTrue(credentials.toString().contains("acoburn"));

--- a/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthUtilsTest.java
+++ b/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthUtilsTest.java
@@ -20,19 +20,18 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
-public class BasicAuthUtilsTest {
+class BasicAuthUtilsTest {
 
     @Test
-    public void uncheckedLinesTest() {
+    void uncheckedLinesTest() {
         final File file = new File(getClass().getResource("/users.auth").getFile());
         assertEquals(5L, BasicAuthUtils.uncheckedLines(file.toPath()).count());
     }
 
     @Test
-    public void uncheckedLinesNonexistentTest() {
+    void uncheckedLinesNonexistentTest() {
         final File file = new File(getClass().getResource("/users.auth").getFile()).getParentFile();
         final Path path = new File(file, "nonexistent.file").toPath();
         assertEquals(0L, BasicAuthUtils.uncheckedLines(path).count());
     }
-
 }

--- a/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicPrincipalTest.java
+++ b/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicPrincipalTest.java
@@ -19,10 +19,10 @@ import java.security.Principal;
 
 import org.junit.jupiter.api.Test;
 
-public class BasicPrincipalTest {
+class BasicPrincipalTest {
 
     @Test
-    public void testPrincipal() {
+    void testPrincipal() {
         final String name = "Name";
         final Principal principal = new BasicPrincipal(name);
         assertEquals(name, principal.getName());

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/FederatedJwtAuthenticatorTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/FederatedJwtAuthenticatorTest.java
@@ -14,6 +14,7 @@
 package org.trellisldp.auth.oauth;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
@@ -33,12 +34,12 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class FederatedJwtAuthenticatorTest {
+class FederatedJwtAuthenticatorTest {
 
-    private static char[] passphrase = "password".toCharArray();
+    private static final char[] passphrase = "password".toCharArray();
 
     @Test
-    public void testAuthenticateKeystore() throws Exception {
+    void testAuthenticateKeystore() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
@@ -56,7 +57,7 @@ public class FederatedJwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateKeystoreRSA() throws Exception {
+    void testAuthenticateKeystoreRSA() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
@@ -66,7 +67,7 @@ public class FederatedJwtAuthenticatorTest {
             .signWith(privateKey, SignatureAlgorithm.RS256).compact();
 
         final Authenticator authenticator = new FederatedJwtAuthenticator(ks,
-                asList("trellis-public"));
+                singletonList("trellis-public"));
 
         final Principal p = authenticator.authenticate(token);
         assertNotNull(p, "Missing principal!");
@@ -74,13 +75,13 @@ public class FederatedJwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateKeystoreEC() throws Exception {
+    void testAuthenticateKeystoreEC() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
         final String token = buildEcToken(ks.getKey("trellis-ec", passphrase), "trellis-ec");
         final Authenticator authenticator = new FederatedJwtAuthenticator(ks,
-                asList("trellis-ec"));
+                singletonList("trellis-ec"));
 
         final Principal p = authenticator.authenticate(token);
         assertNotNull(p, "Missing principal!");
@@ -88,7 +89,7 @@ public class FederatedJwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateNoSub() throws Exception {
+    void testAuthenticateNoSub() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
@@ -97,13 +98,13 @@ public class FederatedJwtAuthenticatorTest {
             .setIssuer("http://localhost").signWith(privateKey, SignatureAlgorithm.ES256).compact();
 
         final Authenticator authenticator = new FederatedJwtAuthenticator(ks,
-                asList("trellis-ec"));
+                singletonList("trellis-ec"));
 
         assertNull(authenticator.authenticate(token), "Unexpected principal!");
     }
 
     @Test
-    public void testAuthenticateSubIss() throws Exception {
+    void testAuthenticateSubIss() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
@@ -113,7 +114,7 @@ public class FederatedJwtAuthenticatorTest {
             .signWith(privateKey, SignatureAlgorithm.ES256).compact();
 
         final Authenticator authenticator = new FederatedJwtAuthenticator(ks,
-                asList("trellis-ec"));
+                singletonList("trellis-ec"));
 
         final Principal p = authenticator.authenticate(token);
         assertNotNull(p, "Missing principal!");
@@ -121,7 +122,7 @@ public class FederatedJwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateSubNoWebIss() throws Exception {
+    void testAuthenticateSubNoWebIss() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
@@ -131,13 +132,13 @@ public class FederatedJwtAuthenticatorTest {
             .signWith(privateKey, SignatureAlgorithm.ES256).compact();
 
         final Authenticator authenticator = new FederatedJwtAuthenticator(ks,
-                asList("trellis-ec"));
+                singletonList("trellis-ec"));
 
         assertNull(authenticator.authenticate(token), "Unexpected principal!");
     }
 
     @Test
-    public void testAuthenticateKeystoreNoKeyId() throws Exception {
+    void testAuthenticateKeystoreNoKeyId() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
@@ -145,13 +146,13 @@ public class FederatedJwtAuthenticatorTest {
         final String token = Jwts.builder().setSubject("https://people.apache.org/~acoburn/#i")
             .signWith(privateKey, SignatureAlgorithm.ES256).compact();
         final Authenticator authenticator = new FederatedJwtAuthenticator(ks,
-                asList("trellis-ec"));
+                singletonList("trellis-ec"));
 
         assertThrows(JwtException.class, () -> authenticator.authenticate(token), "Unexpected key id field!");
     }
 
     @Test
-    public void testAuthenticateKeystoreNoMatch() throws Exception {
+    void testAuthenticateKeystoreNoMatch() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
@@ -163,19 +164,19 @@ public class FederatedJwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateKeystoreAnotherNoMatch() throws Exception {
+    void testAuthenticateKeystoreAnotherNoMatch() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), passphrase);
 
         final String token = buildEcToken(ks.getKey("trellis-ec", passphrase), "foo");
         final Authenticator authenticator = new FederatedJwtAuthenticator(ks,
-                asList("foo"));
+                singletonList("foo"));
 
         assertThrows(SecurityException.class, () -> authenticator.authenticate(token), "Unexpected keystore entry!");
     }
 
     @Test
-    public void testKeyStoreException() throws Exception {
+    void testKeyStoreException() throws Exception {
         final KeyStore mockKeyStore = mock(KeyStore.class, inv -> {
             throw new KeyStoreException("Expected");
         });
@@ -185,7 +186,7 @@ public class FederatedJwtAuthenticatorTest {
 
         final String token = buildEcToken(ks.getKey("trellis-ec", passphrase), "trellis-ec");
         final Authenticator authenticator = new FederatedJwtAuthenticator(mockKeyStore,
-                asList("trellis-ec"));
+                singletonList("trellis-ec"));
 
         assertThrows(SecurityException.class, () -> authenticator.authenticate(token),
                 "Unexpectedly functional keystore!");

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/JwksAuthenticatorTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/JwksAuthenticatorTest.java
@@ -32,7 +32,7 @@ import java.security.spec.RSAPrivateKeySpec;
 
 import org.junit.jupiter.api.Test;
 
-public class JwksAuthenticatorTest {
+class JwksAuthenticatorTest {
 
     private static final String url = "https://www.trellisldp.org/tests/jwks.json";
     private static final String keyid = "trellis-test";
@@ -50,7 +50,7 @@ public class JwksAuthenticatorTest {
             "aahEQ"));
 
     @Test
-    public void testAuthenticateJwks() throws Exception {
+    void testAuthenticateJwks() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
 
         final Key key = KeyFactory.getInstance("RSA").generatePrivate(new RSAPrivateKeySpec(modulus, exponent));
@@ -65,7 +65,7 @@ public class JwksAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateJwksAsWebid() throws Exception {
+    void testAuthenticateJwksAsWebid() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
 
         final Key key = KeyFactory.getInstance("RSA").generatePrivate(new RSAPrivateKeySpec(modulus, exponent));
@@ -80,7 +80,7 @@ public class JwksAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateJwksExpired() throws Exception {
+    void testAuthenticateJwksExpired() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
 
         final Key key = KeyFactory.getInstance("RSA").generatePrivate(new RSAPrivateKeySpec(modulus, exponent));
@@ -93,7 +93,7 @@ public class JwksAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateJwksWrongKeyid() throws Exception {
+    void testAuthenticateJwksWrongKeyid() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
 
         final Key key = KeyFactory.getInstance("RSA").generatePrivate(new RSAPrivateKeySpec(modulus, exponent));
@@ -106,7 +106,7 @@ public class JwksAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateJwksNoKeyid() throws Exception {
+    void testAuthenticateJwksNoKeyid() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
 
         final Key key = KeyFactory.getInstance("RSA").generatePrivate(new RSAPrivateKeySpec(modulus, exponent));
@@ -118,7 +118,7 @@ public class JwksAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateJwksInvalidKeyLocation() throws Exception {
+    void testAuthenticateJwksInvalidKeyLocation() throws Exception {
         final String webid = "https://people.apache.org/~acoburn/#i";
 
         final Key key = KeyFactory.getInstance("RSA").generatePrivate(new RSAPrivateKeySpec(modulus, exponent));

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/JwtAuthenticatorTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/JwtAuthenticatorTest.java
@@ -35,10 +35,10 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class JwtAuthenticatorTest {
+class JwtAuthenticatorTest {
 
     @Test
-    public void testAuthenticate() {
+    void testAuthenticate() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS256);
         final String token = Jwts.builder().setSubject("https://people.apache.org/~acoburn/#i")
              .signWith(key).compact();
@@ -51,7 +51,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateEC() {
+    void testAuthenticateEC() {
         final KeyPair keypair = EllipticCurveProvider.generateKeyPair(SignatureAlgorithm.ES256);
         final String token = Jwts.builder().setSubject("https://people.apache.org/~acoburn/#i")
              .signWith(keypair.getPrivate(), SignatureAlgorithm.ES256).compact();
@@ -64,7 +64,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateRSA() {
+    void testAuthenticateRSA() {
         final KeyPair keypair = RsaProvider.generateKeyPair();
         final String token = Jwts.builder().setSubject("https://people.apache.org/~acoburn/#i")
              .signWith(keypair.getPrivate(), SignatureAlgorithm.RS256).compact();
@@ -77,7 +77,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateKeystore() throws Exception {
+    void testAuthenticateKeystore() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), "password".toCharArray());
 
@@ -94,7 +94,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateKeystoreRSA() throws Exception {
+    void testAuthenticateKeystoreRSA() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), "password".toCharArray());
 
@@ -111,7 +111,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateKeystoreEC() throws Exception {
+    void testAuthenticateKeystoreEC() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), "password".toCharArray());
 
@@ -128,7 +128,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateKeystoreECWebsite() throws Exception {
+    void testAuthenticateKeystoreECWebsite() throws Exception {
         final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
         ks.load(getClass().getResourceAsStream("/keystore.jks"), "password".toCharArray());
 
@@ -146,7 +146,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateNoSub() {
+    void testAuthenticateNoSub() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS384);
         final String token = Jwts.builder().setIssuer("http://localhost").signWith(key).compact();
 
@@ -157,7 +157,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateSubIss() {
+    void testAuthenticateSubIss() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS512);
         final String token = Jwts.builder().setSubject("acoburn").setIssuer("http://localhost")
              .signWith(key).compact();
@@ -170,7 +170,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateSubNoWebIss() {
+    void testAuthenticateSubNoWebIss() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS512);
         final String token = Jwts.builder().setSubject("acoburn").setIssuer("some org").signWith(key).compact();
 
@@ -181,7 +181,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateToken() {
+    void testAuthenticateToken() {
         final String key = "N0NuokWWb5XjMP+V3XLfyLkaSArwxNm17VeAvv7+y4+Y/DmxBLenvwOPO404lfl6UfyyEGgQ02ETDEPRMwV/+Q==";
         final String token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL3Blb3BsZS5hcGFjaGUub3JnL35" +
             "hY29idXJuLyNpIn0.n-C7xhjVyn3WEWGfSXfuqrjXVSoAnD08sO5K8mDsBiZF6Z8lwiksGos6lR-6RjD5jI25d1yPJ47LKBWqMlMm_A";
@@ -194,7 +194,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticateTokenIssSub() {
+    void testAuthenticateTokenIssSub() {
         final String key = "N0NuokWWb5XjMP+V3XLfyLkaSArwxNm17VeAvv7+y4+Y/DmxBLenvwOPO404lfl6UfyyEGgQ02ETDEPRMwV/+Q==";
         final String token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhY29idXJuIiwibmFtZSI6IkFhcm9uIENvYnVyb" +
             "iIsImlzcyI6Imh0dHA6Ly9leGFtcGxlLm9yZy8ifQ.4Srityp5iPScGyqvkPakD3DmtXYWhkyHjr0K6B7kpcR2ll8MC-hGpYoIDM8ar" +
@@ -208,7 +208,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticationTokenWebid() {
+    void testAuthenticationTokenWebid() {
         final String key = "N0NuokWWb5XjMP+V3XLfyLkaSArwxNm17VeAvv7+y4+Y/DmxBLenvwOPO404lfl6UfyyEGgQ02ETDEPRMwV/+Q==";
         final String token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ3ZWJpZCI6Imh0dHBzOi8vcGVvcGxlLmFwYWNoZS5vcmcvfm" +
             "Fjb2J1cm4vI2kiLCJzdWIiOiJhY29idXJuIiwibmFtZSI6IkFhcm9uIENvYnVybiIsImlzcyI6Imh0dHA6Ly9leGFtcGxlLm9yZy8ifQ" +
@@ -222,7 +222,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticationTokenWebidBadKey() {
+    void testAuthenticationTokenWebidBadKey() {
         final String key = "2YuUlb+t36yVzrTkYLl8xBlBJSC41CE7uNF3somMDxdYDfcACv9JYIU54z17s4Ah313uKu/4Ll+vDNKpxx6v4Q==";
         final String token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ3ZWJpZCI6Imh0dHBzOi8vcGVvcGxlLmFwYWNoZS5vcmcvfm" +
             "Fjb2J1cm4vI2kiLCJzdWIiOiJhY29idXJuIiwibmFtZSI6IkFhcm9uIENvYnVybiIsImlzcyI6Imh0dHA6Ly9leGFtcGxlLm9yZy8ifQ" +
@@ -234,7 +234,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testAuthenticationNoPrincipal() {
+    void testAuthenticationNoPrincipal() {
         final String key = "w8+z9hrcbr3ktQ5WTr9xNZknke3L/RAj8r8RieriWozGu1M4RDgkpJcfTEg90pqYyadbIBLy+qFHu1JJ8O0rjw==";
         final String token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhY29idXJuIiwibmFtZSI6IkFhcm9" +
             "uIENvYnVybiJ9.srs7gSbix8nLDuFmwYCEN0In-5pa6-59D5nqF1UgRD-hsJBS2UoieYoBJZNGGKj1hO1DaboqtuS_36bE9QGdCw";
@@ -246,7 +246,7 @@ public class JwtAuthenticatorTest {
     }
 
     @Test
-    public void testGarbledToken() {
+    void testGarbledToken() {
         final String key = "thj983z1fiqAiaV7Nv4nWpjaDi6eVTd7jOGxbs92mp8=";
         final String token = "blahblah";
 

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/NullAuthenticatorTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/NullAuthenticatorTest.java
@@ -17,13 +17,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-public class NullAuthenticatorTest {
+class NullAuthenticatorTest {
 
     @Test
-    public void testNullAuthenticator() {
+    void testNullAuthenticator() {
         final Authenticator authenticator = new NullAuthenticator();
         assertNull(authenticator.authenticate("blah"), "Unexpected principal found!");
         assertNull(authenticator.parse("credentials"), "Credentials were not null!");
     }
-
 }

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthFilterTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthFilterTest.java
@@ -24,7 +24,6 @@ import static java.util.stream.Stream.of;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -55,7 +54,7 @@ import org.mockito.Mock;
  * @author acoburn
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class OAuthFilterTest {
+class OAuthFilterTest {
 
     private static final String WEBID1 = "https://people.apache.org/~acoburn/#i";
     private static final String WEBID2 = "https://user.example.com/#me";
@@ -70,13 +69,13 @@ public class OAuthFilterTest {
     private ArgumentCaptor<SecurityContext> securityArgument;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockContext.getSecurityContext()).thenReturn(mockSecurityContext);
     }
 
     @Test
-    public void testFilterAuth() throws Exception {
+    void testFilterAuth() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS512);
         final String token = Jwts.builder().setSubject(WEBID1).signWith(key).compact();
         final ContainerRequestContext mockCtx = mock(ContainerRequestContext.class);
@@ -93,7 +92,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterNoAuth() throws Exception {
+    void testFilterNoAuth() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS512);
         final ContainerRequestContext mockCtx = mock(ContainerRequestContext.class);
         when(mockCtx.getSecurityContext()).thenReturn(mockSecurityContext);
@@ -105,7 +104,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterWebid() throws Exception {
+    void testFilterWebid() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS512);
         final String token = Jwts.builder().claim("webid", WEBID2).signWith(key).compact();
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
@@ -121,7 +120,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterAdminWebid() throws Exception {
+    void testFilterAdminWebid() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS512);
         final String token = Jwts.builder().claim("webid", WEBID2).signWith(key).compact();
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
@@ -138,7 +137,7 @@ public class OAuthFilterTest {
 
 
     @Test
-    public void testFilterInvalidAuth() throws Exception {
+    void testFilterInvalidAuth() {
         final String key = "BdEaIIfv67jl8mRL+/vnuf3RzfVfpkxtel8icx2B8uSudOcwVXr7zpwj92UtKCOkVGi2FaE+O4q55P3p7UE7Eg==";
         final String token = Jwts.builder().setSubject(WEBID1).signWith(hmacShaKeyFor(key.getBytes(UTF_8))).compact();
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
@@ -149,7 +148,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterExpiredJwt() throws Exception {
+    void testFilterExpiredJwt() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS512);
         final String token = Jwts.builder().claim("webid", WEBID1).setExpiration(from(now().minusSeconds(10)))
             .signWith(key).compact();
@@ -160,7 +159,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterGenericWebid() throws Exception {
+    void testFilterGenericWebid() {
         try {
             System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET,
                     "y7MCBmoOx7TH70q1fabSGLzOrEYx+liUmLWPkwIPUTfWMXn/J5MDZuepBd8mcRObUDYYQN3MIS8p40ZT5EhvWw==");
@@ -178,7 +177,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterGenericJwtSecret() throws Exception {
+    void testFilterGenericJwtSecret() {
         try {
             System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET,
                     "y7MCBmoOx7TH70q1fabSGLzOrEYx+liUmLWPkwIPUTfWMXn/J5MDZuepBd8mcRObUDYYQN3MIS8p40ZT5EhvWw==");
@@ -196,7 +195,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterNotBasicAuth() throws Exception {
+    void testFilterNotBasicAuth() {
         try {
             System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET,
                     "y7MCBmoOx7TH70q1fabSGLzOrEYx+liUmLWPkwIPUTfWMXn/J5MDZuepBd8mcRObUDYYQN3MIS8p40ZT5EhvWw==");
@@ -215,7 +214,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterNoToken() throws Exception {
+    void testFilterNoToken() {
         try {
             System.setProperty(OAuthFilter.CONFIG_AUTH_OAUTH_SHARED_SECRET,
                     "y7MCBmoOx7TH70q1fabSGLzOrEYx+liUmLWPkwIPUTfWMXn/J5MDZuepBd8mcRObUDYYQN3MIS8p40ZT5EhvWw==");
@@ -231,7 +230,7 @@ public class OAuthFilterTest {
 
 
     @Test
-    public void testFilterGenericNoAuth() throws Exception {
+    void testFilterGenericNoAuth() {
         final Key key = secretKeyFor(SignatureAlgorithm.HS512);
         final String token = Jwts.builder().claim("webid", WEBID1).signWith(key).compact();
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
@@ -241,7 +240,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterGenericJwks() throws Exception {
+    void testFilterGenericJwks() throws Exception {
         final BigInteger exponent = new BigInteger(1, getUrlDecoder().decode("VRPRBm9dCoAJfBbEz5oAHEz7Tnm0i0O6m5yj7N" +
             "wqAZOj9i4ZwgZ8VZQo88oxZQWNaYd1yKeoQhUsJija_vxQEPXO1Q2q6OqMcwTBH0wyGhIFp--z2dAyRlDVLUTQbJUXyqammdh7b16-i" +
             "gH-BB67jfolM-cw-O7YaN7GrxCCYX5bI38IipeYfcroeIUXdLYmmUdNy7c8P2_K4O-iHQ6A4AUtQRUOzt2FGOdmlGZihupI9YprshIy" +
@@ -271,7 +270,7 @@ public class OAuthFilterTest {
     }
 
     @Test
-    public void testFilterGenericFederated() throws Exception {
+    void testFilterGenericFederated() throws Exception {
         final String passphrase = "password";
         try {
             final String keystorePath = OAuthUtilsTest.class.getResource("/keystore.jks").getPath();

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthPrincipalTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthPrincipalTest.java
@@ -19,10 +19,10 @@ import java.security.Principal;
 
 import org.junit.jupiter.api.Test;
 
-public class OAuthPrincipalTest {
+class OAuthPrincipalTest {
 
     @Test
-    public void testPrincipal() {
+    void testPrincipal() {
         final String name = "TestPrincipal";
         final Principal principal = new OAuthPrincipal(name);
         assertEquals(name, principal.getName());

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthUtilsTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthUtilsTest.java
@@ -21,24 +21,24 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-public class OAuthUtilsTest {
+class OAuthUtilsTest {
 
-    private static char[] passphrase = "password".toCharArray();
+    private static final char[] passphrase = "password".toCharArray();
 
     @Test
-    public void testBuilderSimpleDefault() {
+    void testBuilderSimpleDefault() {
         assertNull(OAuthUtils.buildAuthenticatorWithSharedSecret(null));
         assertNull(OAuthUtils.buildAuthenticatorWithSharedSecret(""));
     }
 
     @Test
-    public void testBuildFederatedNull() {
+    void testBuildFederatedNull() {
         assertNull(OAuthUtils.buildAuthenticatorWithTruststore(null, "test".toCharArray(),
                     asList("one,two".split(","))));
     }
 
     @Test
-    public void testOAuthFederatedBuilder() {
+    void testOAuthFederatedBuilder() {
         final String keystorePath = OAuthUtilsTest.class.getResource("/keystore.jks").getPath();
         final List<String> ids = asList("trellis,foo".split(","));
         final Authenticator authenticator = OAuthUtils.buildAuthenticatorWithTruststore(keystorePath, passphrase, ids);
@@ -46,21 +46,21 @@ public class OAuthUtilsTest {
     }
 
     @Test
-    public void testOAuthBuilderNoKeystore() {
+    void testOAuthBuilderNoKeystore() {
         final String keystorePath = OAuthUtilsTest.class.getResource("/keystore.jks").getPath();
         final List<String> ids = asList("trellis,foo".split(","));
         assertNull(OAuthUtils.buildAuthenticatorWithTruststore(keystorePath + "foo", passphrase, ids));
     }
 
     @Test
-    public void testOAuthBuilderNoIds() {
+    void testOAuthBuilderNoIds() {
         final String keystorePath = OAuthUtilsTest.class.getResource("/keystore.jks").getPath();
         final List<String> ids = asList("foo,bar".split(","));
         assertNull(OAuthUtils.buildAuthenticatorWithTruststore(keystorePath, passphrase, ids));
     }
 
     @Test
-    public void testOAuthFederatedBuilderMultipleIds() {
+    void testOAuthFederatedBuilderMultipleIds() {
         final String keystorePath = OAuthUtilsTest.class.getResource("/keystore.jks").getPath();
         final List<String> ids = asList("trellis,trellis-ec".split(","));
         final Authenticator authenticator = OAuthUtils.buildAuthenticatorWithTruststore(keystorePath, passphrase, ids);
@@ -68,31 +68,31 @@ public class OAuthUtilsTest {
     }
 
     @Test
-    public void testOAuthFederatedBuilderBadPassphrase() {
+    void testOAuthFederatedBuilderBadPassphrase() {
         final String keystorePath = OAuthUtilsTest.class.getResource("/keystore.jks").getPath();
         final List<String> ids = asList("trellis,trellis-ec".split(","));
         assertNull(OAuthUtils.buildAuthenticatorWithTruststore(keystorePath, "foo".toCharArray(), ids));
     }
 
     @Test
-    public void testOAuthJwkBuilder() {
+    void testOAuthJwkBuilder() {
         final String url = "https://www.trellisldp.org/tests/jwks.json";
         final Authenticator authenticator = OAuthUtils.buildAuthenticatorWithJwk(url);
         assertTrue(authenticator instanceof JwksAuthenticator);
     }
 
     @Test
-    public void testOAuthJwkBuilderNull() {
+    void testOAuthJwkBuilderNull() {
         assertNull(OAuthUtils.buildAuthenticatorWithJwk(null));
     }
 
     @Test
-    public void testOAuthJwkBuilderNotUrl() {
+    void testOAuthJwkBuilderNotUrl() {
         assertNull(OAuthUtils.buildAuthenticatorWithJwk("some text"));
     }
 
     @Test
-    public void testInvalidRSAKey() {
+    void testInvalidRSAKey() {
         assertNull(OAuthUtils.buildRSAPublicKey("EC", BigInteger.ONE, BigInteger.TEN));
     }
 }

--- a/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/AppUtilsTest.java
+++ b/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/AppUtilsTest.java
@@ -36,7 +36,7 @@ import org.trellisldp.kafka.KafkaEventService;
 /**
  * @author acoburn
  */
-public class AppUtilsTest {
+class AppUtilsTest {
 
     @Mock
     private Environment mockEnv;
@@ -45,13 +45,13 @@ public class AppUtilsTest {
     private LifecycleEnvironment mockLifecycle;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockEnv.lifecycle()).thenReturn(mockLifecycle);
     }
 
     @Test
-    public void testEventServiceNone() throws Exception {
+    void testEventServiceNone() {
         final NotificationsConfiguration c = new NotificationsConfiguration();
         c.setConnectionString("localhost");
         c.setEnabled(true);
@@ -62,7 +62,7 @@ public class AppUtilsTest {
     }
 
     @Test
-    public void testEventServiceDisabled() throws Exception {
+    void testEventServiceDisabled() {
         final NotificationsConfiguration c = new NotificationsConfiguration();
         c.set("batch.size", "1000");
         c.set("retries", "10");
@@ -76,7 +76,7 @@ public class AppUtilsTest {
     }
 
     @Test
-    public void testEventServiceKafka() throws Exception {
+    void testEventServiceKafka() {
         final NotificationsConfiguration c = new NotificationsConfiguration();
         c.set("batch.size", "1000");
         c.set("retries", "10");
@@ -90,7 +90,7 @@ public class AppUtilsTest {
     }
 
     @Test
-    public void testGetKafkaProps() {
+    void testGetKafkaProps() {
         final NotificationsConfiguration c = new NotificationsConfiguration();
         c.set("batch.size", "1000");
         c.set("retries", "10");
@@ -106,10 +106,10 @@ public class AppUtilsTest {
     }
 
     @Test
-    public void testEventServiceJms() throws Exception {
+    void testEventServiceJms() throws Exception {
         final NotificationsConfiguration c = new NotificationsConfiguration();
         final int port = new ServerSocket(0).getLocalPort();
-        c.setConnectionString("tcp://localhost:" + Integer.toString(port));
+        c.setConnectionString("tcp://localhost:" + port);
         c.setEnabled(true);
         c.setType(NotificationsConfiguration.Type.JMS);
         assertThrows(RuntimeTrellisException.class, () ->
@@ -117,7 +117,7 @@ public class AppUtilsTest {
     }
 
     @Test
-    public void testGetJmsFactory() {
+    void testGetJmsFactory() {
         final NotificationsConfiguration c = new NotificationsConfiguration();
         c.setConnectionString("localhost:61616");
 

--- a/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/RDFConnectionHealthCheckTest.java
+++ b/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/RDFConnectionHealthCheckTest.java
@@ -27,12 +27,12 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class RDFConnectionHealthCheckTest {
+class RDFConnectionHealthCheckTest {
 
     private static final JenaRDF rdf = new JenaRDF();
 
     @Test
-    public void testIsConnected() throws Exception {
+    void testIsConnected() {
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
         final HealthCheck check = new RDFConnectionHealthCheck(rdfConnection);
@@ -40,7 +40,7 @@ public class RDFConnectionHealthCheckTest {
     }
 
     @Test
-    public void testNonConnected() throws Exception {
+    void testNonConnected() {
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
         rdfConnection.close();

--- a/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/TrellisApplicationTest.java
+++ b/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/TrellisApplicationTest.java
@@ -70,26 +70,26 @@ import org.trellisldp.test.AbstractApplicationMementoTests;
  * Integration tests for Trellis.
  */
 @TestInstance(PER_CLASS)
-public class TrellisApplicationTest implements MessageListener {
+class TrellisApplicationTest implements MessageListener {
 
     private static final Logger LOGGER = getLogger(TrellisApplicationTest.class);
     private static final RDF rdf = getInstance();
     private static final BrokerService BROKER = new BrokerService();
 
-    protected static final DropwizardTestSupport<AppConfiguration> APP = buildApplication();
-    protected static final String JWT_KEY
+    private static final DropwizardTestSupport<AppConfiguration> APP = buildApplication();
+    private static final String JWT_KEY
         = "EEPPbd/7llN/chRwY2UgbdcyjFdaGjlzaupd3AIyjcu8hMnmMCViWoPUBb5FphGLxBlUlT/G5WMx0WcDq/iNKA==";
 
     private final Set<Graph> MESSAGES = new CopyOnWriteArraySet<>();
 
-    protected Client CLIENT;
+    private Client CLIENT;
 
     private MessageConsumer consumer;
     private Connection connection;
 
 
     @BeforeAll
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         BROKER.setPersistent(false);
         BROKER.start();
 
@@ -101,13 +101,13 @@ public class TrellisApplicationTest implements MessageListener {
     }
 
     @AfterAll
-    public void cleanup() throws Exception {
+    void cleanup() throws Exception {
         APP.after();
         BROKER.stop();
     }
 
     @BeforeEach
-    public void aquireConnection() throws Exception {
+    void aquireConnection() throws Exception {
         final ConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost");
         connection = connectionFactory.createConnection();
         connection.start();
@@ -118,7 +118,7 @@ public class TrellisApplicationTest implements MessageListener {
     }
 
     @AfterEach
-    public void releaseConnection() throws Exception {
+    void releaseConnection() throws Exception {
         consumer.setMessageListener(msg -> { });
         consumer.close();
         connection.close();
@@ -131,18 +131,18 @@ public class TrellisApplicationTest implements MessageListener {
 
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         final Application<AppConfiguration> app = new TrellisApplication();
         assertEquals("Trellis LDP", app.getName(), "Incorrect application name!");
     }
 
     @Nested
     @DisplayName("Trellis Audit Tests")
-    public class AuditTests extends AbstractApplicationAuditTests {
+    class AuditTests extends AbstractApplicationAuditTests {
 
         @Override
         public String getJwtSecret() {
-            return TrellisApplicationTest.this.JWT_KEY;
+            return JWT_KEY;
         }
 
         @Override
@@ -152,13 +152,13 @@ public class TrellisApplicationTest implements MessageListener {
 
         @Override
         public String getBaseURL() {
-            return "http://localhost:" + TrellisApplicationTest.this.APP.getLocalPort() + "/";
+            return "http://localhost:" + APP.getLocalPort() + "/";
         }
     }
 
     @Nested
     @DisplayName("Trellis LDP Tests")
-    public class LdpTests extends AbstractApplicationLdpTests {
+    class LdpTests extends AbstractApplicationLdpTests {
 
         @Override
         public Client getClient() {
@@ -167,7 +167,7 @@ public class TrellisApplicationTest implements MessageListener {
 
         @Override
         public String getBaseURL() {
-            return "http://localhost:" + TrellisApplicationTest.this.APP.getLocalPort() + "/";
+            return "http://localhost:" + APP.getLocalPort() + "/";
         }
 
         @Override
@@ -178,7 +178,7 @@ public class TrellisApplicationTest implements MessageListener {
 
     @Nested
     @DisplayName("Trellis Memento Tests")
-    public class MementoTests extends AbstractApplicationMementoTests {
+    class MementoTests extends AbstractApplicationMementoTests {
 
         @Override
         public Client getClient() {
@@ -187,13 +187,13 @@ public class TrellisApplicationTest implements MessageListener {
 
         @Override
         public String getBaseURL() {
-            return "http://localhost:" + TrellisApplicationTest.this.APP.getLocalPort() + "/";
+            return "http://localhost:" + APP.getLocalPort() + "/";
         }
     }
 
     @Nested
     @DisplayName("Trellis Event Tests")
-    public class EventTests extends AbstractApplicationEventTests {
+    class EventTests extends AbstractApplicationEventTests {
         @Override
         public Client getClient() {
             return TrellisApplicationTest.this.CLIENT;
@@ -201,7 +201,7 @@ public class TrellisApplicationTest implements MessageListener {
 
         @Override
         public String getBaseURL() {
-            return "http://localhost:" + TrellisApplicationTest.this.APP.getLocalPort() + "/";
+            return "http://localhost:" + APP.getLocalPort() + "/";
         }
 
         @Override
@@ -211,13 +211,13 @@ public class TrellisApplicationTest implements MessageListener {
 
         @Override
         public String getJwtSecret() {
-            return TrellisApplicationTest.this.JWT_KEY;
+            return JWT_KEY;
         }
     }
 
     @Nested
     @DisplayName("Trellis AuthZ Tests")
-    public class AuthorizationTests extends AbstractApplicationAuthTests {
+    class AuthorizationTests extends AbstractApplicationAuthTests {
 
         @Override
         public Client getClient() {
@@ -226,7 +226,7 @@ public class TrellisApplicationTest implements MessageListener {
 
         @Override
         public String getBaseURL() {
-            return "http://localhost:" + TrellisApplicationTest.this.APP.getLocalPort() + "/";
+            return "http://localhost:" + APP.getLocalPort() + "/";
         }
 
         @Override
@@ -246,12 +246,12 @@ public class TrellisApplicationTest implements MessageListener {
 
         @Override
         public String getJwtSecret() {
-            return TrellisApplicationTest.this.JWT_KEY;
+            return JWT_KEY;
         }
     }
 
     private static DropwizardTestSupport<AppConfiguration> buildApplication() {
-        return new DropwizardTestSupport<AppConfiguration>(TrellisApplication.class,
+        return new DropwizardTestSupport<>(TrellisApplication.class,
                 resourceFilePath("trellis-config.yml"),
                 config("notifications.type", "JMS"),
                 config("notifications.connectionString", "vm://localhost"),

--- a/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/TrellisConfigurationTest.java
+++ b/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/TrellisConfigurationTest.java
@@ -30,10 +30,10 @@ import org.trellisldp.dropwizard.config.NotificationsConfiguration;
 /**
  * @author acoburn
  */
-public class TrellisConfigurationTest {
+class TrellisConfigurationTest {
 
     @Test
-    public void testConfigurationGeneral1() throws Exception {
+    void testConfigurationGeneral1() throws Exception {
         final AppConfiguration config = new YamlConfigurationFactory<>(AppConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -52,7 +52,7 @@ public class TrellisConfigurationTest {
         assertEquals(2, config.getBinaryHierarchyLevels(), "Incorrect binaryHierarchyLevels value!");
         assertEquals(1, config.getBinaryHierarchyLength(), "Incorrect binaryHierarchyLength value!");
         assertEquals("my.cluster.node", config.any().get("cassandraAddress"), "Incorrect custom value!");
-        assertEquals((Integer)245993, config.any().get("cassandraPort"), "Incorrect custom value (2)!");
+        assertEquals(245993, config.any().get("cassandraPort"), "Incorrect custom value (2)!");
         @SuppressWarnings("unchecked")
         final Map<String, Object> extraConfig = (Map<String, Object>) config.any().get("extraConfigValues");
         assertTrue((Boolean) extraConfig.get("one"), "Invalid nested custom values as boolean!");
@@ -63,7 +63,7 @@ public class TrellisConfigurationTest {
 
 
     @Test
-    public void testConfigurationAssets1() throws Exception {
+    void testConfigurationAssets1() throws Exception {
         final AppConfiguration config = new YamlConfigurationFactory<>(AppConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -74,7 +74,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationNotifications() throws Exception {
+    void testConfigurationNotifications() throws Exception {
         final AppConfiguration config = new YamlConfigurationFactory<>(AppConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -89,7 +89,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationLocations() throws Exception {
+    void testConfigurationLocations() throws Exception {
         final AppConfiguration config = new YamlConfigurationFactory<>(AppConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -105,7 +105,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationAuth1() throws Exception {
+    void testConfigurationAuth1() throws Exception {
         final AppConfiguration config = new YamlConfigurationFactory<>(AppConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -132,7 +132,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationNamespaces1() throws Exception {
+    void testConfigurationNamespaces1() throws Exception {
         final AppConfiguration config = new YamlConfigurationFactory<>(AppConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -141,7 +141,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationCORS1() throws Exception {
+    void testConfigurationCORS1() throws Exception {
         final AppConfiguration config = new YamlConfigurationFactory<>(AppConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));

--- a/components/app/src/test/java/org/trellisldp/app/CDIServiceBundlerTest.java
+++ b/components/app/src/test/java/org/trellisldp/app/CDIServiceBundlerTest.java
@@ -13,6 +13,7 @@
  */
 package org.trellisldp.app;
 
+import static java.util.stream.StreamSupport.stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 import javax.inject.Inject;
@@ -33,7 +34,7 @@ import org.trellisldp.io.NoopProfileCache;
 import org.trellisldp.rdfa.DefaultRdfaWriterService;
 
 @ExtendWith(WeldJunit5Extension.class)
-public class CDIServiceBundlerTest {
+class CDIServiceBundlerTest {
 
     @WeldSetup
     private WeldInitiator weld = WeldInitiator.of(WeldInitiator.createWeld()
@@ -61,46 +62,42 @@ public class CDIServiceBundlerTest {
     private ServiceBundler serviceBundler;
 
     @Test
-    public void testResourceService() {
+    void testResourceService() {
         assertNotNull(serviceBundler.getResourceService());
     }
 
     @Test
-    public void testBinaryService() {
+    void testBinaryService() {
         assertNotNull(serviceBundler.getBinaryService());
     }
 
     @Test
-    public void testAuditService() {
+    void testAuditService() {
         assertNotNull(serviceBundler.getAuditService());
     }
 
     @Test
-    public void testTimemapGenerator() {
+    void testTimemapGenerator() {
         assertNotNull(serviceBundler.getTimemapGenerator());
     }
 
     @Test
-    public void testIOService() {
+    void testIOService() {
         assertNotNull(serviceBundler.getIOService());
     }
 
     @Test
-    public void testConstraintServices() {
-        int counter = 0;
-        for (final ConstraintService c : serviceBundler.getConstraintServices()) {
-            counter++;
-        }
-        assertEquals(1, counter);
+    void testConstraintServices() {
+        assertEquals(1, stream(serviceBundler.getConstraintServices().spliterator(), false).count());
     }
 
     @Test
-    public void testMementoService() {
+    void testMementoService() {
         assertNotNull(serviceBundler.getMementoService());
     }
 
     @Test
-    public void testEventService() {
+    void testEventService() {
         assertNotNull(serviceBundler.getEventService());
     }
 }

--- a/components/app/src/test/java/org/trellisldp/app/DefaultConstraintServicesTest.java
+++ b/components/app/src/test/java/org/trellisldp/app/DefaultConstraintServicesTest.java
@@ -20,16 +20,16 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.trellisldp.constraint.LdpConstraintService;
 
-public class DefaultConstraintServicesTest {
+class DefaultConstraintServicesTest {
 
     @Test
-    public void testEmptyServices() {
+    void testEmptyServices() {
         final ConstraintServices svcs = new DefaultConstraintServices(emptyList());
         assertFalse(svcs.iterator().hasNext());
     }
 
     @Test
-    public void testSingleServices() {
+    void testSingleServices() {
         final ConstraintServices svcs = new DefaultConstraintServices(singletonList(new LdpConstraintService()));
         assertTrue(svcs.iterator().hasNext());
     }

--- a/components/audit/src/test/java/org/trellisldp/audit/DefaultAuditServiceTest.java
+++ b/components/audit/src/test/java/org/trellisldp/audit/DefaultAuditServiceTest.java
@@ -41,19 +41,18 @@ import org.trellisldp.vocabulary.XSD;
 /**
  * @author acoburn
  */
-public class DefaultAuditServiceTest {
+class DefaultAuditServiceTest {
 
-    private static RDF rdf = new SimpleRDF();
+    private static final RDF rdf = new SimpleRDF();
 
     private final Instant created = now();
-
     private final IRI subject = rdf.createIRI("trellis:data/resource");
 
     @Mock
     private Session mockSession;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockSession.getAgent()).thenReturn(Trellis.AnonymousAgent);
         when(mockSession.getCreated()).thenReturn(created);
@@ -61,7 +60,7 @@ public class DefaultAuditServiceTest {
     }
 
     @Test
-    public void testAuditCreation() {
+    void testAuditCreation() {
         final Dataset dataset = rdf.createDataset();
         final AuditService svc = new DefaultAuditService() {};
         svc.creation(subject, mockSession).forEach(dataset::add);
@@ -72,7 +71,7 @@ public class DefaultAuditServiceTest {
     }
 
     @Test
-    public void testAuditDeletion() {
+    void testAuditDeletion() {
         final Dataset dataset = rdf.createDataset();
         final AuditService svc = new DefaultAuditService() {};
         svc.deletion(subject, mockSession).forEach(dataset::add);
@@ -83,7 +82,7 @@ public class DefaultAuditServiceTest {
     }
 
     @Test
-    public void testAuditUpdate() {
+    void testAuditUpdate() {
         final Dataset dataset = rdf.createDataset();
         final AuditService svc = new DefaultAuditService() {};
         svc.update(subject, mockSession).forEach(dataset::add);

--- a/components/constraint-rules/src/test/java/org/trellisldp/constraint/LdpConstraintServiceTest.java
+++ b/components/constraint-rules/src/test/java/org/trellisldp/constraint/LdpConstraintServiceTest.java
@@ -19,7 +19,6 @@ import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.riot.Lang.TURTLE;
 import static org.apache.jena.riot.RDFDataMgr.read;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.trellisldp.vocabulary.RDF.type;
 
 import java.util.List;
 import java.util.Optional;
@@ -39,7 +38,7 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * @author acoburn
  */
-public class LdpConstraintServiceTest {
+class LdpConstraintServiceTest {
 
     private static final JenaRDF rdf = new JenaRDF();
 
@@ -49,13 +48,13 @@ public class LdpConstraintServiceTest {
             LDP.DirectContainer, LDP.IndirectContainer);
 
     @Test
-    public void testInvalidAccessControlProperty() {
+    void testInvalidAccessControlProperty() {
         assertTrue(models.stream()
                 .map(type -> svc.constrainedBy(type, asGraph("/hasAccessControlTriples.ttl", domain + "foo"), domain)
                     .anyMatch(v -> v.getConstraint().equals(Trellis.InvalidProperty)))
                 .reduce(true, (acc, x) -> acc && x), "InvalidProperty constraint not found!");
 
-        models.stream().forEach(type -> {
+        models.forEach(type -> {
             final String subject = domain + "foo";
             final Optional<ConstraintViolation> res = svc.constrainedBy(type,
                     asGraph("/hasAccessControlTriples.ttl", subject), domain)
@@ -71,13 +70,13 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testInvalidContainsProperty() {
+    void testInvalidContainsProperty() {
         assertTrue(models.stream()
                 .map(type -> svc.constrainedBy(type, asGraph("/hasLdpContainsTriples.ttl", domain + "foo"), domain)
                     .anyMatch(v -> v.getConstraint().equals(Trellis.InvalidProperty)))
                 .reduce(true, (acc, x) -> acc && x), "InvalidProperty constring not found!");
 
-        models.stream().forEach(type -> {
+        models.forEach(type -> {
             final String subject = domain + "foo";
             final Optional<ConstraintViolation> res = svc.constrainedBy(type,
                     asGraph("/hasLdpContainsTriples.ttl", subject), domain)
@@ -93,7 +92,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testInvalidInsertedContentRelation() {
+    void testInvalidInsertedContentRelation() {
         final List<IRI> found = models.stream()
             .filter(type -> svc.constrainedBy(type, asGraph("/hasInsertedContent.ttl", domain + "foo"), domain)
                     .findFirst().isPresent())
@@ -103,7 +102,7 @@ public class LdpConstraintServiceTest {
         assertFalse(found.contains(LDP.DirectContainer), "ldp:DirectContainer not expected!");
         assertFalse(found.contains(LDP.IndirectContainer), "ldp:IndirectContainer not expected!");
 
-        models.stream().forEach(type -> {
+        models.forEach(type -> {
             final String subject = domain + "foo";
             final Optional<ConstraintViolation> res = svc.constrainedBy(type, asGraph("/hasInsertedContent.ttl",
                         subject), domain).findFirst();
@@ -122,7 +121,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testInvalidLdpProps() {
+    void testInvalidLdpProps() {
         final List<IRI> found = models.stream()
             .filter(type -> svc.constrainedBy(type, asGraph("/basicContainer.ttl", domain + "foo"), domain)
                     .findFirst().isPresent())
@@ -132,7 +131,7 @@ public class LdpConstraintServiceTest {
         assertFalse(found.contains(LDP.DirectContainer), "ldp:DirectContainer not expected!");
         assertFalse(found.contains(LDP.IndirectContainer), "ldp:IndirectContainer not expected!");
 
-        models.stream().forEach(type -> {
+        models.forEach(type -> {
             final String subject = domain + "foo";
             final Optional<ConstraintViolation> res = svc.constrainedBy(type, asGraph("/basicContainer.ttl",
                         subject), domain).findFirst();
@@ -151,7 +150,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testLdpType() {
+    void testLdpType() {
         assertFalse(models.stream().map(ldpType ->
             svc.constrainedBy(ldpType, asGraph("/withLdpType.ttl", domain + "foo"), domain).anyMatch(v ->
                         Trellis.InvalidType.equals(v.getConstraint())))
@@ -159,13 +158,13 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testInvalidDomain() {
+    void testInvalidDomain() {
         assertEquals(0L, models.stream()
                 .filter(type -> !svc.constrainedBy(type, asGraph("/invalidDomain.ttl", domain + "foo"), domain)
                     .findAny().isPresent())
                 .count(), "Unexpected InvalidDomain violation!");
 
-        models.stream().forEach(type -> {
+        models.forEach(type -> {
             final String subject = domain + "foo";
             final List<ConstraintViolation> res = svc.constrainedBy(type, asGraph("/invalidDomain.ttl",
                         subject), domain).collect(toList());
@@ -188,7 +187,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testInvalidInbox() {
+    void testInvalidInbox() {
         final Optional<ConstraintViolation> res = svc.constrainedBy(LDP.RDFSource,
                 asGraph("/invalidInbox.ttl", domain + "foo"), domain).findFirst();
         assertTrue(res.isPresent(), "no constraint violation found!");
@@ -201,7 +200,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testBasicConstraints1() {
+    void testBasicConstraints1() {
         final Optional<ConstraintViolation> res = svc.constrainedBy(LDP.Container,
                 asGraph("/invalidContainer1.ttl", domain + "foo"), domain).findFirst();
         assertTrue(res.isPresent(), "no constraint violation found!");
@@ -214,7 +213,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testBasicConstraints2() {
+    void testBasicConstraints2() {
         final Optional<ConstraintViolation> res = svc.constrainedBy(LDP.Container,
                 asGraph("/invalidContainer2.ttl", domain + "foo"), domain).findFirst();
         assertTrue(res.isPresent(), "no constraint violation found!");
@@ -227,7 +226,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testBasicConstraints3() {
+    void testBasicConstraints3() {
         final Optional<ConstraintViolation> res = svc.constrainedBy(LDP.Container,
                 asGraph("/invalidContainer3.ttl", domain + "foo"), domain).findFirst();
         assertTrue(res.isPresent(), "no constraint violation found!");
@@ -240,7 +239,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testMembershipTriples1() {
+    void testMembershipTriples1() {
         final Optional<ConstraintViolation> res = svc.constrainedBy(LDP.IndirectContainer,
                 asGraph("/invalidMembershipTriple.ttl", domain + "foo"), domain)
             .filter(v -> v.getConstraint().equals(Trellis.InvalidRange)).findFirst();
@@ -253,7 +252,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testMembershipTriples2() {
+    void testMembershipTriples2() {
         final Optional<ConstraintViolation> res = svc.constrainedBy(LDP.DirectContainer,
                 asGraph("/invalidMembershipTriple2.ttl", domain + "foo"), domain).findFirst();
         assertTrue(res.isPresent(), "no constraint violation found!");
@@ -265,7 +264,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testCardinality() {
+    void testCardinality() {
         assertEquals(0L, models.stream()
                 .filter(type -> !svc.constrainedBy(type, asGraph("/invalidCardinality.ttl", domain + "foo"), domain)
                     .findFirst().isPresent())
@@ -282,7 +281,7 @@ public class LdpConstraintServiceTest {
     }
 
     @Test
-    public void testInvalidType2() {
+    void testInvalidType2() {
         final Optional<ConstraintViolation> res = svc.constrainedBy(LDP.RDFSource,
                 asGraph("/invalidType.ttl", domain + "foo"), domain)
             .filter(v -> v.getConstraint().equals(Trellis.InvalidRange)).findFirst();
@@ -293,7 +292,7 @@ public class LdpConstraintServiceTest {
 
 
     @Test
-    public void testTooManyMembershipTriples() {
+    void testTooManyMembershipTriples() {
         final Optional<ConstraintViolation> res = svc.constrainedBy(LDP.IndirectContainer,
                 asGraph("/tooManyMembershipTriples.ttl", domain + "foo"), domain).findFirst();
         assertTrue(res.isPresent(), "no constraint violation found!");

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/NoInitTrellisApplicationTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/NoInitTrellisApplicationTest.java
@@ -27,7 +27,7 @@ import org.trellisldp.dropwizard.config.TrellisConfiguration;
 /**
  * LDP-related tests for Trellis.
  */
-public class NoInitTrellisApplicationTest extends TrellisApplicationTest {
+class NoInitTrellisApplicationTest extends TrellisApplicationTest {
 
     private static final DropwizardTestSupport<TrellisConfiguration> APP
         = new DropwizardTestSupport<TrellisConfiguration>(SimpleNoInitTrellisApp.class,

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleServiceBundler.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleServiceBundler.java
@@ -38,10 +38,11 @@ import org.trellisldp.triplestore.TriplestoreResourceService;
  */
 public class SimpleServiceBundler extends BaseServiceBundler {
 
-    private final TriplestoreResourceService triplestoreService
-        = new TriplestoreResourceService(connect(createTxnMem()));
-
-    public SimpleServiceBundler() {
+    SimpleServiceBundler() {
+        final TriplestoreResourceService triplestoreService
+                = new TriplestoreResourceService(connect(createTxnMem()));
+        triplestoreService.initialize();
+        resourceService = triplestoreService;
         auditService = new DefaultAuditService();
         mementoService = new NoopMementoService();
         eventService = new NoopEventService();
@@ -51,8 +52,5 @@ public class SimpleServiceBundler extends BaseServiceBundler {
                 emptySet(), emptySet());
         binaryService = new FileBinaryService(new DefaultIdentifierService(),
                 resourceFilePath("data") + "/binaries", 2, 2);
-
-        triplestoreService.initialize();
-        resourceService = triplestoreService;
     }
 }

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisApplicationTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisApplicationTest.java
@@ -41,10 +41,10 @@ import org.trellisldp.vocabulary.LDP;
 /**
  * LDP-related tests for Trellis.
  */
-public class TrellisApplicationTest {
+class TrellisApplicationTest {
 
     private static final DropwizardTestSupport<TrellisConfiguration> APP
-        = new DropwizardTestSupport<TrellisConfiguration>(SimpleTrellisApp.class,
+        = new DropwizardTestSupport<>(SimpleTrellisApp.class,
                 resourceFilePath("trellis-config.yml"));
 
     private static final Client CLIENT;
@@ -57,13 +57,13 @@ public class TrellisApplicationTest {
     }
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         final Application<TrellisConfiguration> app = new SimpleTrellisApp();
         assertEquals("Trellis LDP", app.getName(), "Incorrect application name!");
     }
 
     @Test
-    public void testGET() {
+    void testGET() {
         final String baseUrl = "http://localhost:" + APP.getLocalPort();
         try (final Response res = CLIENT.target(baseUrl).request().get()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Incorrect response family!");
@@ -75,7 +75,7 @@ public class TrellisApplicationTest {
     }
 
     @Test
-    public void testPOST() {
+    void testPOST() {
         final String baseUrl = "http://localhost:" + APP.getLocalPort();
         try (final Response res = CLIENT.target(baseUrl).request().post(entity("", TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Incorrect response family!");

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisCacheTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisCacheTest.java
@@ -15,7 +15,6 @@ package org.trellisldp.dropwizard;
 
 import static com.google.common.cache.CacheBuilder.newBuilder;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -30,25 +29,25 @@ import org.mockito.Mock;
 /**
  * @author acoburn
  */
-public class TrellisCacheTest {
+class TrellisCacheTest {
 
     @Mock
     private Cache<String, String> mockCache;
 
     @BeforeEach
-    public void setUp() throws ExecutionException {
+    void setUp() throws ExecutionException {
         initMocks(this);
         when(mockCache.get(any(), any())).thenThrow(ExecutionException.class);
     }
 
     @Test
-    public void testCache() {
+    void testCache() {
         final TrellisCache<String, String> cache = new TrellisCache<>(newBuilder().maximumSize(5).build());
         assertEquals("longer", cache.get("long", x -> x + "er"), "Incorrect cache response!");
     }
 
     @Test
-    public void testCacheException() throws Exception {
+    void testCacheException() {
         final TrellisCache<String, String> cache = new TrellisCache<>(mockCache);
         assertNull(cache.get("long", x -> x + "er"), "Exception wasn't swallowed!");
     }

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisUtilsTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisUtilsTest.java
@@ -42,7 +42,7 @@ import org.trellisldp.dropwizard.config.TrellisConfiguration;
 /**
  * @author acoburn
  */
-public class TrellisUtilsTest {
+class TrellisUtilsTest {
 
     @Mock
     private Environment mockEnv;
@@ -51,13 +51,13 @@ public class TrellisUtilsTest {
     private LifecycleEnvironment mockLifecycle;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockEnv.lifecycle()).thenReturn(mockLifecycle);
     }
 
     @Test
-    public void testGetCORSConfig() throws Exception {
+    void testGetCORSConfig() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -71,7 +71,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetWebacCache() throws Exception {
+    void testGetWebacCache() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -84,7 +84,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetAuthFilters() throws Exception {
+    void testGetAuthFilters() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -101,7 +101,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetJwksAuthenticator() throws Exception {
+    void testGetJwksAuthenticator() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -110,7 +110,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetJwtAuthenticator() throws Exception {
+    void testGetJwtAuthenticator() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -121,7 +121,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetJwtAuthenticatorNoKeyIds() throws Exception {
+    void testGetJwtAuthenticatorNoKeyIds() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -133,7 +133,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetJwtAuthenticatorFederated() throws Exception {
+    void testGetJwtAuthenticatorFederated() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -145,7 +145,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetJwtAuthenticatorBadKeystore() throws Exception {
+    void testGetJwtAuthenticatorBadKeystore() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -156,7 +156,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetJwtAuthenticatorNoKeystore() throws Exception {
+    void testGetJwtAuthenticatorNoKeystore() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -168,7 +168,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetNoJwtAuthenticator() throws Exception {
+    void testGetNoJwtAuthenticator() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/config/TrellisConfigurationTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/config/TrellisConfigurationTest.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class TrellisConfigurationTest {
+class TrellisConfigurationTest {
 
     @Test
-    public void testConfigurationGeneral1() throws Exception {
+    void testConfigurationGeneral1() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -60,7 +60,7 @@ public class TrellisConfigurationTest {
 
         // Other tests
         assertEquals("my.cluster.address", config.any().get("cassandraAddress"), "Incorrect custom property!");
-        assertEquals((Integer)245994, config.any().get("cassandraPort"), "Incorrect custom Integer property!");
+        assertEquals(245994, config.any().get("cassandraPort"), "Incorrect custom Integer property!");
         @SuppressWarnings("unchecked")
         final Map<String, Object> extraConfig = (Map<String, Object>) config.any().get("extraConfigValues");
         assertTrue((Boolean) extraConfig.get("first"), "Incorrect boolean nested custom properties!");
@@ -71,7 +71,7 @@ public class TrellisConfigurationTest {
 
 
     @Test
-    public void testConfigurationAssets1() throws Exception {
+    void testConfigurationAssets1() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -82,7 +82,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationNotifications() throws Exception {
+    void testConfigurationNotifications() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -97,7 +97,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationLocations() throws Exception {
+    void testConfigurationLocations() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -107,7 +107,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationAuth1() throws Exception {
+    void testConfigurationAuth1() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));
@@ -136,7 +136,7 @@ public class TrellisConfigurationTest {
     }
 
     @Test
-    public void testConfigurationCORS1() throws Exception {
+    void testConfigurationCORS1() throws Exception {
         final TrellisConfiguration config = new YamlConfigurationFactory<>(TrellisConfiguration.class,
                 Validators.newValidator(), Jackson.newMinimalObjectMapper(), "")
             .build(new File(getClass().getResource("/config1.yml").toURI()));

--- a/components/event-serialization/src/test/java/org/trellisldp/event/DefaultActivityStreamServiceTest.java
+++ b/components/event-serialization/src/test/java/org/trellisldp/event/DefaultActivityStreamServiceTest.java
@@ -46,7 +46,7 @@ import org.trellisldp.vocabulary.AS;
 /**
  * @author acoburn
  */
-public class DefaultActivityStreamServiceTest {
+class DefaultActivityStreamServiceTest {
 
     private static final RDF rdf = new SimpleRDF();
 
@@ -58,7 +58,7 @@ public class DefaultActivityStreamServiceTest {
     private Event mockEvent;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockEvent.getIdentifier()).thenReturn(rdf.createIRI("info:event/12345"));
         when(mockEvent.getAgents()).thenReturn(singleton(rdf.createIRI("info:user/test")));
@@ -70,14 +70,14 @@ public class DefaultActivityStreamServiceTest {
     }
 
     @Test
-    public void testSerialization() {
+    void testSerialization() {
         final Optional<String> json = svc.serialize(mockEvent);
         assertTrue(json.isPresent(), "Serialization not present!");
         assertTrue(json.get().contains("\"inbox\":\"info:ldn/inbox\""), "ldp:inbox not in serialization!");
     }
 
     @Test
-    public void testError() {
+    void testError() {
         when(mockEvent.getIdentifier()).thenAnswer(inv -> {
             sneakyJsonException();
             return rdf.createIRI("info:event/12456");
@@ -88,7 +88,7 @@ public class DefaultActivityStreamServiceTest {
     }
 
     @Test
-    public void testSerializationStructure() throws Exception {
+    void testSerializationStructure() throws Exception {
         when(mockEvent.getTypes()).thenReturn(asList(Create, Activity));
 
         final Optional<String> json = svc.serialize(mockEvent);
@@ -114,13 +114,13 @@ public class DefaultActivityStreamServiceTest {
         final List<?> actor = (List<?>) map.get("actor");
         assertTrue(actor.contains("info:user/test"), "actor property has incorrect value!");
 
-        assertTrue(map.get("id").equals("info:event/12345"), "id property has incorrect value!");
-        assertTrue(map.get("inbox").equals("info:ldn/inbox"), "inbox property has incorrect value!");
-        assertTrue(map.get("published").equals(time.toString()), "published property has incorrect value!");
+        assertEquals("info:event/12345", map.get("id"), "id property has incorrect value!");
+        assertEquals("info:ldn/inbox", map.get("inbox"), "inbox property has incorrect value!");
+        assertEquals(time.toString(), map.get("published"), "published property has incorrect value!");
     }
 
     @Test
-    public void testSerializationStructureNoEmptyElements() throws Exception {
+    void testSerializationStructureNoEmptyElements() throws Exception {
         when(mockEvent.getInbox()).thenReturn(empty());
         when(mockEvent.getAgents()).thenReturn(emptyList());
         when(mockEvent.getTargetTypes()).thenReturn(emptyList());
@@ -149,8 +149,8 @@ public class DefaultActivityStreamServiceTest {
 
         assertTrue(AS.getNamespace().contains((String) map.get("@context")), "AS namespace not in @context!");
 
-        assertTrue(map.get("id").equals("info:event/12345"), "id property has incorrect value!");
-        assertTrue(map.get("published").equals(time.toString()), "published property has incorrect value!");
+        assertEquals("info:event/12345", map.get("id"), "id property has incorrect value!");
+        assertEquals(time.toString(), map.get("published"), "published property has incorrect value!");
     }
 
     @SuppressWarnings("unchecked")

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -39,7 +39,7 @@ import org.trellisldp.api.BinaryService;
 /**
  * Test the file-based binary service.
  */
-public class FileBinaryServiceTest {
+class FileBinaryServiceTest {
 
     private static final String testDoc = "test.txt";
 
@@ -51,17 +51,17 @@ public class FileBinaryServiceTest {
     private static final IRI file = rdf.createIRI("file:///" + testDoc);
 
     @BeforeAll
-    public static void setUpEverything() {
+    static void setUpEverything() {
         System.setProperty(FileBinaryService.CONFIG_FILE_BINARY_BASE_PATH, directory);
     }
 
     @AfterAll
-    public static void cleanUp() {
+    static void cleanUp() {
         System.clearProperty(FileBinaryService.CONFIG_FILE_BINARY_BASE_PATH);
     }
 
     @Test
-    public void testFilePurge() {
+    void testFilePurge() {
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         final InputStream inputStream = new ByteArrayInputStream("Some data".getBytes(UTF_8));
@@ -76,14 +76,14 @@ public class FileBinaryServiceTest {
     }
 
     @Test
-    public void testIdSupplier() {
+    void testIdSupplier() {
         final BinaryService service = new FileBinaryService();
         assertTrue(service.generateIdentifier().startsWith("file:///"), "Identifier has incorrect prefix!");
         assertNotEquals(service.generateIdentifier(), service.generateIdentifier(), "Identifiers are not unique!");
     }
 
     @Test
-    public void testFileContent() {
+    void testFileContent() {
         final BinaryService service = new FileBinaryService();
         assertEquals("A test document.\n",
                         service.get(file).thenApply(Binary::getContent).thenApply(this::uncheckedToString)
@@ -92,7 +92,7 @@ public class FileBinaryServiceTest {
     }
 
     @Test
-    public void testFileContentSegment() {
+    void testFileContentSegment() {
         final BinaryService service = new FileBinaryService();
         assertEquals(" tes",
                         service.get(file).thenApply(b -> b.getContent(1, 5)).thenApply(this::uncheckedToString)
@@ -103,14 +103,14 @@ public class FileBinaryServiceTest {
     }
 
     @Test
-    public void testFileContentSegmentBeyond() {
+    void testFileContentSegmentBeyond() {
         final BinaryService service = new FileBinaryService();
         assertEquals("", service.get(file).thenApply(b -> b.getContent(1000, 1005)).thenApply(this::uncheckedToString)
                         .toCompletableFuture().join(), "Incorrect out-of-range segment when fetching from a file!");
     }
 
     @Test
-    public void testSetFileContent() {
+    void testSetFileContent() {
         final String contents = "A new file";
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
@@ -123,7 +123,7 @@ public class FileBinaryServiceTest {
     }
 
     @Test
-    public void testGetFileContentError() throws IOException {
+    void testGetFileContentError() {
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         assertThrows(CompletionException.class, () -> service.get(fileIRI).thenApply(Binary::getContent)
@@ -134,7 +134,7 @@ public class FileBinaryServiceTest {
     }
 
     @Test
-    public void testSetFileContentError() throws Exception {
+    void testSetFileContentError() {
         final InputStream throwingMockInputStream = mock(InputStream.class, inv -> {
                 throw new IOException("Expected error");
         });
@@ -148,7 +148,7 @@ public class FileBinaryServiceTest {
     }
 
     @Test
-    public void testGetFileSkipContentError() throws Exception {
+    void testGetFileSkipContentError() {
         final BinaryService service = new FileBinaryService();
         final IRI fileIRI = rdf.createIRI("file:///" + randomFilename());
         assertAll(() -> service.get(fileIRI).thenApply(binary -> binary.getContent(10, 20)).handle((val, err) -> {
@@ -158,7 +158,7 @@ public class FileBinaryServiceTest {
     }
 
     @Test
-    public void testBadIdentifier() {
+    void testBadIdentifier() {
         final BinaryService service = new FileBinaryService();
         assertFalse(service.get(rdf.createIRI("http://example.com/")).thenApply(Binary::getContent)
                         .handle(this::checkError).toCompletableFuture().join(),

--- a/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
@@ -46,12 +46,12 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * Test a file-based memento service.
  */
-public class FileMementoServiceTest {
+class FileMementoServiceTest {
 
     private static final RDF rdf = new JenaRDF();
 
     @AfterAll
-    public static void cleanUp() throws IOException {
+    static void cleanUp() throws IOException {
         final File dir = new File(FileMementoServiceTest.class.getResource("/versions").getFile()).getParentFile();
         final File vDir = new File(dir, "versions2");
         if (vDir.exists()) {
@@ -60,7 +60,7 @@ public class FileMementoServiceTest {
     }
 
     @Test
-    public void testPutThenDelete() throws Exception {
+    void testPutThenDelete() {
         final File dir = new File(getClass().getResource("/versions").getFile());
         final FileMementoService svc = new FileMementoService(dir.getAbsolutePath());
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "another-resource");
@@ -98,7 +98,7 @@ public class FileMementoServiceTest {
 
 
     @Test
-    public void testList() {
+    void testList() {
         final Instant time = parse("2017-02-16T11:15:01Z");
         final Instant time2 = parse("2017-02-16T11:15:11Z");
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
@@ -130,7 +130,7 @@ public class FileMementoServiceTest {
     }
 
     @Test
-    public void testPutBinary() {
+    void testPutBinary() {
         final File dir = new File(getClass().getResource("/versions").getFile());
         final MementoService svc = new FileMementoService(dir.getAbsolutePath());
         final IRI identifier = rdf.createIRI("trellis:data/a-binary");
@@ -175,7 +175,7 @@ public class FileMementoServiceTest {
     }
 
     @Test
-    public void testPutIndirectContainer() {
+    void testPutIndirectContainer() {
         final File dir = new File(getClass().getResource("/versions").getFile());
         final MementoService svc = new FileMementoService(dir.getAbsolutePath());
         final IRI identifier = rdf.createIRI("trellis:data/a-resource");
@@ -214,7 +214,7 @@ public class FileMementoServiceTest {
     }
 
     @Test
-    public void testListNonExistent() {
+    void testListNonExistent() {
         final File dir = new File(getClass().getResource("/versions").getFile());
 
         try {
@@ -235,7 +235,7 @@ public class FileMementoServiceTest {
     }
 
     @Test
-    public void testListNone() {
+    void testListNone() {
         final File dir = new File(getClass().getResource("/versions").getFile());
 
         try {
@@ -256,7 +256,7 @@ public class FileMementoServiceTest {
     }
 
     @Test
-    public void testNewVersionSystem() {
+    void testNewVersionSystem() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final File dir = new File(getClass().getResource("/versions").getFile()).getParentFile();
         assertTrue(dir.exists(), "Resource directory doesn't exist!");

--- a/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
@@ -32,12 +32,12 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * Test a file-based resource.
  */
-public class FileResourceTest {
+class FileResourceTest {
 
     private static final RDF rdf = new JenaRDF();
 
     @Test
-    public void testResource() {
+    void testResource() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final File file = new File(getClass().getResource("/resource.nq").getFile());
         assertTrue(file.exists(), "Resource file doesn't exist!");
@@ -60,7 +60,7 @@ public class FileResourceTest {
     }
 
     @Test
-    public void testBinary() {
+    void testBinary() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "binary");
         final File file = new File(getClass().getResource("/binary.nq").getFile());
         assertTrue(file.exists(), "Resource file doesn't exist!");
@@ -87,7 +87,7 @@ public class FileResourceTest {
     }
 
     @Test
-    public void testInvalidFile() {
+    void testInvalidFile() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final File dir = new File(getClass().getResource("/resource.nq").getFile()).getParentFile();
         final File file = new File(dir, "nonexistent");
@@ -99,7 +99,7 @@ public class FileResourceTest {
     }
 
     @Test
-    public void testIndirectContainer() {
+    void testIndirectContainer() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final File file = new File(getClass().getResource("/ldpic.nq").getFile());
         assertTrue(file.exists(), "Resource file doesn't exist!");
@@ -126,7 +126,7 @@ public class FileResourceTest {
     }
 
     @Test
-    public void testDirectContainer() {
+    void testDirectContainer() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final File file = new File(getClass().getResource("/ldpdc.nq").getFile());
         assertTrue(file.exists(), "Resource file doesn't exist!");

--- a/components/file/src/test/java/org/trellisldp/file/FileUtilsTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileUtilsTest.java
@@ -38,12 +38,12 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * Test the file utilities.
  */
-public class FileUtilsTest {
+class FileUtilsTest {
 
     private static final RDF rdf = new JenaRDF();
 
     @Test
-    public void testParseQuad() {
+    void testParseQuad() {
         final Optional<Quad> quad = FileUtils.parseQuad(
                 "<trellis:data/resource> <http://purl.org/dc/terms/title> "
                 + "\"Some title\" <http://www.trellisldp.org/ns/trellis#PreferUserManaged> .").findFirst();
@@ -58,7 +58,7 @@ public class FileUtilsTest {
     }
 
     @Test
-    public void testParseQuadWithComment() {
+    void testParseQuadWithComment() {
         final Optional<Quad> quad = FileUtils.parseQuad(
                 "<trellis:data/resource> <http://purl.org/dc/terms/description> "
                 + "\"A description\" <http://www.trellisldp.org/ns/trellis#PreferUserManaged> . # some comment")
@@ -74,7 +74,7 @@ public class FileUtilsTest {
     }
 
     @Test
-    public void testParseQuadNoGraph() {
+    void testParseQuadNoGraph() {
         final Optional<Quad> quad = FileUtils.parseQuad(
                 "<trellis:data/resource> <http://purl.org/dc/terms/title> "
                 + "\"A different title\" .").findFirst();
@@ -88,12 +88,12 @@ public class FileUtilsTest {
     }
 
     @Test
-    public void testParseBadQuad() {
+    void testParseBadQuad() {
         assertFalse(FileUtils.parseQuad("blah blah blah").findFirst().isPresent(), "Invalid quad shouldn't parse!");
     }
 
     @Test
-    public void testSerializeQuad() {
+    void testSerializeQuad() {
         final Quad quad = rdf.createQuad(Trellis.PreferServerManaged, rdf.createIRI("trellis:data/resource"),
                 DC.subject, rdf.createIRI("http://example.org"));
         assertEquals("<trellis:data/resource> <http://purl.org/dc/terms/subject> <http://example.org> "
@@ -102,7 +102,7 @@ public class FileUtilsTest {
     }
 
     @Test
-    public void testSerializeQuadDefaultGraph() {
+    void testSerializeQuadDefaultGraph() {
         final Quad quad = rdf.createQuad(null, rdf.createIRI("trellis:data/resource"),
                 DC.subject, rdf.createIRI("http://example.org"));
         assertEquals("<trellis:data/resource> <http://purl.org/dc/terms/subject> <http://example.org> .",
@@ -111,14 +111,14 @@ public class FileUtilsTest {
     }
 
     @Test
-    public void testListFilesBadDirectory() {
+    void testListFilesBadDirectory() {
         final File file = new File(getClass().getResource("/resource.nq").getFile());
         final File dir = new File(file.getParentFile(), "nonexistent");
         assertThrows(UncheckedIOException.class, () -> FileUtils.uncheckedList(dir.toPath()));
     }
 
     @Test
-    public void testBadBoundedStream() throws IOException {
+    void testBadBoundedStream() {
         final InputStream badInput = mock(InputStream.class, inv -> {
                 throw new IOException("Expected exception");
             });
@@ -126,7 +126,7 @@ public class FileUtilsTest {
     }
 
     @Test
-    public void testDeleteException() throws IOException {
+    void testDeleteException() {
         final Path badPath = mock(Path.class, inv -> {
                 throw new IOException("Expected exception");
             });
@@ -134,7 +134,7 @@ public class FileUtilsTest {
     }
 
     @Test
-    public void testWriteMementoBadDirectory() {
+    void testWriteMementoBadDirectory() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         final File file = new File(getClass().getResource("/resource.nq").getFile());
         final Resource res = new FileResource(identifier, file);

--- a/components/io-jena/src/test/java/org/trellisldp/io/JenaIOServiceTest.java
+++ b/components/io-jena/src/test/java/org/trellisldp/io/JenaIOServiceTest.java
@@ -33,7 +33,6 @@ import static org.apache.jena.vocabulary.DCTerms.title;
 import static org.apache.jena.vocabulary.DCTypes.Text;
 import static org.apache.jena.vocabulary.RDF.Nodes.type;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Syntax.LD_PATCH;
@@ -78,7 +77,7 @@ import org.trellisldp.api.RuntimeTrellisException;
 /**
  * @author acoburn
  */
-public class JenaIOServiceTest {
+class JenaIOServiceTest {
 
     private static final JenaRDF rdf = new JenaRDF();
     private IOService service, service2, service3;
@@ -103,7 +102,7 @@ public class JenaIOServiceTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         final Map<String, String> namespaces = new HashMap<>();
         namespaces.put("dcterms", DCTerms.NS);
@@ -126,7 +125,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdDefaultSerializer() throws UnsupportedEncodingException {
+    void testJsonLdDefaultSerializer() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service3.write(getTriples(), out, JSONLD);
         final String output = out.toString("UTF-8");
@@ -136,7 +135,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdExpandedSerializer() throws UnsupportedEncodingException {
+    void testJsonLdExpandedSerializer() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, expanded);
         final String output = out.toString("UTF-8");
@@ -146,7 +145,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdExpandedFlatSerializer() throws UnsupportedEncodingException {
+    void testJsonLdExpandedFlatSerializer() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, expanded, flattened);
         final String output = out.toString("UTF-8");
@@ -156,7 +155,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdCustomSerializer() throws UnsupportedEncodingException {
+    void testJsonLdCustomSerializer() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, rdf.createIRI("http://www.w3.org/ns/anno.jsonld"));
         final String output = out.toString("UTF-8");
@@ -172,7 +171,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdCustomSerializerNoopCache() throws UnsupportedEncodingException {
+    void testJsonLdCustomSerializerNoopCache() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final IOService svc = new JenaIOService(mockNamespaceService, null, new NoopProfileCache(),
                 "http://www.w3.org/ns/anno.jsonld,,,", "http://www.trellisldp.org/ns/");
@@ -186,7 +185,7 @@ public class JenaIOServiceTest {
 
 
     @Test
-    public void testJsonLdCustomSerializer2() throws UnsupportedEncodingException {
+    void testJsonLdCustomSerializer2() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service2.write(getTriples(), out, JSONLD, rdf.createIRI("http://www.w3.org/ns/anno.jsonld"));
         final String output = out.toString("UTF-8");
@@ -202,7 +201,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdCustomUnrecognizedSerializer() throws UnsupportedEncodingException {
+    void testJsonLdCustomUnrecognizedSerializer() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, rdf.createIRI("http://www.example.org/context.jsonld"));
         final String output = out.toString("UTF-8");
@@ -212,7 +211,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdNullCache() throws UnsupportedEncodingException {
+    void testJsonLdNullCache() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final IOService myservice = new JenaIOService();
         myservice.write(getTriples(), out, JSONLD, rdf.createIRI("http://www.w3.org/ns/anno.jsonld"));
@@ -223,7 +222,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdCustomUnrecognizedSerializer2() throws UnsupportedEncodingException {
+    void testJsonLdCustomUnrecognizedSerializer2() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service2.write(getTriples(), out, JSONLD, rdf.createIRI("http://www.example.org/context.jsonld"));
         final String output = out.toString("UTF-8");
@@ -233,7 +232,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdCustomUnrecognizedSerializer3() throws UnsupportedEncodingException {
+    void testJsonLdCustomUnrecognizedSerializer3() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, rdf.createIRI("http://www.trellisldp.org/ns/nonexistent.jsonld"));
         final String output = out.toString("UTF-8");
@@ -243,7 +242,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdCompactedSerializer() throws UnsupportedEncodingException {
+    void testJsonLdCompactedSerializer() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, compacted);
         final String output = out.toString("UTF-8");
@@ -253,7 +252,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdFlattenedSerializer() throws UnsupportedEncodingException {
+    void testJsonLdFlattenedSerializer() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, flattened);
         final String output = out.toString("UTF-8");
@@ -263,7 +262,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdFlattenedSerializer2() throws UnsupportedEncodingException {
+    void testJsonLdFlattenedSerializer2() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, compacted_flattened);
         final String output = out.toString("UTF-8");
@@ -273,7 +272,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdFlattenedSerializer3() throws UnsupportedEncodingException {
+    void testJsonLdFlattenedSerializer3() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, expanded_flattened);
         final String output = out.toString("UTF-8");
@@ -283,7 +282,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testJsonLdFlattenedSerializer4() throws UnsupportedEncodingException {
+    void testJsonLdFlattenedSerializer4() throws UnsupportedEncodingException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, JSONLD, compacted, flattened);
         final String output = out.toString("UTF-8");
@@ -293,14 +292,14 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testMalformedInput() {
+    void testMalformedInput() {
         final ByteArrayInputStream in = new ByteArrayInputStream("<> <ex:test> a Literal\" . ".getBytes(UTF_8));
         assertThrows(RuntimeTrellisException.class, () ->
                 service.read(in, TURTLE, null), "No exception on malformed input!");
     }
 
     @Test
-    public void testNTriplesSerializer() {
+    void testNTriplesSerializer() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service3.write(getTriples(), out, NTRIPLES);
         final ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
@@ -310,7 +309,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testBufferedSerializer() {
+    void testBufferedSerializer() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, RDFXML);
         final ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
@@ -320,7 +319,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testTurtleSerializer() {
+    void testTurtleSerializer() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, TURTLE);
         final ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
@@ -330,7 +329,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testTurtleReaderWithContext() {
+    void testTurtleReaderWithContext() {
         final Graph graph = rdf.createGraph();
         service.read(getClass().getResourceAsStream("/testRdf.ttl"), TURTLE, "trellis:data/resource")
             .forEach(graph::add);
@@ -338,7 +337,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testHtmlSerializer() throws Exception {
+    void testHtmlSerializer() {
         final IOService service4 = new JenaIOService(mockNamespaceService, mockRdfaWriterService);
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -347,7 +346,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testHtmlSerializer2() throws Exception {
+    void testHtmlSerializer2() {
         final IOService service4 = new JenaIOService(mockNamespaceService, mockRdfaWriterService);
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -356,7 +355,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testNullHtmlSerializer() {
+    void testNullHtmlSerializer() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, RDFA);
         final ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
@@ -366,7 +365,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testUpdateError() {
+    void testUpdateError() {
         final Graph graph = rdf.createGraph();
         getTriples().forEach(graph::add);
         assertEquals(3L, graph.size(), "Incorrect graph size!");
@@ -375,21 +374,21 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testReadError() throws IOException {
+    void testReadError() throws IOException {
         doThrow(new IOException()).when(mockInputStream).read(any(byte[].class), anyInt(), anyInt());
         assertThrows(RuntimeTrellisException.class, () -> service.read(mockInputStream, TURTLE, "context"),
                 "No read exception on bad input stream!");
     }
 
     @Test
-    public void testWriteError() throws IOException {
+    void testWriteError() throws IOException {
         doThrow(new IOException()).when(mockOutputStream).write(any(byte[].class), anyInt(), anyInt());
         assertThrows(RuntimeTrellisException.class, () -> service.write(getTriples(), mockOutputStream, TURTLE),
                 "No write exception on bad input stream!");
     }
 
     @Test
-    public void testUpdate() {
+    void testUpdate() {
         final Graph graph = rdf.createGraph();
         getTriples().forEach(graph::add);
         assertEquals(3L, graph.size(), "Incorrect graph size!");
@@ -408,7 +407,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testUpdateInvalidSyntax() {
+    void testUpdateInvalidSyntax() {
         final Graph graph = rdf.createGraph();
         getTriples().forEach(graph::add);
         final String patch = "UpdateList <#> <http://example.org/vocab#preferredLanguages> 1..2 ( \"fr\" ) .";
@@ -417,7 +416,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testWriteInvalidSyntax() {
+    void testWriteInvalidSyntax() {
         when(mockSyntax.mediaType()).thenReturn("fake/mediatype");
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -426,7 +425,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testReadInvalidSyntax() {
+    void testReadInvalidSyntax() {
         when(mockSyntax.mediaType()).thenReturn("fake/mediatype");
         final String output = "blah blah blah";
 
@@ -436,7 +435,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testReadSyntaxes() {
+    void testReadSyntaxes() {
         assertTrue(service.supportedReadSyntaxes().contains(TURTLE), "Turtle not supported for reading!");
         assertTrue(service.supportedReadSyntaxes().contains(JSONLD), "JSON-LD not supported for reading!");
         assertTrue(service.supportedReadSyntaxes().contains(NTRIPLES), "N-Triples not supported for reading!");
@@ -446,7 +445,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testWriteSyntaxes() {
+    void testWriteSyntaxes() {
         assertTrue(service.supportedWriteSyntaxes().contains(TURTLE), "Turtle not supported for writing!");
         assertTrue(service.supportedWriteSyntaxes().contains(JSONLD), "JSON-LD not supported for writing!");
         assertTrue(service.supportedWriteSyntaxes().contains(NTRIPLES), "N-Triples not supported for writing!");
@@ -456,7 +455,7 @@ public class JenaIOServiceTest {
     }
 
     @Test
-    public void testUpdateSyntaxes() {
+    void testUpdateSyntaxes() {
         assertTrue(service.supportedUpdateSyntaxes().contains(SPARQL_UPDATE), "SPARQL-Update not supported!");
         assertFalse(service.supportedUpdateSyntaxes().contains(LD_PATCH), "LD-PATCH unexpectedly supported!");
     }

--- a/components/io-jena/src/test/java/org/trellisldp/io/NoopProfileCacheTest.java
+++ b/components/io-jena/src/test/java/org/trellisldp/io/NoopProfileCacheTest.java
@@ -23,10 +23,10 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.trellisldp.api.CacheService;
 
-public class NoopProfileCacheTest {
+class NoopProfileCacheTest {
 
     @Test
-    public void testPassthroughCache() {
+    void testPassthroughCache() {
         final List<String> list = new CopyOnWriteArrayList<>();
         final Function<String, String> mapper = key -> {
             list.add(key);

--- a/components/namespaces/src/test/java/org/trellisldp/namespaces/JsonNamespaceServiceTest.java
+++ b/components/namespaces/src/test/java/org/trellisldp/namespaces/JsonNamespaceServiceTest.java
@@ -28,12 +28,12 @@ import org.trellisldp.vocabulary.JSONLD;
 /**
  * @author acoburn
  */
-public class JsonNamespaceServiceTest {
+class JsonNamespaceServiceTest {
 
     private static final String nsDoc = "/testNamespaces.json";
 
     @Test
-    public void testReadFromJson() {
+    void testReadFromJson() {
         final URL res = JsonNamespaceService.class.getResource(nsDoc);
         try {
             System.setProperty(JsonNamespaceService.CONFIG_NAMESPACES_PATH, res.getPath());
@@ -45,7 +45,7 @@ public class JsonNamespaceServiceTest {
     }
 
     @Test
-    public void testReadError() {
+    void testReadError() {
         final URL res = JsonNamespaceService.class.getResource("/thisIsNot.json");
         try {
             System.setProperty(JsonNamespaceService.CONFIG_NAMESPACES_PATH, res.getPath());
@@ -57,7 +57,7 @@ public class JsonNamespaceServiceTest {
     }
 
     @Test
-    public void testWriteError() {
+    void testWriteError() {
         final File file = new File(getClass().getResource(nsDoc).getFile());
         final File nonexistent = new File(file.getParentFile(), "nonexistent/dir/file.json");
         assertThrows(UncheckedIOException.class, () -> new JsonNamespaceService(nonexistent.getAbsolutePath()),
@@ -65,7 +65,7 @@ public class JsonNamespaceServiceTest {
     }
 
     @Test
-    public void testWriteToJson() {
+    void testWriteToJson() {
         final File file = new File(JsonNamespaceService.class.getResource(nsDoc).getPath());
         final String filename = file.getParent() + "/" + randomFilename();
 

--- a/components/rdfa/src/test/java/org/trellisldp/rdfa/DefaultRdfaWriterServiceTest.java
+++ b/components/rdfa/src/test/java/org/trellisldp/rdfa/DefaultRdfaWriterServiceTest.java
@@ -25,7 +25,6 @@ import static org.apache.jena.vocabulary.DCTerms.title;
 import static org.apache.jena.vocabulary.DCTypes.Text;
 import static org.apache.jena.vocabulary.RDF.Nodes.type;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -54,7 +53,7 @@ import org.trellisldp.api.RDFaWriterService;
 /**
  * @author acoburn
  */
-public class DefaultRdfaWriterServiceTest {
+class DefaultRdfaWriterServiceTest {
 
     private static final JenaRDF rdf = new JenaRDF();
 
@@ -67,8 +66,7 @@ public class DefaultRdfaWriterServiceTest {
     private RDFaWriterService service;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         final Map<String, String> namespaces = new HashMap<>();
         namespaces.put("dc", DCTerms.NS);
@@ -81,14 +79,14 @@ public class DefaultRdfaWriterServiceTest {
     }
 
     @Test
-    public void testWriteError() throws IOException {
+    void testWriteError() throws IOException {
         doThrow(new IOException()).when(mockOutputStream).write(any(byte[].class), anyInt(), anyInt());
         assertThrows(UncheckedIOException.class, () -> service.write(getTriples(), mockOutputStream, ""),
                 "IOException in write operation doesn't cause failure!");
     }
 
     @Test
-    public void testDefaultSerializer() {
+    void testDefaultSerializer() {
         final RDFaWriterService svc = new DefaultRdfaWriterService();
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         svc.write(getTriples2(), out, "http://example.com/");
@@ -96,21 +94,21 @@ public class DefaultRdfaWriterServiceTest {
     }
 
     @Test
-    public void testDefaultRdfaWriterService() {
+    void testDefaultRdfaWriterService() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, null);
         assertAll("HTML check", checkHtmlFromTriples(new String(out.toByteArray(), UTF_8)));
     }
 
     @Test
-    public void testDefaultRdfaWriterService2() {
+    void testDefaultRdfaWriterService2() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.write(getTriples(), out, "http://example.com/");
         assertAll("HTML check", checkHtmlFromTriples(new String(out.toByteArray(), UTF_8)));
     }
 
     @Test
-    public void testDefaultRdfaWriterService3() {
+    void testDefaultRdfaWriterService3() {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final RDFaWriterService service4 = new DefaultRdfaWriterService(mockNamespaceService, "/resource-test.mustache",
                 "//www.trellisldp.org/assets/css/trellis.css", "", "//www.trellisldp.org/assets/img/trellis.png");
@@ -120,7 +118,7 @@ public class DefaultRdfaWriterServiceTest {
     }
 
     @Test
-    public void testDefaultRdfaWriterService4() throws Exception {
+    void testDefaultRdfaWriterService4() throws Exception {
         final String path = getClass().getResource("/resource-test.mustache").toURI().getPath();
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final RDFaWriterService service4 = new DefaultRdfaWriterService(mockNamespaceService, path,
@@ -130,23 +128,22 @@ public class DefaultRdfaWriterServiceTest {
     }
 
     @Test
-    public void testDefaultRdfaWriterService5() throws Exception {
+    void testDefaultRdfaWriterService5() throws Exception {
         final String path = getClass().getResource("/resource-test.mustache").toURI().getPath();
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final RDFaWriterService service4 = new DefaultRdfaWriterService(new NoopNamespaceService(), path,
-                (String) null, (String) null, (String) null);
+                null, (String) null, null);
 
         service4.write(getTriples2(), out, "http://example.com/");
         assertAll("HTML check", checkHtmlWithoutNamespaces(new String(out.toByteArray(), UTF_8)));
     }
 
     @Test
-    public void testHtmlNullSerializer() throws Exception {
+    void testHtmlNullSerializer() throws Exception {
         final String path = getClass().getResource("/resource-test.mustache").toURI().getPath();
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        final List<String> nullList = null;
         final RDFaWriterService service6 = new DefaultRdfaWriterService(new NoopNamespaceService(), path,
-                nullList, nullList, null);
+                (List<String>) null, null, null);
 
         service6.write(getTriples2(), out, "http://example.com/");
         assertAll("HTML check", checkHtmlWithoutNamespaces(new String(out.toByteArray(), UTF_8)));

--- a/components/rdfa/src/test/java/org/trellisldp/rdfa/LabelledTripleTest.java
+++ b/components/rdfa/src/test/java/org/trellisldp/rdfa/LabelledTripleTest.java
@@ -25,12 +25,12 @@ import org.trellisldp.vocabulary.DC;
 /**
  * @author acoburn
  */
-public class LabelledTripleTest {
+class LabelledTripleTest {
 
     private static final RDF rdf = new JenaRDF();
 
     @Test
-    public void testOrdinaryLabelledTriple() {
+    void testOrdinaryLabelledTriple() {
         final Triple triple = rdf.createTriple(
                 rdf.createIRI("test:value"), DC.title, rdf.createLiteral("A title"));
         final LabelledTriple t = new LabelledTriple(triple, "title", null);
@@ -41,7 +41,7 @@ public class LabelledTripleTest {
     }
 
     @Test
-    public void testOrdinaryLabelledTriple2() {
+    void testOrdinaryLabelledTriple2() {
         final Triple triple = rdf.createTriple(
                 rdf.createIRI("test:value"), DC.title, rdf.createLiteral("A title"));
         final LabelledTriple t = new LabelledTriple(triple, null, null);
@@ -52,7 +52,7 @@ public class LabelledTripleTest {
     }
 
     @Test
-    public void testOrdinaryLabelledTriple3() {
+    void testOrdinaryLabelledTriple3() {
         final Triple triple = rdf.createTriple(
                 rdf.createIRI("test:value"), DC.title, rdf.createLiteral("A title"));
         final LabelledTriple t = new LabelledTriple(triple, null, null);
@@ -64,7 +64,7 @@ public class LabelledTripleTest {
     }
 
     @Test
-    public void testBnodes() {
+    void testBnodes() {
         final BlankNode bn1 = rdf.createBlankNode();
         final BlankNode bn2 = rdf.createBlankNode();
         final Triple triple = rdf.createTriple(bn1, DC.subject, bn2);

--- a/components/test/src/test/java/org/trellisldp/test/TestUtilsTest.java
+++ b/components/test/src/test/java/org/trellisldp/test/TestUtilsTest.java
@@ -16,7 +16,6 @@ package org.trellisldp.test;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -29,17 +28,17 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-public class TestUtilsTest {
+class TestUtilsTest {
 
     @Test
-    public void testReadEntityAsString() {
+    void testReadEntityAsString() {
         final String text = "some text";
         final InputStream is = new ByteArrayInputStream(text.getBytes(UTF_8));
         assertEquals(text, TestUtils.readEntityAsString(is), "Verify that the input stream matches");
     }
 
     @Test
-    public void testReadEntityAsStringError() throws IOException {
+    void testReadEntityAsStringError() throws IOException {
         final InputStream mockInputStream = mock(InputStream.class);
         when(mockInputStream.read(any(), anyInt(), anyInt())).thenThrow(new IOException("Expected"));
         assertThrows(UncheckedIOException.class, () -> TestUtils.readEntityAsString(mockInputStream),
@@ -47,19 +46,20 @@ public class TestUtilsTest {
     }
 
     @Test
-    public void testGetResourceAsString() {
-        assertTrue(TestUtils.getResourceAsString("/annotation.ttl").contains("<> a oa:Annotation"),
-                "Check the resource loader works as expected");
+    void testGetResourceAsString() {
+        final String resource = TestUtils.getResourceAsString("/annotation.ttl");
+        assertNotNull(resource, "Resource is null!");
+        assertTrue(resource.contains("<> a oa:Annotation"),"Check the resource loader works as expected");
     }
 
     @Test
-    public void testGetResourceAsStringNull() {
+    void testGetResourceAsStringNull() {
         assertNull(TestUtils.getResourceAsString("/non-existent-resource.ttl"),
                 "Check loading a non-existent resource");
     }
 
     @Test
-    public void testReadEntityAsJson() {
+    void testReadEntityAsJson() {
         final Map<String, Object> data = singletonMap("foo", "bar");
         final InputStream is = new ByteArrayInputStream("{\"foo\" : \"bar\" }".getBytes(UTF_8));
         assertEquals(data, TestUtils.readEntityAsJson(is, new TypeReference<Map<String, Object>>(){}),
@@ -67,7 +67,7 @@ public class TestUtilsTest {
     }
 
     @Test
-    public void testReadEntityAsJsonError() {
+    void testReadEntityAsJsonError() {
         final InputStream is = new ByteArrayInputStream("{\"invalid JSON\" }".getBytes(UTF_8));
         assertThrows(UncheckedIOException.class, () ->
                 TestUtils.readEntityAsJson(is, new TypeReference<Map<String, Object>>(){}),

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreHealthCheckTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreHealthCheckTest.java
@@ -24,18 +24,18 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.junit.jupiter.api.Test;
 
-public class TriplestoreHealthCheckTest {
+class TriplestoreHealthCheckTest {
 
     private static final JenaRDF rdf = new JenaRDF();
 
     @Test
-    public void testUnhealthyDefault() {
+    void testUnhealthyDefault() {
         final HealthCheck check = new TriplestoreHealthCheck();
         assertEquals(HealthCheckResponse.State.DOWN, check.call().getState(), "RDFConnection isn't healthy!");
     }
 
     @Test
-    public void testHealthy() {
+    void testHealthy() {
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
         final HealthCheck check = new TriplestoreHealthCheck(rdfConnection);
@@ -43,7 +43,7 @@ public class TriplestoreHealthCheckTest {
     }
 
     @Test
-    public void testUnhealthy() {
+    void testUnhealthy() {
         final JenaDataset dataset = rdf.createDataset();
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
         rdfConnection.close();

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -23,7 +23,6 @@ import static org.apache.jena.rdfconnection.RDFConnectionFactory.connect;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.setDefaultPollInterval;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Metadata.builder;
@@ -67,7 +66,7 @@ import org.trellisldp.vocabulary.XSD;
 /**
  * Test the TriplestoreResourceService class.
  */
-public class TriplestoreResourceServiceTest {
+class TriplestoreResourceServiceTest {
 
     private static final JenaRDF rdf = new JenaRDF();
     private static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
@@ -85,26 +84,26 @@ public class TriplestoreResourceServiceTest {
     private RDFConnection mockRdfConnection;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void testIdentifierService() {
+    void testIdentifierService() {
         final ResourceService svc = new TriplestoreResourceService();
         assertNotEquals(svc.generateIdentifier(), svc.generateIdentifier(), "Not unique identifiers!");
         assertNotEquals(svc.generateIdentifier(), svc.generateIdentifier(), "Not unique identifiers!");
     }
 
     @Test
-    public void testResourceNotFound() {
+    void testResourceNotFound() {
         final ResourceService svc = new TriplestoreResourceService();
         assertEquals(MISSING_RESOURCE, svc.get(rdf.createIRI(TRELLIS_DATA_PREFIX + "missing")).toCompletableFuture()
                 .join(), "Not a missing resource!");
     }
 
     @Test
-    public void testNoRoot() {
+    void testNoRoot() {
         final ResourceService svc = new TriplestoreResourceService();
 
         assertEquals(MISSING_RESOURCE, svc.get(rdf.createIRI(TRELLIS_DATA_PREFIX)).toCompletableFuture().join(),
@@ -112,7 +111,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testInitializeRoot() {
+    void testInitializeRoot() {
         final Instant early = now();
         final TriplestoreResourceService svc = new TriplestoreResourceService();
         svc.initialize();
@@ -123,7 +122,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testInitializeRoot2() {
+    void testInitializeRoot2() {
         final Instant early = now();
         final JenaDataset dataset = rdf.createDataset();
         dataset.add(Trellis.PreferServerManaged, root, RDF.type, LDP.BasicContainer);
@@ -139,7 +138,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testUpdateRoot() throws Exception {
+    void testUpdateRoot() {
         final Instant early = now();
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
@@ -169,7 +168,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testRDFConnectionError() throws Exception {
+    void testRDFConnectionError() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(mockRdfConnection);
         svc.initialize();
         doThrow(new RuntimeException("Expected exception")).when(mockRdfConnection).update(any(UpdateRequest.class));
@@ -191,7 +190,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpRs() throws Exception {
+    void testPutLdpRs() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -216,7 +215,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpRsWithoutBaseUrl() throws Exception {
+    void testPutLdpRsWithoutBaseUrl() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -238,7 +237,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpNr() throws Exception {
+    void testPutLdpNr() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -288,7 +287,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpC() throws Exception {
+    void testPutLdpC() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -352,7 +351,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testAddAuditTriples() throws Exception {
+    void testAddAuditTriples() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -379,7 +378,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutDeleteLdpC() throws Exception {
+    void testPutDeleteLdpC() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -442,7 +441,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpBc() throws Exception {
+    void testPutLdpBc() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -504,7 +503,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpDcSelf() throws Exception {
+    void testPutLdpDcSelf() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -553,7 +552,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpDc() throws Exception {
+    void testPutLdpDc() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -622,7 +621,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpDcMultiple() throws Exception {
+    void testPutLdpDcMultiple() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -748,7 +747,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpDcMultipleInverse() throws Exception {
+    void testPutLdpDcMultipleInverse() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -872,7 +871,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpIc() throws Exception {
+    void testPutLdpIc() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -957,7 +956,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpIcDefaultContent() throws Exception {
+    void testPutLdpIcDefaultContent() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -1033,7 +1032,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpIcMultipleStatements() throws Exception {
+    void testPutLdpIcMultipleStatements() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -1116,7 +1115,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testPutLdpIcMultipleResources() throws Exception {
+    void testPutLdpIcMultipleResources() {
         final TriplestoreResourceService svc = new TriplestoreResourceService(
                 connect(wrap(rdf.createDataset().asJenaDatasetGraph())));
         svc.initialize();
@@ -1261,7 +1260,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testBuildRDFConnectionMemory() {
+    void testBuildRDFConnectionMemory() {
 
         final RDFConnection rdfConnection = TriplestoreResourceService.buildRDFConnection(null);
         assertNotNull(rdfConnection, "Missing RDFConnection, using in-memory dataset!");
@@ -1270,7 +1269,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testBuildRDFConnectionTDB() throws Exception {
+    void testBuildRDFConnectionTDB() throws Exception {
         final File dir = new File(new File(getClass().getResource("/logback-test.xml").toURI()).getParent(), "data");
         final RDFConnection rdfConnection = TriplestoreResourceService.buildRDFConnection(dir.getAbsolutePath());
         assertNotNull(rdfConnection, "Missing RDFConnection, using local file!");
@@ -1279,7 +1278,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testBuildRDFConnectionRemote() {
+    void testBuildRDFConnectionRemote() {
         final RDFConnection rdfConnection = TriplestoreResourceService.buildRDFConnection("http://localhost/sparql");
         assertNotNull(rdfConnection, "Missing RDFConnection, using local HTTP!");
         assertFalse(rdfConnection.isClosed(), "RDFConnection has been closed!");
@@ -1287,7 +1286,7 @@ public class TriplestoreResourceServiceTest {
     }
 
     @Test
-    public void testBuildRDFConnectionRemoteHTTPS() {
+    void testBuildRDFConnectionRemoteHTTPS() {
         final RDFConnection rdfConnection = TriplestoreResourceService.buildRDFConnection("https://localhost/sparql");
         assertNotNull(rdfConnection, "Missing RDFConnection, using local HTTP!");
         assertFalse(rdfConnection.isClosed(), "RDFConnection has been closed!");

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
@@ -56,7 +56,7 @@ import org.trellisldp.vocabulary.XSD;
 /**
  * Test the TriplestoreResource class.
  */
-public class TriplestoreResourceTest {
+class TriplestoreResourceTest {
 
     private static final JenaRDF rdf = getInstance();
     private static final IRI root = rdf.createIRI("trellis:");
@@ -79,7 +79,7 @@ public class TriplestoreResourceTest {
     private Session mockSession;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockSession.getAgent()).thenReturn(Trellis.AnonymousAgent);
         when(mockSession.getCreated()).thenReturn(created);
@@ -87,14 +87,14 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testEmptyResource() {
+    void testEmptyResource() {
         final TriplestoreResource res = new TriplestoreResource(connect(create()), identifier, false);
         res.fetchData();
         assertFalse(res.exists(), "Unexpected resource!");
     }
 
     @Test
-    public void testPartialResource() {
+    void testPartialResource() {
         final JenaDataset dataset = rdf.createDataset();
         dataset.add(Trellis.PreferServerManaged, identifier, DC.modified, rdf.createLiteral(time, XSD.dateTime));
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
@@ -104,7 +104,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testMinimalResource() {
+    void testMinimalResource() {
         final JenaDataset dataset = buildLdpDataset(LDP.RDFSource);
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
                 identifier, false);
@@ -117,7 +117,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testResourceWithAuditQuads() {
+    void testResourceWithAuditQuads() {
         final JenaDataset dataset = buildLdpDataset(LDP.RDFSource);
         auditService.creation(identifier, mockSession).forEach(q ->
                 dataset.add(auditId, q.getSubject(), q.getPredicate(), q.getObject()));
@@ -132,7 +132,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testResourceWithAuditQuads2() {
+    void testResourceWithAuditQuads2() {
         final JenaDataset dataset = buildLdpDataset(LDP.RDFSource);
         auditService.creation(identifier, mockSession).forEach(q ->
                 dataset.add(auditId, q.getSubject(), q.getPredicate(), q.getObject()));
@@ -147,7 +147,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testResourceWithAclQuads() {
+    void testResourceWithAclQuads() {
         final JenaDataset dataset = buildLdpDataset(LDP.RDFSource);
         dataset.add(aclId, aclSubject, ACL.mode, ACL.Read);
         dataset.add(aclId, aclSubject, ACL.agentClass, FOAF.Agent);
@@ -165,7 +165,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testBinaryResource() {
+    void testBinaryResource() {
         final String mimeType = "image/jpeg";
         final IRI binaryIdentifier = rdf.createIRI("file:///binary");
         final JenaDataset dataset = buildLdpDataset(LDP.NonRDFSource);
@@ -189,7 +189,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testResourceWithChildren() {
+    void testResourceWithChildren() {
         final JenaDataset dataset = buildLdpDataset(LDP.Container);
         dataset.add(Trellis.PreferServerManaged, identifier, DC.isPartOf, root);
         getChildIRIs().forEach(c -> dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier));
@@ -205,7 +205,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testResourceWithoutChildren() {
+    void testResourceWithoutChildren() {
         final JenaDataset dataset = buildLdpDataset(LDP.RDFSource);
         dataset.add(Trellis.PreferServerManaged, identifier, DC.isPartOf, root);
         getChildIRIs().forEach(c -> dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier));
@@ -220,7 +220,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testDirectContainer() {
+    void testDirectContainer() {
         final JenaDataset dataset = buildLdpDataset(LDP.DirectContainer);
         dataset.add(Trellis.PreferServerManaged, identifier, DC.isPartOf, root);
         dataset.add(Trellis.PreferServerManaged, identifier, LDP.member, member);
@@ -252,7 +252,7 @@ public class TriplestoreResourceTest {
     }
 
     @Test
-    public void testIndirectContainer() {
+    void testIndirectContainer() {
         final JenaDataset dataset = buildLdpDataset(LDP.IndirectContainer);
         dataset.add(Trellis.PreferServerManaged, identifier, DC.isPartOf, root);
         dataset.add(Trellis.PreferServerManaged, identifier, LDP.member, member);

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreUtilsTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreUtilsTest.java
@@ -35,7 +35,7 @@ import org.trellisldp.vocabulary.SKOS;
 /**
  * ResourceService tests.
  */
-public class TriplestoreUtilsTest {
+class TriplestoreUtilsTest {
 
     private static final RDF simpleRdf = new SimpleRDF();
     private static final RDF jenaRdf = new JenaRDF();
@@ -44,7 +44,7 @@ public class TriplestoreUtilsTest {
     private static final Literal literal = simpleRdf.createLiteral("title");
 
     @Test
-    public void testDatasetNoConversion() {
+    void testDatasetNoConversion() {
         final Dataset dataset = jenaRdf.createDataset();
 
         dataset.add(jenaRdf.createQuad(PreferUserManaged, subject, SKOS.prefLabel, literal));
@@ -59,7 +59,7 @@ public class TriplestoreUtilsTest {
     }
 
     @Test
-    public void testDatasetConversion() {
+    void testDatasetConversion() {
         final Dataset dataset = simpleRdf.createDataset();
 
         dataset.add(simpleRdf.createQuad(PreferUserManaged, subject, SKOS.prefLabel, literal));
@@ -74,20 +74,20 @@ public class TriplestoreUtilsTest {
     }
 
     @Test
-    public void testBaseIRItruncate() {
+    void testBaseIRItruncate() {
         final IRI iri = jenaRdf.createIRI("http://example.com/resource#i");
         assertEquals(jenaRdf.createIRI("http://example.com/resource"), TriplestoreUtils.getBaseIRI(iri),
                 "Check that fragment URLs are removed");
     }
 
     @Test
-    public void testBaseIRInoTruncate() {
+    void testBaseIRInoTruncate() {
         final IRI iri = jenaRdf.createIRI("http://example.com/resource");
         assertEquals(iri, TriplestoreUtils.getBaseIRI(iri), "Check that fragment URLs are removed");
     }
 
     @Test
-    public void testNodeConversion() {
+    void testNodeConversion() {
         final Resource s = createResource("http://example.com/Resource");
         final Property p = createProperty("http://example.com/prop");
         final Resource o = createResource("http://example.com/Other");
@@ -102,7 +102,7 @@ public class TriplestoreUtilsTest {
     }
 
     @Test
-    public void testBaseIRIliteral() {
+    void testBaseIRIliteral() {
         final Literal l = jenaRdf.createLiteral("a literal");
         assertEquals(l, TriplestoreUtils.getBaseIRI(l), "Incorrect literal value!");
     }

--- a/components/webac/src/test/java/org/trellisldp/webac/AuthorizationTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/AuthorizationTest.java
@@ -27,7 +27,7 @@ import org.trellisldp.vocabulary.PROV;
 /**
  * @author acoburn
  */
-public class AuthorizationTest {
+class AuthorizationTest {
 
     private static final RDF rdf = new SimpleRDF();
 
@@ -36,7 +36,7 @@ public class AuthorizationTest {
     private final IRI subject = rdf.createIRI("trellis:data/resource");
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
 
         final IRI other = rdf.createIRI("trellis:data/other");
 
@@ -69,7 +69,7 @@ public class AuthorizationTest {
     }
 
     @Test
-    public void testGraph() {
+    void testGraph() {
         final Authorization auth = Authorization.from(subject, graph);
 
         assertEquals(subject, auth.getIdentifier(), "Incorrect identifier!");

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
@@ -14,13 +14,11 @@
 package org.trellisldp.webac;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
+import static java.util.Collections.*;
 import static javax.ws.rs.HttpMethod.DELETE;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -55,7 +53,7 @@ import org.trellisldp.vocabulary.Trellis;
  * @author acoburn
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class WebAcFilterTest {
+class WebAcFilterTest {
 
     private static final Set<IRI> allModes = new HashSet<>();
 
@@ -88,21 +86,21 @@ public class WebAcFilterTest {
     private Principal mockPrincipal;
 
     @BeforeAll
-    public static void setUpProperties() {
+    static void setUpProperties() {
         System.setProperty(WebAcFilter.CONFIG_WEBAC_METHOD_READABLE, "READ");
         System.setProperty(WebAcFilter.CONFIG_WEBAC_METHOD_WRITABLE, "WRITE");
         System.setProperty(WebAcFilter.CONFIG_WEBAC_METHOD_APPENDABLE, "APPEND");
     }
 
     @AfterAll
-    public static void cleanUpProperties() {
+    static void cleanUpProperties() {
         System.clearProperty(WebAcFilter.CONFIG_WEBAC_METHOD_READABLE);
         System.clearProperty(WebAcFilter.CONFIG_WEBAC_METHOD_WRITABLE);
         System.clearProperty(WebAcFilter.CONFIG_WEBAC_METHOD_APPENDABLE);
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(allModes);
         when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
@@ -115,7 +113,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterUnknownMethod() throws Exception {
+    void testFilterUnknownMethod() {
         when(mockContext.getMethod()).thenReturn("FOO");
 
         final WebAcFilter filter = new WebAcFilter(mockWebAcService);
@@ -123,7 +121,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterRead() throws Exception {
+    void testFilterRead() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("GET");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
@@ -142,7 +140,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterCustomRead() throws Exception {
+    void testFilterCustomRead() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("READ");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
@@ -162,7 +160,7 @@ public class WebAcFilterTest {
 
 
     @Test
-    public void testFilterWrite() throws Exception {
+    void testFilterWrite() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("PUT");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
@@ -181,7 +179,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterCustomWrite() throws Exception {
+    void testFilterCustomWrite() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("WRITE");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
@@ -200,7 +198,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterAppend() throws Exception {
+    void testFilterAppend() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("POST");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
@@ -225,7 +223,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterCustomAppend() throws Exception {
+    void testFilterCustomAppend() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("APPEND");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
@@ -250,7 +248,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterControl() throws Exception {
+    void testFilterControl() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("GET");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
@@ -275,7 +273,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterControl2() throws Exception {
+    void testFilterControl2() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("GET");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
@@ -284,7 +282,7 @@ public class WebAcFilterTest {
         modes.add(ACL.Read);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
 
-        when(mockQueryParams.getOrDefault(eq("ext"), eq(emptyList()))).thenReturn(asList("acl"));
+        when(mockQueryParams.getOrDefault(eq("ext"), eq(emptyList()))).thenReturn(singletonList("acl"));
 
         assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
                 "No expception thrown when not authorized!");
@@ -299,7 +297,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterChallenges() throws Exception {
+    void testFilterChallenges() {
         when(mockContext.getMethod()).thenReturn("POST");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
 
@@ -314,7 +312,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterResponse() throws Exception {
+    void testFilterResponse() {
         final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         when(mockResponseContext.getStatusInfo()).thenReturn(OK);
         when(mockResponseContext.getHeaders()).thenReturn(headers);
@@ -333,7 +331,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterResponseDelete() throws Exception {
+    void testFilterResponseDelete() {
         final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         when(mockContext.getMethod()).thenReturn(DELETE);
         when(mockResponseContext.getStatusInfo()).thenReturn(OK);
@@ -348,7 +346,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterResponseBaseUrl() throws Exception {
+    void testFilterResponseBaseUrl() {
         final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         when(mockResponseContext.getStatusInfo()).thenReturn(OK);
         when(mockResponseContext.getHeaders()).thenReturn(headers);
@@ -367,7 +365,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterResponseWebac2() throws Exception {
+    void testFilterResponseWebac2() {
         final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         final MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
         params.add("ext", "foo");
@@ -385,7 +383,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testFilterResponseForbidden() throws Exception {
+    void testFilterResponseForbidden() {
         final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         when(mockResponseContext.getStatusInfo()).thenReturn(FORBIDDEN);
         when(mockResponseContext.getHeaders()).thenReturn(headers);
@@ -398,7 +396,7 @@ public class WebAcFilterTest {
     }
 
     @Test
-    public void testNoParamCtor() {
+    void testNoParamCtor() {
         assertDoesNotThrow(() -> new WebAcFilter());
     }
 }

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcServiceTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcServiceTest.java
@@ -18,7 +18,6 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
@@ -55,7 +54,7 @@ import org.trellisldp.vocabulary.VCARD;
 /**
  * Tests to verify the correctness of WebAC authorization decisions.
  */
-public class WebAcServiceTest {
+class WebAcServiceTest {
 
     private static final RDF rdf = new JenaRDF();
 
@@ -114,7 +113,7 @@ public class WebAcServiceTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    public void setUp() {
+    void setUp() {
         initMocks(this);
 
         when(mockServiceBundler.getResourceService()).thenReturn(mockResourceService);
@@ -148,12 +147,12 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testDefaultResourceService() {
+    void testDefaultResourceService() {
         assertDoesNotThrow(() -> new WebAcService());
     }
 
     @Test
-    public void testInitialize() {
+    void testInitialize() {
         when(mockRootResource.hasAcl()).thenReturn(false);
 
         assertDoesNotThrow(() -> testService.initialize());
@@ -161,7 +160,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testDontInitialize() {
+    void testDontInitialize() {
         when(mockRootResource.hasAcl()).thenReturn(true);
 
         assertDoesNotThrow(() -> testService.initialize());
@@ -169,7 +168,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testUseDefaultAcl() {
+    void testUseDefaultAcl() {
         when(mockRootResource.hasAcl()).thenReturn(false);
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
 
@@ -181,7 +180,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanRead1() {
+    void testCanRead1() {
         when(mockResourceService.get(eq(nonexistentIRI))).thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         assertAll("Check readability for " + acoburnIRI,
@@ -193,19 +192,19 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanRead2() {
+    void testCanRead2() {
         when(mockSession.getAgent()).thenReturn(addisonIRI);
         assertAll("Check user can read all resources", checkAllCanRead());
     }
 
     @Test
-    public void testCanRead3() {
+    void testCanRead3() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         assertAll("Check user can read all resources", checkAllCanRead());
     }
 
     @Test
-    public void testCanRead4() {
+    void testCanRead4() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         when(mockParentResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
         when(mockResourceService.supportedInteractionModels()).thenReturn(singleton(LDP.DirectContainer));
@@ -214,7 +213,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanRead5() {
+    void testCanRead5() {
         when(mockSession.getAgent()).thenReturn(addisonIRI);
         when(mockResourceService.supportedInteractionModels()).thenReturn(singleton(LDP.IndirectContainer));
         when(mockParentResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
@@ -223,7 +222,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanWrite1() {
+    void testCanWrite1() {
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         assertAll("Check writability for " + acoburnIRI,
                 checkCannotWrite(nonexistentIRI),
@@ -234,7 +233,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanWrite2() {
+    void testCanWrite2() {
         when(mockSession.getAgent()).thenReturn(addisonIRI);
         when(mockResourceService.supportedInteractionModels()).thenReturn(singleton(LDP.Container));
         assertAll("Check writability for " + addisonIRI,
@@ -246,7 +245,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanWrite2b() {
+    void testCanWrite2b() {
         when(mockSession.getAgent()).thenReturn(browserIRI);
         when(mockResourceService.supportedInteractionModels()).thenReturn(singleton(LDP.Container));
         assertAll("Check writability for " + addisonIRI,
@@ -258,13 +257,13 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanWrite3() {
+    void testCanWrite3() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         assertAll("Check user can write to all resources", checkAllCanWrite());
     }
 
     @Test
-    public void testCanWrite4() {
+    void testCanWrite4() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         when(mockParentResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
         when(mockParentResource.getMembershipResource()).thenReturn(of(memberIRI));
@@ -273,7 +272,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanWrite5() {
+    void testCanWrite5() {
         when(mockSession.getAgent()).thenReturn(addisonIRI);
         when(mockParentResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         when(mockParentResource.getMembershipResource()).thenReturn(of(memberIRI));
@@ -286,7 +285,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanWrite6() {
+    void testCanWrite6() {
         final WebAcService testService2 = new WebAcService(mockResourceService,
                 new WebAcService.NoopAuthorizationCache(), false);
         when(mockSession.getAgent()).thenReturn(agentIRI);
@@ -308,7 +307,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanWrite7() {
+    void testCanWrite7() {
         final WebAcService testService2 = new WebAcService(mockResourceService,
                 new WebAcService.NoopAuthorizationCache(), false);
         when(mockSession.getAgent()).thenReturn(addisonIRI);
@@ -328,7 +327,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanControl1() {
+    void testCanControl1() {
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         assertAll("Test controlability for " + acoburnIRI,
                 checkCannotWrite(nonexistentIRI),
@@ -339,7 +338,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanControl2() {
+    void testCanControl2() {
         when(mockSession.getAgent()).thenReturn(addisonIRI);
         assertAll("Test controlability for " + addisonIRI,
                 checkCanControl(nonexistentIRI),
@@ -349,7 +348,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanControl3() {
+    void testCanControl3() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         assertAll("Test controlability for " + agentIRI,
                 checkCanControl(nonexistentIRI),
@@ -360,7 +359,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanAppend1() {
+    void testCanAppend1() {
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         assertAll("Test appendability for " + acoburnIRI,
                 checkCannotAppend(nonexistentIRI),
@@ -371,7 +370,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanAppend2() {
+    void testCanAppend2() {
         when(mockSession.getAgent()).thenReturn(addisonIRI);
         assertAll("Test appendability for " + addisonIRI,
                 checkCannotAppend(nonexistentIRI),
@@ -382,7 +381,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanAppend3() {
+    void testCanAppend3() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         assertAll("Test appendability for " + agentIRI,
                 checkCannotAppend(nonexistentIRI),
@@ -393,7 +392,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanAppend4() {
+    void testCanAppend4() {
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         when(mockParentResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         when(mockParentResource.getMembershipResource()).thenReturn(of(memberIRI));
@@ -407,7 +406,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCanAppend5() {
+    void testCanAppend5() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         when(mockParentResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
         when(mockParentResource.getMembershipResource()).thenReturn(of(memberIRI));
@@ -420,7 +419,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testAdmin1() {
+    void testAdmin1() {
         when(mockSession.getAgent()).thenReturn(Trellis.AdministratorAgent);
         assertAll("Test appendability for admin",
                 checkCanAppend(nonexistentIRI),
@@ -438,7 +437,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testDelegate1() {
+    void testDelegate1() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         when(mockSession.getDelegatedBy()).thenReturn(of(acoburnIRI));
 
@@ -447,7 +446,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testDelegate2() {
+    void testDelegate2() {
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         when(mockSession.getDelegatedBy()).thenReturn(of(agentIRI));
 
@@ -456,7 +455,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testDelegate3() {
+    void testDelegate3() {
         when(mockSession.getAgent()).thenReturn(agentIRI);
         when(mockSession.getDelegatedBy()).thenReturn(of(addisonIRI));
         assertAll("Test delegated writabliity for " + agentIRI + " via " + addisonIRI,
@@ -468,7 +467,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testInheritance() {
+    void testInheritance() {
         when(mockRootResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
                 rdf.createQuad(PreferAccessControl, authIRI8, type, ACL.Authorization),
                 rdf.createQuad(PreferAccessControl, authIRI8, ACL.agent, agentIRI),
@@ -486,7 +485,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testNoInheritance() {
+    void testNoInheritance() {
         when(mockChildResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
                 rdf.createQuad(PreferAccessControl, authIRI2, ACL.mode, ACL.Read),
                 rdf.createQuad(PreferAccessControl, authIRI2, ACL.mode, ACL.Write),
@@ -511,7 +510,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testInheritRoot() {
+    void testInheritRoot() {
         when(mockRootResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
                 rdf.createQuad(PreferAccessControl, authIRI8, type, ACL.Authorization),
                 rdf.createQuad(PreferAccessControl, authIRI8, ACL.agent, agentIRI),
@@ -536,7 +535,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testFoafAgent() {
+    void testFoafAgent() {
         when(mockSession.getAgent()).thenReturn(Trellis.AnonymousAgent);
         when(mockChildResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
                 rdf.createQuad(PreferAccessControl, authIRI1, type, ACL.Authorization),
@@ -578,7 +577,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testNotInherited() {
+    void testNotInherited() {
         when(mockParentResource.hasAcl()).thenReturn(true);
         when(mockParentResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
                     rdf.createQuad(PreferAccessControl, authIRI5, type, ACL.Authorization),
@@ -602,7 +601,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testGroup() {
+    void testGroup() {
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         when(mockGroupResource.stream(eq(PreferUserManaged))).thenAnswer(inv -> Stream.of(
                     rdf.createQuad(PreferUserManaged, authIRI1, VCARD.hasMember, acoburnIRI),
@@ -642,7 +641,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testGroup2() {
+    void testGroup2() {
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         when(mockGroupResource.stream(eq(PreferUserManaged))).thenAnswer(inv -> Stream.of(
                     rdf.createQuad(PreferUserManaged, authIRI1, VCARD.hasMember, acoburnIRI),
@@ -683,7 +682,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testAuthenticatedUser() {
+    void testAuthenticatedUser() {
         when(mockRootResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
                 rdf.createQuad(PreferAccessControl, authIRI5, ACL.accessTo, rootIRI),
                 rdf.createQuad(PreferAccessControl, authIRI5, ACL.agentClass, ACL.AuthenticatedAgent),
@@ -698,7 +697,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testUnauthenticatedUser() {
+    void testUnauthenticatedUser() {
         when(mockRootResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
                 rdf.createQuad(PreferAccessControl, authIRI5, ACL.accessTo, rootIRI),
                 rdf.createQuad(PreferAccessControl, authIRI5, ACL.agentClass, ACL.AuthenticatedAgent),
@@ -713,7 +712,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCacheCanWrite1() {
+    void testCacheCanWrite1() {
         final WebAcService testCacheService = new WebAcService(mockResourceService, mockCache);
         when(mockSession.getAgent()).thenReturn(acoburnIRI);
         assertAll("Check writability with cache", checkCannotWrite(testCacheService, nonexistentIRI),
@@ -724,7 +723,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCacheCanWrite2() {
+    void testCacheCanWrite2() {
         final WebAcService testCacheService = new WebAcService(mockResourceService, mockCache);
         when(mockSession.getAgent()).thenReturn(addisonIRI);
         assertAll("Check writability with cache", checkCanWrite(testCacheService, nonexistentIRI),
@@ -734,7 +733,7 @@ public class WebAcServiceTest {
     }
 
     @Test
-    public void testCacheCanWrite3() {
+    void testCacheCanWrite3() {
         final WebAcService testCacheService = new WebAcService(mockResourceService, mockCache);
         when(mockSession.getAgent()).thenReturn(agentIRI);
         when(mockSession.getDelegatedBy()).thenReturn(of(addisonIRI));

--- a/components/webdav/src/test/java/org/trellisldp/webdav/AbstractWebDAVTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/AbstractWebDAVTest.java
@@ -40,7 +40,6 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static org.apache.commons.io.IOUtils.readLines;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
@@ -100,7 +99,7 @@ import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.XSD;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class AbstractWebDAVTest extends JerseyTest {
+abstract class AbstractWebDAVTest extends JerseyTest {
 
     private static final Logger LOGGER = getLogger(WebDAVTest.class);
     private static final int SC_MULTI_STATUS = 207;
@@ -149,7 +148,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     private Resource mockResource, mockRootResource, mockBinaryResource, mockOtherResource;
 
     @BeforeAll
-    public void before() throws Exception {
+    void before() throws Exception {
         super.setUp();
     }
 
@@ -159,12 +158,12 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @AfterAll
-    public void after() throws Exception {
+    void after() throws Exception {
         super.tearDown();
     }
 
     @BeforeEach
-    public void setUpMocks() throws Exception {
+    void setUpMocks() {
         setUpBundler();
         setUpResourceService();
         setUpBinaryService();
@@ -175,7 +174,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
      *           MKCOL Tests
      * ****************************** */
     @Test
-    public void testMkcol() {
+    void testMkcol() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
 
         final Response res = target(CHILD_PATH).request().method("MKCOL");
@@ -185,19 +184,19 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMkcolRoot() {
+    void testMkcolRoot() {
         final Response res = target().request().method("MKCOL");
         assertEquals(SC_CONFLICT, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testMkcolExisting() {
+    void testMkcolExisting() {
         final Response res = target(RESOURCE_PATH).request().method("MKCOL");
         assertEquals(SC_CONFLICT, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testMkcolNotContainer() {
+    void testMkcolNotContainer() {
         final Response res = target(CHILD_PATH).request().method("MKCOL");
         assertEquals(SC_METHOD_NOT_ALLOWED, res.getStatus(), "Unexpected response code!");
     }
@@ -207,7 +206,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
      *           PROPFIND Tests
      * ****************************** */
     @Test
-    public void testPropFindAll() throws IOException {
+    void testPropFindAll() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .method("PROPFIND", xml("<D:propfind xmlns:D=\"DAV:\">"
                         + "  <D:allprop/>"
@@ -229,7 +228,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropFindNamesOnly() throws IOException {
+    void testPropFindNamesOnly() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .method("PROPFIND", xml("<D:propfind xmlns:D=\"DAV:\">"
                         + "  <D:propname/>"
@@ -258,7 +257,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropFind() throws IOException {
+    void testPropFind() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .method("PROPFIND", xml("<D:propfind xmlns:D=\"DAV:\">\n"
                         + "  <D:prop xmlns:dc=\"http://purl.org/dc/terms/\">\n"
@@ -280,7 +279,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropFindContainer() throws IOException {
+    void testPropFindContainer() throws IOException {
         when(mockRootResource.stream(eq(LDP.PreferContainment))).thenAnswer(inf -> Stream.of(
                 rdf.createQuad(LDP.PreferContainment, root, LDP.contains, identifier),
                 rdf.createQuad(LDP.PreferContainment, root, LDP.contains, binaryIdentifier)));
@@ -304,7 +303,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropFindDeleted() {
+    void testPropFindDeleted() {
         final Response res = target(DELETED_PATH).request()
             .method("PROPFIND", xml("<D:propfind xmlns:D=\"DAV:\">\n"
                         + "  <D:prop xmlns:dc=\"http://purl.org/dc/terms/\">\n"
@@ -315,7 +314,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropFindNonExistent() {
+    void testPropFindNonExistent() {
         final Response res = target(NON_EXISTENT_PATH).request()
             .method("PROPFIND", xml("<D:propfind xmlns:D=\"DAV:\">\n"
                         + "  <D:prop xmlns:dc=\"http://purl.org/dc/terms/\">\n"
@@ -326,7 +325,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropFindBadXMl() {
+    void testPropFindBadXMl() {
         final Response res = target(RESOURCE_PATH).request()
             .method("PROPFIND", xml("<D:propfind xmlns:D=\"DAV:\">\n"
                         + "  <D:prop xmlns:dc=\"http://purl.org/dc/terms/\">\n"
@@ -341,7 +340,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
      *           PROPPATCH Tests
      * ****************************** */
     @Test
-    public void testPropPatchAddRemove() throws IOException {
+    void testPropPatchAddRemove() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .method("PROPPATCH", xml("<D:propertyupdate xmlns:D=\"DAV:\">\n"
                         + "  <D:set>"
@@ -381,7 +380,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropPatchAdd() throws IOException {
+    void testPropPatchAdd() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .method("PROPPATCH", xml("<D:propertyupdate xmlns:D=\"DAV:\">\n"
                         + "  <D:set>"
@@ -407,7 +406,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropPatchRemove() throws IOException {
+    void testPropPatchRemove() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .method("PROPPATCH", xml("<D:propertyupdate xmlns:D=\"DAV:\">\n"
                         + "  <D:remove>"
@@ -430,7 +429,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPropPatchRemoveWithEmptySet() throws IOException {
+    void testPropPatchRemoveWithEmptySet() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .method("PROPPATCH", xml("<D:propertyupdate xmlns:D=\"DAV:\">\n"
                         + "  <D:set>"
@@ -458,7 +457,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
      *           PUT Tests
      * ****************************** */
     @Test
-    public void testPut() {
+    void testPut() {
         final Response res = target(BINARY_PATH).request().put(entity("a text document.", TEXT_PLAIN_TYPE));
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -470,7 +469,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPutNew() {
+    void testPutNew() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         final Response res = target(CHILD_PATH).request().put(entity("a text document.", TEXT_PLAIN_TYPE));
 
@@ -482,7 +481,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPutPreviouslyDeleted() {
+    void testPutPreviouslyDeleted() {
         when(mockResourceService.get(eq(childIdentifier))).thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         final Response res = target(CHILD_PATH).request().put(entity("another text document.", TEXT_PLAIN_TYPE));
@@ -495,7 +494,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testPutRoot() {
+    void testPutRoot() {
         when(mockResourceService.get(eq(root))).thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
         final Response res = target().request().put(entity("another text document.", TEXT_PLAIN_TYPE));
 
@@ -510,14 +509,14 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
      *           DELETE Tests
      * ****************************** */
     @Test
-    public void testDeleteExisting() {
+    void testDeleteExisting() {
         final Response res = target(RESOURCE_PATH).request().delete();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testDeleteRecursive() {
+    void testDeleteRecursive() {
 
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
@@ -533,7 +532,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
      *           MOVE Tests
      * ****************************** */
     @Test
-    public void testMove() {
+    void testMove() {
         final Response res = target(RESOURCE_PATH).request().header("Destination", getBaseUri() + NON_EXISTENT_PATH)
             .method("MOVE");
 
@@ -541,14 +540,14 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMoveNoDestination() {
+    void testMoveNoDestination() {
         final Response res = target(RESOURCE_PATH).request().method("MOVE");
 
         assertEquals(SC_BAD_REQUEST, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testMoveToExisting() {
+    void testMoveToExisting() {
         final Response res = target(RESOURCE_PATH).request()
             .header("Destination", getBaseUri() + BINARY_PATH).method("MOVE");
 
@@ -556,7 +555,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMoveToDeleted() {
+    void testMoveToDeleted() {
         final Response res = target(RESOURCE_PATH).request()
             .header("Destination", getBaseUri() + DELETED_PATH).method("MOVE");
 
@@ -564,7 +563,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMoveFromDeleted() {
+    void testMoveFromDeleted() {
         final Response res = target(DELETED_PATH).request()
             .header("Destination", getBaseUri() + DELETED_PATH).method("MOVE");
 
@@ -572,7 +571,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMoveOutOfDomain() {
+    void testMoveOutOfDomain() {
         final Response res = target(RESOURCE_PATH).request().header("Destination", "http://example.com/location")
             .method("MOVE");
 
@@ -580,7 +579,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMoveError() {
+    void testMoveError() {
         when(mockResourceService.get(root)).thenAnswer(inv -> supplyAsync(() -> {
             throw new RuntimeTrellisException("Expected");
         }));
@@ -591,7 +590,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMoveToRoot() {
+    void testMoveToRoot() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -603,7 +602,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMoveToDeletedParent() {
+    void testMoveToDeletedParent() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
@@ -615,7 +614,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testMoveToMissingParent() {
+    void testMoveToMissingParent() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -630,7 +629,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
      *           COPY Tests
      * ****************************** */
     @Test
-    public void testCopy() {
+    void testCopy() {
         final Response res = target(RESOURCE_PATH).request().header("Destination", getBaseUri() + NON_EXISTENT_PATH)
             .method("COPY");
 
@@ -638,7 +637,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyDepth0() {
+    void testCopyDepth0() {
         final Response res = target(RESOURCE_PATH).request().header("Destination", getBaseUri() + NON_EXISTENT_PATH)
             .header("Depth", "0").method("COPY");
 
@@ -646,7 +645,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyDepth1() {
+    void testCopyDepth1() {
         final Response res = target(RESOURCE_PATH).request().header("Destination", getBaseUri() + NON_EXISTENT_PATH)
             .header("Depth", "1").method("COPY");
 
@@ -654,7 +653,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyDepthInfinity() {
+    void testCopyDepthInfinity() {
         final Response res = target(RESOURCE_PATH).request().header("Destination", getBaseUri() + NON_EXISTENT_PATH)
             .header("Depth", "infinity").method("COPY");
 
@@ -662,7 +661,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyFromDeleted() {
+    void testCopyFromDeleted() {
         final Response res = target(DELETED_PATH).request()
             .header("Destination", getBaseUri() + DELETED_PATH).method("COPY");
 
@@ -670,7 +669,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyFromRoot() {
+    void testCopyFromRoot() {
         final Response res = target().request()
             .header("Destination", getBaseUri() + NON_EXISTENT_PATH).method("COPY");
 
@@ -678,14 +677,14 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyNoDestination() {
+    void testCopyNoDestination() {
         final Response res = target(RESOURCE_PATH).request().method("COPY");
 
         assertEquals(SC_BAD_REQUEST, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testCopyToExisting() {
+    void testCopyToExisting() {
         final Response res = target(RESOURCE_PATH).request()
             .header("Destination", getBaseUri() + BINARY_PATH).method("COPY");
 
@@ -693,7 +692,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyToDeleted() {
+    void testCopyToDeleted() {
         final Response res = target(RESOURCE_PATH).request()
             .header("Destination", getBaseUri() + DELETED_PATH).method("COPY");
 
@@ -701,7 +700,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyOutOfDomain() {
+    void testCopyOutOfDomain() {
         final Response res = target(RESOURCE_PATH).request().header("Destination", "http://example.com/location")
             .method("COPY");
 
@@ -709,7 +708,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyMissingResource() {
+    void testCopyMissingResource() {
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
         final Response res = target(RESOURCE_PATH).request().header("Destination", getBaseUri() + NON_EXISTENT_PATH)
             .method("COPY");
@@ -718,7 +717,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyRecursive() {
+    void testCopyRecursive() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
@@ -732,7 +731,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyRecursiveDepth0() {
+    void testCopyRecursiveDepth0() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
@@ -746,7 +745,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyRecursiveDepth1() {
+    void testCopyRecursiveDepth1() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
@@ -760,7 +759,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyToRoot() {
+    void testCopyToRoot() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -772,7 +771,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyToDeletedParent() {
+    void testCopyToDeletedParent() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
@@ -784,7 +783,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
     }
 
     @Test
-    public void testCopyToMissingParent() {
+    void testCopyToMissingParent() {
 
         when(mockResourceService.get(eq(otherIdentifier))).thenAnswer(inv -> completedFuture(mockOtherResource));
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -799,7 +798,7 @@ public abstract class AbstractWebDAVTest extends JerseyTest {
      *           OPTIONS Tests
      * ****************************** */
     @Test
-    public void testOptions() {
+    void testOptions() {
         final Response res = target(RESOURCE_PATH).request().options();
         assertEquals("1,3", res.getHeaderString("DAV"));
     }

--- a/components/webdav/src/test/java/org/trellisldp/webdav/DepthTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/DepthTest.java
@@ -23,47 +23,46 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class DepthTest {
+class DepthTest {
 
     @Test
-    public void testDepthInfinity() {
+    void testDepthInfinity() {
         final Depth depth = Depth.valueOf("infinity");
         assertEquals(INFINITY, depth.getDepth());
     }
 
     @Test
-    public void testDepthInfinity2() {
+    void testDepthInfinity2() {
         final Depth depth = Depth.valueOf("INFINITY");
         assertEquals(INFINITY, depth.getDepth());
     }
 
     @Test
-    public void testDepthZero() {
+    void testDepthZero() {
         final Depth depth = Depth.valueOf("0");
         assertEquals(ZERO, depth.getDepth());
     }
 
     @Test
-    public void testDepthOne() {
+    void testDepthOne() {
         final Depth depth = Depth.valueOf("1");
         assertEquals(ONE, depth.getDepth());
     }
 
     @Test
-    public void testDepthOther() {
+    void testDepthOther() {
         final Depth depth = new Depth("blah");
         assertEquals(ZERO, depth.getDepth());
     }
 
     @Test
-    public void testDepthOther2() {
+    void testDepthOther2() {
         final Depth depth = Depth.valueOf("blah");
         assertNull(depth);
     }
 
     @Test
-    public void testDepthNull() {
-        final Depth depth = Depth.valueOf(null);
-        assertNull(depth);
+    void testDepthNull() {
+        assertNull(Depth.valueOf(null));
     }
 }

--- a/components/webdav/src/test/java/org/trellisldp/webdav/TrellisWebDAVRequestFilterTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/TrellisWebDAVRequestFilterTest.java
@@ -13,12 +13,11 @@
  */
 package org.trellisldp.webdav;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.HttpMethod.PUT;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
@@ -42,10 +41,9 @@ import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.http.core.ServiceBundler;
 
-public class TrellisWebDAVRequestFilterTest {
+class TrellisWebDAVRequestFilterTest {
 
-    private static RDF rdf = getInstance();
-
+    private static final RDF rdf = getInstance();
     private static final String PATH = "resource";
 
     @Mock
@@ -75,7 +73,7 @@ public class TrellisWebDAVRequestFilterTest {
     private TrellisWebDAVRequestFilter filter;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
 
         when(mockBundler.getResourceService()).thenReturn(mockResourceService);
@@ -87,7 +85,7 @@ public class TrellisWebDAVRequestFilterTest {
         when(mockUriBuilder.path(any(String.class))).thenReturn(mockUriBuilder);
         when(mockUriInfo.getBaseUriBuilder()).thenReturn(mockUriBuilder);
         when(mockUriInfo.getPath()).thenReturn(PATH);
-        when(mockUriInfo.getPathSegments()).thenReturn(asList(mockPathSegment));
+        when(mockUriInfo.getPathSegments()).thenReturn(singletonList(mockPathSegment));
         when(mockUriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
         when(mockPathSegment.getPath()).thenReturn(PATH);
 
@@ -95,7 +93,7 @@ public class TrellisWebDAVRequestFilterTest {
     }
 
     @Test
-    public void testTestPutUncontainedMissing() throws Exception {
+    void testTestPutUncontainedMissing() {
 
         filter.filter(mockContext);
         verify(mockContext).setMethod(eq(POST));
@@ -103,7 +101,7 @@ public class TrellisWebDAVRequestFilterTest {
     }
 
     @Test
-    public void testTestPutContainedMissing() throws Exception {
+    void testTestPutContainedMissing() {
         final TrellisWebDAVRequestFilter filter2 = new TrellisWebDAVRequestFilter(mockBundler, false, null);
 
         filter2.filter(mockContext);
@@ -113,7 +111,7 @@ public class TrellisWebDAVRequestFilterTest {
 
 
     @Test
-    public void testTestPutUncontainedDeleted() throws Exception {
+    void testTestPutUncontainedDeleted() {
 
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + PATH))))
             .thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
@@ -124,7 +122,7 @@ public class TrellisWebDAVRequestFilterTest {
     }
 
     @Test
-    public void testTestPutUncontainedExisting() throws Exception {
+    void testTestPutUncontainedExisting() {
 
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + PATH))))
             .thenAnswer(inv -> completedFuture(mockResource));
@@ -136,7 +134,7 @@ public class TrellisWebDAVRequestFilterTest {
 
 
     @Test
-    public void testTestPutUncontainedNoPaths() throws Exception {
+    void testTestPutUncontainedNoPaths() {
 
         when(mockUriInfo.getPathSegments()).thenReturn(emptyList());
 
@@ -146,7 +144,7 @@ public class TrellisWebDAVRequestFilterTest {
     }
 
     @Test
-    public void testTestPutUncontainedEmptyPaths() throws Exception {
+    void testTestPutUncontainedEmptyPaths() {
 
         when(mockPathSegment.getPath()).thenReturn("");
 

--- a/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVNoBaseUrlTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVNoBaseUrlTest.java
@@ -15,7 +15,6 @@ package org.trellisldp.webdav;
 
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.io.IOException;
 import java.security.Principal;
 
 import javax.annotation.Priority;
@@ -30,7 +29,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.trellisldp.http.TrellisHttpResource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class WebDAVNoBaseUrlTest extends AbstractWebDAVTest {
+class WebDAVNoBaseUrlTest extends AbstractWebDAVTest {
 
     @PreMatching
     @Priority(500)
@@ -38,22 +37,17 @@ public class WebDAVNoBaseUrlTest extends AbstractWebDAVTest {
         private final String principal;
         private final String userRole;
 
-        public TestAuthnFilter(final String principal, final String role) {
+        TestAuthnFilter(final String principal, final String role) {
             this.principal = principal;
             this.userRole = role;
         }
 
         @Override
-        public void filter(final ContainerRequestContext requestContext) throws IOException {
+        public void filter(final ContainerRequestContext requestContext) {
             requestContext.setSecurityContext(new SecurityContext() {
                 @Override
                 public Principal getUserPrincipal() {
-                    return new Principal() {
-                        @Override
-                        public String getName() {
-                            return principal;
-                        }
-                    };
+                    return () -> principal;
                 }
 
                 @Override

--- a/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVTest.java
@@ -23,10 +23,10 @@ import org.junit.jupiter.api.TestInstance;
 import org.trellisldp.http.TrellisHttpResource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class WebDAVTest extends AbstractWebDAVTest {
+class WebDAVTest extends AbstractWebDAVTest {
 
     @Override
-    public Application configure() {
+    protected Application configure() {
 
         initMocks(this);
 

--- a/components/webdav/src/test/java/org/trellisldp/webdav/impl/WebDAVUtilsTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/impl/WebDAVUtilsTest.java
@@ -36,12 +36,12 @@ import org.trellisldp.api.RuntimeTrellisException;
 /**
  * @author acoburn
  */
-public class WebDAVUtilsTest {
+class WebDAVUtilsTest {
 
     private static final RDF rdf = getInstance();
 
     @Test
-    public void testPathLastSegments() {
+    void testPathLastSegments() {
         assertEquals("", WebDAVUtils.getLastSegment(emptyList()));
         assertEquals("foo", WebDAVUtils.getLastSegment(singletonList(asPathSegment("foo"))));
         assertEquals("bar", WebDAVUtils.getLastSegment(asList(asPathSegment("foo"), asPathSegment("bar"))));
@@ -50,7 +50,7 @@ public class WebDAVUtilsTest {
     }
 
     @Test
-    public void testEmptyPathSegments() {
+    void testEmptyPathSegments() {
         assertEquals("", WebDAVUtils.getAllButLastSegment(emptyList()));
         assertEquals("", WebDAVUtils.getAllButLastSegment(singletonList(asPathSegment("foo"))));
         assertEquals("foo", WebDAVUtils.getAllButLastSegment(asList(asPathSegment("foo"), asPathSegment("bar"))));
@@ -59,14 +59,14 @@ public class WebDAVUtilsTest {
     }
 
     @Test
-    public void testBaseUrl() {
+    void testBaseUrl() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
         assertEquals("https://example.com/resource", WebDAVUtils.externalUrl(identifier, "https://example.com"));
         assertEquals("https://example.com/resource", WebDAVUtils.externalUrl(identifier, "https://example.com/"));
     }
 
     @Test
-    public void testCloseDataset() throws Exception {
+    void testCloseDataset() throws Exception {
         final Dataset mockDataset = mock(Dataset.class);
         doThrow(new IOException()).when(mockDataset).close();
         assertThrows(RuntimeTrellisException.class, () -> WebDAVUtils.closeDataset(mockDataset));

--- a/core/api/src/test/java/org/trellisldp/api/AuditServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/AuditServiceTest.java
@@ -17,10 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class AuditServiceTest {
+class AuditServiceTest {
 
     @Test
-    public void testNullAuditService() {
+    void testNullAuditService() {
         final AuditService svc = new NoopAuditService();
         assertTrue(svc.creation(null, null).isEmpty(), "Audit triples were generated for a create event");
         assertTrue(svc.deletion(null, null).isEmpty(), "Audit triples were generated for a delete event");

--- a/core/api/src/test/java/org/trellisldp/api/BinaryMetadataTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryMetadataTest.java
@@ -29,16 +29,16 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class BinaryMetadataTest {
+class BinaryMetadataTest {
 
     private static final RDF rdf = new SimpleRDF();
 
-    private final String mimeType = "text/plain";
     private final IRI identifier = rdf.createIRI("trellis:data/resource");
-    private final Map<String, List<String>> hints = singletonMap("key", asList("val1", "val2"));
 
     @Test
-    public void testBinaryMetadata() {
+    void testBinaryMetadata() {
+        final String mimeType = "text/plain";
+        final Map<String, List<String>> hints = singletonMap("key", asList("val1", "val2"));
         final BinaryMetadata binary = BinaryMetadata.builder(identifier).mimeType(mimeType).hints(hints).build();
         assertEquals(identifier, binary.getIdentifier(), "Identifier did not match");
         assertEquals(of(mimeType), binary.getMimeType(), "MimeType did not match");
@@ -46,7 +46,7 @@ public class BinaryMetadataTest {
     }
 
     @Test
-    public void testBinaryMetadataWithOptionalArgs() {
+    void testBinaryMetadataWithOptionalArgs() {
         final BinaryMetadata binary = BinaryMetadata.builder(identifier).build();
         assertEquals(identifier, binary.getIdentifier(), "Identifier did not match");
         assertFalse(binary.getMimeType().isPresent(), "MimeType was not absent");

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -16,7 +16,6 @@ package org.trellisldp.api;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -35,11 +34,9 @@ import org.mockito.Mock;
 /**
  * @author acoburn
  */
-public class BinaryServiceTest {
+class BinaryServiceTest {
 
     private static final RDF rdf = new SimpleRDF();
-
-    private final IRI identifier = rdf.createIRI("trellis:data/resource");
 
     @Mock
     private BinaryService mockBinaryService;
@@ -48,12 +45,13 @@ public class BinaryServiceTest {
     private Binary mockBinary;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void testGetContent() throws IOException {
+    void testGetContent() throws IOException {
+        final IRI identifier = rdf.createIRI("trellis:data/resource");
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("FooBar".getBytes(UTF_8));
         when(mockBinaryService.get(eq(identifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent(anyInt(), anyInt())).thenReturn(inputStream);

--- a/core/api/src/test/java/org/trellisldp/api/ConstraintServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ConstraintServiceTest.java
@@ -17,7 +17,6 @@ import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.of;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Set;
@@ -33,7 +32,7 @@ import org.trellisldp.vocabulary.RDFS;
 /**
  * @author acoburn
  */
-public class ConstraintServiceTest {
+class ConstraintServiceTest {
 
     private static final RDF rdf = TrellisUtils.getInstance();
     private static final String INCORRECT_LDP_TYPES = "Incorrect number of LDP types found";
@@ -48,7 +47,7 @@ public class ConstraintServiceTest {
     }
 
     @Test
-    public void testResource() {
+    void testResource() {
         assertEquals(1, ldpResourceTypes(LDP.Resource).count(), INCORRECT_LDP_TYPES);
         final Set<IRI> types = ldpResourceTypes(LDP.Resource).collect(toSet());
         assertEquals(1, types.size(), INCORRECT_UNIQUE_LDP_TYPES);
@@ -56,12 +55,12 @@ public class ConstraintServiceTest {
     }
 
     @Test
-    public void testNonLDP() {
+    void testNonLDP() {
         assertEquals(0, ldpResourceTypes(RDFS.label).count(), "ldp types found when they shouldn't be");
     }
 
     @Test
-    public void testRDFSource() {
+    void testRDFSource() {
         assertEquals(2, ldpResourceTypes(LDP.RDFSource).count(), INCORRECT_LDP_TYPES);
         final Set<IRI> types = ldpResourceTypes(LDP.RDFSource).collect(toSet());
         assertEquals(2, types.size(), INCORRECT_UNIQUE_LDP_TYPES);
@@ -70,7 +69,7 @@ public class ConstraintServiceTest {
     }
 
     @Test
-    public void testNonRDFSource() {
+    void testNonRDFSource() {
         assertEquals(2, ldpResourceTypes(LDP.NonRDFSource).count(), INCORRECT_LDP_TYPES);
         final Set<IRI> types = ldpResourceTypes(LDP.NonRDFSource).collect(toSet());
         assertEquals(2, types.size(), INCORRECT_UNIQUE_LDP_TYPES);
@@ -79,7 +78,7 @@ public class ConstraintServiceTest {
     }
 
     @Test
-    public void testContainer() {
+    void testContainer() {
         assertEquals(3, ldpResourceTypes(LDP.Container).count(), INCORRECT_LDP_TYPES);
         final Set<IRI> types = ldpResourceTypes(LDP.Container).collect(toSet());
         assertEquals(3, types.size(), INCORRECT_UNIQUE_LDP_TYPES);
@@ -89,7 +88,7 @@ public class ConstraintServiceTest {
     }
 
     @Test
-    public void testBasicContainer() {
+    void testBasicContainer() {
         assertEquals(4, ldpResourceTypes(LDP.BasicContainer).count(), INCORRECT_LDP_TYPES);
         final Set<IRI> types = ldpResourceTypes(LDP.BasicContainer).collect(toSet());
         assertEquals(4, types.size(), INCORRECT_UNIQUE_LDP_TYPES);
@@ -100,7 +99,7 @@ public class ConstraintServiceTest {
     }
 
     @Test
-    public void testDirectContainer() {
+    void testDirectContainer() {
         assertEquals(4, ldpResourceTypes(LDP.DirectContainer).count(), INCORRECT_LDP_TYPES);
         final Set<IRI> types = ldpResourceTypes(LDP.DirectContainer).collect(toSet());
         assertEquals(4, types.size(), INCORRECT_UNIQUE_LDP_TYPES);
@@ -111,7 +110,7 @@ public class ConstraintServiceTest {
     }
 
     @Test
-    public void testIndirectContainer() {
+    void testIndirectContainer() {
         assertEquals(4, ldpResourceTypes(LDP.IndirectContainer).count(), INCORRECT_LDP_TYPES);
         final Set<IRI> types = ldpResourceTypes(LDP.IndirectContainer).collect(toSet());
         assertEquals(4, types.size(), INCORRECT_UNIQUE_LDP_TYPES);
@@ -122,7 +121,7 @@ public class ConstraintServiceTest {
     }
 
     @Test
-    public void testConstrainedBy() {
+    void testConstrainedBy() {
         final ConstraintService svc = mock(ConstraintService.class);
 
         doCallRealMethod().when(svc).constrainedBy(eq(LDP.RDFSource), any(Graph.class));

--- a/core/api/src/test/java/org/trellisldp/api/ConstraintViolationTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ConstraintViolationTest.java
@@ -26,7 +26,7 @@ import org.trellisldp.vocabulary.LDP;
 /**
  * @author acoburn
  */
-public class ConstraintViolationTest {
+class ConstraintViolationTest {
 
     private static final RDF rdf = new SimpleRDF();
     private static final Triple triple = rdf.createTriple(rdf.createIRI("ex:subject"), LDP.contains,
@@ -35,7 +35,7 @@ public class ConstraintViolationTest {
             rdf.createIRI("ex:object2"));
 
     @Test
-    public void testSingleConstraint() {
+    void testSingleConstraint() {
         final ConstraintViolation violation = new ConstraintViolation(InvalidProperty, triple);
 
         assertEquals(InvalidProperty, violation.getConstraint(), "Incorrect constraint IRI");
@@ -44,7 +44,7 @@ public class ConstraintViolationTest {
     }
 
     @Test
-    public void testMultipleConstraint() {
+    void testMultipleConstraint() {
         final ConstraintViolation violation = new ConstraintViolation(InvalidProperty, asList(triple, triple2));
 
         assertEquals(InvalidProperty, violation.getConstraint(), "Incorrect constraint IRI");
@@ -54,7 +54,7 @@ public class ConstraintViolationTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         final ConstraintViolation violation = new ConstraintViolation(InvalidProperty, triple);
         assertEquals("http://www.trellisldp.org/ns/trellis#InvalidProperty: " +
                 "[<ex:subject> <http://www.w3.org/ns/ldp#contains> <ex:object> .]", violation.toString(),

--- a/core/api/src/test/java/org/trellisldp/api/DefaultIdentifierServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/DefaultIdentifierServiceTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class DefaultIdentifierServiceTest {
+class DefaultIdentifierServiceTest {
 
     @Test
-    public void testSupplier() {
+    void testSupplier() {
         final String prefix = "trellis:data/";
         final Supplier<String> supplier = new DefaultIdentifierService().getSupplier(prefix);
         final String id1 = supplier.get();
@@ -37,13 +37,12 @@ public class DefaultIdentifierServiceTest {
     }
 
     @Test
-    public void testGenerator() {
+    void testGenerator() {
         final String prefix1 = "http://example.org/";
         final String prefix2 = "trellis:data/a/b/c/";
         final IdentifierService svc = new DefaultIdentifierService();
         final Supplier<String> gen1 = svc.getSupplier(prefix1);
         final Supplier<String> gen2 = svc.getSupplier(prefix2);
-
         final String id1 = gen1.get();
         final String id2 = gen2.get();
 
@@ -54,13 +53,12 @@ public class DefaultIdentifierServiceTest {
     }
 
     @Test
-    public void testGenerator2() {
+    void testGenerator2() {
         final IdentifierService svc = new DefaultIdentifierService();
         final Supplier<String> gen = svc.getSupplier("", 4, 2);
-
         final String id = gen.get();
-
         final String[] parts = id.split("/");
+
         assertEquals(5L, parts.length, "hierarchical supplier has wrong number of levels!");
         assertEquals(parts[0], parts[4].substring(0, 2), "hierarchical supplier has wrong first section!");
         assertEquals(parts[1], parts[4].substring(2, 4), "hierarchical supplier has wrong second section!");
@@ -69,7 +67,7 @@ public class DefaultIdentifierServiceTest {
     }
 
     @Test
-    public void testSupplier2() {
+    void testSupplier2() {
         final Supplier<String> supplier = new DefaultIdentifierService().getSupplier();
         final String id1 = supplier.get();
         final String id2 = supplier.get();

--- a/core/api/src/test/java/org/trellisldp/api/MetadataTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/MetadataTest.java
@@ -25,7 +25,7 @@ import org.trellisldp.vocabulary.DC;
 import org.trellisldp.vocabulary.FOAF;
 import org.trellisldp.vocabulary.LDP;
 
-public class MetadataTest {
+class MetadataTest {
 
     private static final RDF rdf = TrellisUtils.getInstance();
     private static final IRI identifier = rdf.createIRI("trellis:data/resource");
@@ -33,7 +33,7 @@ public class MetadataTest {
     private static final IRI root = rdf.createIRI("trellis:data/");
 
     @Test
-    public void testMetadataIndirectContainer() {
+    void testMetadataIndirectContainer() {
         final Metadata metadata = Metadata.builder(identifier)
                 .interactionModel(LDP.IndirectContainer)
                 .container(root).memberRelation(LDP.member)
@@ -53,7 +53,7 @@ public class MetadataTest {
     }
 
     @Test
-    public void testMetadataDirectContainer() {
+    void testMetadataDirectContainer() {
         final Metadata metadata = Metadata.builder(identifier)
                 .interactionModel(LDP.DirectContainer)
                 .container(root).memberOfRelation(DC.isPartOf)
@@ -70,7 +70,7 @@ public class MetadataTest {
     }
 
     @Test
-    public void testMetadataBinary() {
+    void testMetadataBinary() {
         final BinaryMetadata binary = BinaryMetadata.builder(rdf.createIRI("http://example.com/binary")).build();
         final Metadata metadata = Metadata.builder(identifier)
                 .interactionModel(LDP.NonRDFSource)
@@ -87,7 +87,7 @@ public class MetadataTest {
     }
 
     @Test
-    public void testMetadataResource() {
+    void testMetadataResource() {
         final Resource mockResource = mock(Resource.class);
         when(mockResource.getContainer()).thenReturn(of(root));
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);

--- a/core/api/src/test/java/org/trellisldp/api/NoopCacheServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopCacheServiceTest.java
@@ -22,10 +22,10 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
-public class NoopCacheServiceTest {
+class NoopCacheServiceTest {
 
     @Test
-    public void testPassthroughCache() {
+    void testPassthroughCache() {
         final List<String> list = new CopyOnWriteArrayList<>();
         final Function<String, String> mapper = key -> {
             list.add(key);

--- a/core/api/src/test/java/org/trellisldp/api/NoopEventServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopEventServiceTest.java
@@ -23,18 +23,18 @@ import org.mockito.Mock;
 /**
  * Test the no-op event service.
  */
-public class NoopEventServiceTest {
+class NoopEventServiceTest {
 
     @Mock
     private Event mockEvent;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void testNoopEventSvc() {
+    void testNoopEventSvc() {
         try {
             final EventService svc = new NoopEventService();
             svc.emit(mockEvent);

--- a/core/api/src/test/java/org/trellisldp/api/NoopMementoServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopMementoServiceTest.java
@@ -18,7 +18,6 @@ import static java.time.Instant.now;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Stream.of;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
@@ -37,7 +36,7 @@ import org.mockito.Mock;
 import org.trellisldp.vocabulary.SKOS;
 import org.trellisldp.vocabulary.Trellis;
 
-public class NoopMementoServiceTest {
+class NoopMementoServiceTest {
 
     private static final MementoService testService = new NoopMementoService();
     private static final RDF rdf = getInstance();
@@ -55,7 +54,7 @@ public class NoopMementoServiceTest {
     private MementoService mockMementoService;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockResource.getIdentifier()).thenReturn(identifier);
         when(mockResource.getModified()).thenReturn(time);
@@ -66,31 +65,31 @@ public class NoopMementoServiceTest {
     }
 
     @Test
-    public void testPutDefaultMethod() {
+    void testPutDefaultMethod() {
         mockMementoService.put(mockResourceService, identifier).toCompletableFuture().join();
         verify(mockResourceService).get(eq(identifier));
         verify(mockMementoService).put(eq(mockResource));
     }
 
     @Test
-    public void testPutResourceServiceNoop() {
+    void testPutResourceServiceNoop() {
         testService.put(mockResourceService, identifier).toCompletableFuture().join();
         verifyZeroInteractions(mockResourceService);
     }
 
     @Test
-    public void testPutResourceNoop() {
+    void testPutResourceNoop() {
         testService.put(mockResource).toCompletableFuture().join();
         verifyZeroInteractions(mockResource);
     }
 
     @Test
-    public void testGetResource() {
+    void testGetResource() {
         assertEquals(MISSING_RESOURCE, testService.get(identifier, time).toCompletableFuture().join());
     }
 
     @Test
-    public void testMementos() {
+    void testMementos() {
         assertTrue(testService.mementos(identifier).thenApply(SortedSet::isEmpty).toCompletableFuture().join());
     }
 }

--- a/core/api/src/test/java/org/trellisldp/api/NoopNamespaceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopNamespaceServiceTest.java
@@ -18,10 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class NoopNamespaceServiceTest {
+class NoopNamespaceServiceTest {
 
     @Test
-    public void noAction() {
+    void noAction() {
         final NamespaceService testService = new NoopNamespaceService();
         testService.setPrefix("foo", "http://bar/");
         assertTrue(testService.getNamespaces().isEmpty(), "Namespace list not empty in no-op service!");

--- a/core/api/src/test/java/org/trellisldp/api/NoopResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopResourceServiceTest.java
@@ -25,48 +25,48 @@ import org.apache.commons.rdf.api.RDF;
 import org.junit.jupiter.api.Test;
 import org.trellisldp.vocabulary.LDP;
 
-public class NoopResourceServiceTest {
+class NoopResourceServiceTest {
 
     private static final ResourceService testService = new NoopResourceService();
     private static final RDF rdf = getInstance();
     private static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
 
     @Test
-    public void testGetResource() {
+    void testGetResource() {
         assertEquals(MISSING_RESOURCE, testService.get(identifier).toCompletableFuture().join());
     }
 
     @Test
-    public void testReplaceResource() {
+    void testReplaceResource() {
         final Metadata metadata = Metadata.builder(identifier).interactionModel(LDP.RDFSource).build();
         final Dataset dataset = rdf.createDataset();
         assertDoesNotThrow(() -> testService.replace(metadata, dataset).toCompletableFuture().join());
     }
 
     @Test
-    public void testDeleteResource() {
+    void testDeleteResource() {
         final Metadata metadata = Metadata.builder(identifier).interactionModel(LDP.RDFSource).build();
         assertDoesNotThrow(() -> testService.delete(metadata).toCompletableFuture().join());
     }
 
     @Test
-    public void testAddResource() {
+    void testAddResource() {
         final Dataset dataset = rdf.createDataset();
         assertDoesNotThrow(() -> testService.add(identifier, dataset).toCompletableFuture().join());
     }
 
     @Test
-    public void testTouchResource() {
+    void testTouchResource() {
         assertDoesNotThrow(() -> testService.touch(identifier).toCompletableFuture().join());
     }
 
     @Test
-    public void testSupportedModels() {
+    void testSupportedModels() {
         assertTrue(testService.supportedInteractionModels().isEmpty());
     }
 
     @Test
-    public void testGetIdentifier() {
+    void testGetIdentifier() {
         assertEquals(TRELLIS_DATA_PREFIX, testService.generateIdentifier());
     }
 }

--- a/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -15,7 +15,6 @@ package org.trellisldp.api;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -35,7 +34,7 @@ import org.trellisldp.vocabulary.LDP;
 /**
  * @author acoburn
  */
-public class ResourceServiceTest {
+class ResourceServiceTest {
 
     private static final RDF rdf = new JenaRDF();
     private static final IRI existing = rdf.createIRI("trellis:data/existing");
@@ -57,7 +56,7 @@ public class ResourceServiceTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         doCallRealMethod().when(mockResourceService).skolemize(any());
         doCallRealMethod().when(mockResourceService).unskolemize(any());
@@ -69,20 +68,20 @@ public class ResourceServiceTest {
     }
 
     @Test
-    public void testRetrievalService2() {
+    void testRetrievalService2() {
         final RetrievalService<Resource> svc = new MyRetrievalService();
         assertEquals(mockResource, svc.get(existing).toCompletableFuture().join(),
                 "Incorrect resource returned by retrieval service!");
     }
 
     @Test
-    public void testRetrievalService() {
+    void testRetrievalService() {
         assertEquals(mockResource, mockRetrievalService.get(existing).toCompletableFuture().join(),
                 "Incorrect resource found by retrieval service!");
     }
 
     @Test
-    public void testDefaultCreate() {
+    void testDefaultCreate() {
         final IRI root = rdf.createIRI("trellis:data/");
         final Dataset dataset = rdf.createDataset();
         final Metadata metadata = Metadata.builder(existing).container(root).interactionModel(LDP.RDFSource).build();
@@ -94,7 +93,7 @@ public class ResourceServiceTest {
     }
 
     @Test
-    public void testSkolemization() {
+    void testSkolemization() {
         final BlankNode bnode = rdf.createBlankNode("testing");
         final IRI iri = rdf.createIRI("trellis:bnode/testing");
         final IRI resource = rdf.createIRI("trellis:data/resource");
@@ -114,7 +113,7 @@ public class ResourceServiceTest {
     }
 
     @Test
-    public void testInternalExternal() {
+    void testInternalExternal() {
         final String baseUrl = "http://example.com/";
         final IRI external = rdf.createIRI(baseUrl + "resource");
         final IRI internal = rdf.createIRI("trellis:data/resource");

--- a/core/api/src/test/java/org/trellisldp/api/ResourceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceTest.java
@@ -17,7 +17,6 @@ import static java.util.Collections.singleton;
 import static java.util.stream.Stream.empty;
 import static java.util.stream.Stream.of;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
@@ -35,7 +34,7 @@ import org.trellisldp.vocabulary.DC;
 /**
  * @author acoburn
  */
-public class ResourceTest {
+class ResourceTest {
 
     private static final RDF rdf = new SimpleRDF();
 
@@ -45,7 +44,7 @@ public class ResourceTest {
     private Resource mockResource;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         doCallRealMethod().when(mockResource).getMembershipResource();
         doCallRealMethod().when(mockResource).getMemberRelation();
@@ -63,7 +62,7 @@ public class ResourceTest {
     }
 
     @Test
-    public void testResource() {
+    void testResource() {
         assertEquals(0L, mockResource.stream(prefer).count(), "Resource stream has extra triples!");
         assertEquals(0L, mockResource.stream(singleton(prefer)).count(), "Resource stream has extra triples!");
         assertNotNull(mockResource.getRevision(), "Resource revision should not be null!");
@@ -77,7 +76,7 @@ public class ResourceTest {
     }
 
     @Test
-    public void testResourceWithQuads() {
+    void testResourceWithQuads() {
         final IRI subject = rdf.createIRI("ex:subject");
         when(mockResource.stream()).thenAnswer((x) -> of(
                     rdf.createQuad(prefer, subject, DC.title, rdf.createLiteral("A title")),
@@ -89,14 +88,14 @@ public class ResourceTest {
     }
 
     @Test
-    public void testSingletons() {
+    void testSingletons() {
         assertEquals(MISSING_RESOURCE, MISSING_RESOURCE, "Missing resource singleton doesn't act like a singleton!");
         assertEquals(DELETED_RESOURCE, DELETED_RESOURCE, "Deleted resource singleton doesn't act like a singleton!");
         assertNotEquals(MISSING_RESOURCE, DELETED_RESOURCE, "Deleted and missing resources match each other!");
     }
 
     @Test
-    public void testMissingResource() {
+    void testMissingResource() {
         assertNull(MISSING_RESOURCE.getIdentifier(), "Missing resource has an identifier!");
         assertNull(MISSING_RESOURCE.getInteractionModel(), "Missing resource has an interaction model!");
         assertNull(MISSING_RESOURCE.getModified(), "Missing resource has a last modified date!");
@@ -107,7 +106,7 @@ public class ResourceTest {
     }
 
     @Test
-    public void testDeletedResource() {
+    void testDeletedResource() {
         assertNull(DELETED_RESOURCE.getIdentifier(), "Deleted resource has an identifier!");
         assertNull(DELETED_RESOURCE.getInteractionModel(), "Deleted resource has an interaction model!");
         assertNull(DELETED_RESOURCE.getModified(), "Deleted resource has a modification date!");

--- a/core/api/src/test/java/org/trellisldp/api/RuntimeTrellisExceptionTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/RuntimeTrellisExceptionTest.java
@@ -20,30 +20,30 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class RuntimeTrellisExceptionTest {
+class RuntimeTrellisExceptionTest {
 
     @Test
-    public void testException1() {
+    void testException1() {
         final RuntimeException ex = new RuntimeTrellisException();
         assertNull(ex.getMessage(), "Message was not null");
     }
 
     @Test
-    public void testException2() {
+    void testException2() {
         final String msg = "the cause";
         final RuntimeException ex = new RuntimeTrellisException(msg);
         assertEquals(msg, ex.getMessage(), "Unexpected message");
     }
 
     @Test
-    public void testException3() {
+    void testException3() {
         final Throwable cause = new Throwable("an error");
         final RuntimeException ex = new RuntimeTrellisException(cause);
         assertEquals(cause, ex.getCause(), "Unexpected exception cause");
     }
 
     @Test
-    public void testException4() {
+    void testException4() {
         final Throwable cause = new Throwable("an error");
         final String msg = "The message";
         final RuntimeException ex = new RuntimeTrellisException(msg, cause);

--- a/core/api/src/test/java/org/trellisldp/api/SyntaxTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/SyntaxTest.java
@@ -19,10 +19,10 @@ import static org.trellisldp.api.Syntax.SPARQL_UPDATE;
 
 import org.junit.jupiter.api.Test;
 
-public class SyntaxTest {
+class SyntaxTest {
 
     @Test
-    public void testSparqlUpdate() {
+    void testSparqlUpdate() {
         assertEquals("SPARQL-Update", SPARQL_UPDATE.name(), "Incorrect name for SPARQL-Update!");
         assertEquals("SPARQL 1.1 Update", SPARQL_UPDATE.title(), "Incorrect title for SPARQL-Update!");
         assertEquals("application/sparql-update", SPARQL_UPDATE.mediaType(), "Incorrect mediaType for SPARQL-Update!");
@@ -39,7 +39,7 @@ public class SyntaxTest {
     }
 
     @Test
-    public void testLDPatch() {
+    void testLDPatch() {
         assertEquals("LD-Patch", LD_PATCH.name(), "Incorrect name for LD-Patch");
         assertEquals("Linked Data Patch Format", LD_PATCH.title(), "Incorrect title for LD-Patch!");
         assertEquals("text/ldpatch", LD_PATCH.mediaType(), "Incorrect mediaType for LD-Patch!");

--- a/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.condition.EnabledOnJre;
 /**
  * @author acoburn
  */
-public class TrellisUtilsTest {
+class TrellisUtilsTest {
 
     private static final RDF rdf = getInstance();
     private static final long size = 10000L;
@@ -40,12 +40,12 @@ public class TrellisUtilsTest {
         .withinRange('a', 'z').build();
 
     @Test
-    public void testGetInstance() {
+    void testGetInstance() {
         assertNotNull(rdf, "RDF instance is null!");
     }
 
     @Test
-    public void testCollectGraph() {
+    void testCollectGraph() {
         final Graph graph = generate(() -> rdf.createTriple(getIRI(), getIRI(), getIRI()))
             .parallel().limit(size).collect(toGraph());
 
@@ -53,7 +53,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testCollectDataset() {
+    void testCollectDataset() {
         final Dataset dataset = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
             .parallel().limit(size).collect(toDataset());
 
@@ -61,7 +61,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testDatasetCollectorFinisher() {
+    void testDatasetCollectorFinisher() {
         final Dataset dataset = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
             .parallel().limit(size).collect(toDataset());
 
@@ -74,7 +74,7 @@ public class TrellisUtilsTest {
     }
 
     @Test
-    public void testGetContainer() {
+    void testGetContainer() {
         final IRI root = rdf.createIRI("trellis:data/");
         final IRI resource = rdf.createIRI("trellis:data/resource");
         final IRI child = rdf.createIRI("trellis:data/resource/child");
@@ -85,7 +85,7 @@ public class TrellisUtilsTest {
 
     @Test
     @EnabledOnJre(JAVA_8)
-    public void testGetService() {
+    void testGetService() {
         assertTrue(TrellisUtils.findFirst(RDF.class).isPresent());
         assertFalse(TrellisUtils.findFirst(String.class).isPresent());
     }

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -60,7 +60,6 @@ import static javax.ws.rs.core.MediaType.WILDCARD;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
@@ -128,7 +127,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      *           HEAD Tests
      * ****************************** */
     @Test
-    public void testHeadDefaultType() {
+    void testHeadDefaultType() {
         final Response res = target(RESOURCE_PATH).request().head();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -140,7 +139,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      *            GET Tests
      * ******************************* */
     @Test
-    public void testGetJson() throws IOException {
+    void testGetJson() throws IOException {
         final Response res = target("/" + RESOURCE_PATH).request().accept("application/ld+json").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -158,7 +157,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetDefaultType() {
+    void testGetDefaultType() {
         final Response res = target(RESOURCE_PATH).request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -167,7 +166,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetDefaultType2() {
+    void testGetDefaultType2() {
         final Response res = target("resource").request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -176,7 +175,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testScrewyAcceptDatetimeHeader() {
+    void testScrewyAcceptDatetimeHeader() {
         final Response res = target(RESOURCE_PATH).request().header("Accept-Datetime",
                 "it's pathetic how we both").get();
 
@@ -184,14 +183,14 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testScrewyRange() {
+    void testScrewyRange() {
         final Response res = target(BINARY_PATH).request().header("Range", "say it to my face, then").get();
 
         assertEquals(SC_BAD_REQUEST, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetRootSlash() {
+    void testGetRootSlash() {
         final Response res = target("/").request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -200,7 +199,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetRoot() {
+    void testGetRoot() {
         final Response res = target("").request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -209,7 +208,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetDatetime() {
+    void testGetDatetime() {
         assumeTrue(getBaseUrl().startsWith("http://localhost"));
         final Response res = target(RESOURCE_PATH).request()
             .header(ACCEPT_DATETIME, RFC_1123_DATE_TIME.withZone(UTC).format(time)).get();
@@ -228,7 +227,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetTrailingSlash() {
+    void testGetTrailingSlash() {
         final Response res = target(RESOURCE_PATH + "/").request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -238,35 +237,35 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetNotModified() {
+    void testGetNotModified() {
         final Response res = target("").request().header("If-Modified-Since", "Wed, 12 Dec 2018 07:28:00 GMT").get();
 
         assertEquals(SC_NOT_MODIFIED, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetNotModifiedInvalidDate() {
+    void testGetNotModifiedInvalidDate() {
         final Response res = target("").request().header("If-Modified-Since", "Wed, 12 Dec 2017 07:28:00 GMT").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetNotModifiedInvalidSyntax() {
+    void testGetNotModifiedInvalidSyntax() {
         final Response res = target("").request().header("If-Modified-Since", "Yesterday").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetIfNoneMatchStar() {
+    void testGetIfNoneMatchStar() {
         final Response res = target("").request().header("If-None-Match", "*").get();
 
         assertEquals(SC_NOT_MODIFIED, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetIfMatchWeak() {
+    void testGetIfMatchWeak() {
         final String etag = target("").request().get().getEntityTag().getValue();
 
         final Response res = target("").request().header("If-Match", "W/\"" + etag + "\"").get();
@@ -275,7 +274,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetIfMatch() {
+    void testGetIfMatch() {
         final String etag = target("").request().get().getEntityTag().getValue();
 
         final Response res = target("").request().header("If-Match", "\"" + etag + "\"").get();
@@ -284,14 +283,14 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetIfNoneMatchFoo() {
+    void testGetIfNoneMatchFoo() {
         final Response res = target("").request().header("If-None-Match", "\"blah\"").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetIfNoneMatch() {
+    void testGetIfNoneMatch() {
         final String etag = target("").request().get().getEntityTag().getValue();
 
         final Response res = target("").request().header("If-None-Match", "\"" + etag + "\"").get();
@@ -300,7 +299,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetIfNoneMatchWeak() {
+    void testGetIfNoneMatchWeak() {
         final String etag = target("").request().get().getEntityTag().getValue();
 
         final Response res = target("").request().header("If-None-Match", "W/\"" + etag + "\"").get();
@@ -309,7 +308,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetIfMatchBinaryWeak() {
+    void testGetIfMatchBinaryWeak() {
         final String etag = target(BINARY_PATH).request().get().getEntityTag().getValue();
 
         final Response res = target(BINARY_PATH).request().header("If-Match", "W/\"" + etag + "\"").get();
@@ -318,7 +317,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetIfMatchBinary() {
+    void testGetIfMatchBinary() {
         final String etag = target(BINARY_PATH).request().get().getEntityTag().getValue();
 
         final Response res = target(BINARY_PATH).request().header("If-Match", "\"" + etag + "\"").get();
@@ -327,7 +326,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetIfNoneMatchBinary() {
+    void testGetIfNoneMatchBinary() {
         final String etag = target(BINARY_PATH).request().get().getEntityTag().getValue();
 
         final Response res = target(BINARY_PATH).request().header("If-None-Match", "\"" + etag + "\"").get();
@@ -336,7 +335,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetIfNoneMatchWeakBinary() {
+    void testGetIfNoneMatchWeakBinary() {
         final String etag = target(BINARY_PATH).request().get().getEntityTag().getValue();
 
         final Response res = target(BINARY_PATH).request().header("If-None-Match", "W/\"" + etag + "\"").get();
@@ -345,7 +344,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinaryDescription() {
+    void testGetBinaryDescription() {
         final Response res = target(BINARY_PATH).request().accept("text/turtle").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -362,7 +361,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinary() throws IOException {
+    void testGetBinary() throws IOException {
         final Response res = target(BINARY_PATH).request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -376,7 +375,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinaryHeaders() throws IOException {
+    void testGetBinaryHeaders() {
         final Response res = target(BINARY_PATH).request().head();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -388,7 +387,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinaryRange() throws IOException {
+    void testGetBinaryRange() throws IOException {
         final Response res = target(BINARY_PATH).request().header(RANGE, "bytes=3-10").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -399,7 +398,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinaryErrorSkip() throws IOException {
+    void testGetBinaryErrorSkip() throws IOException {
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent()).thenReturn(mockInputStream);
         when(mockInputStream.skip(anyLong())).thenThrow(new IOException());
@@ -408,32 +407,32 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetVersionError() {
+    void testGetVersionError() {
         final Response res = target(BINARY_PATH).queryParam("version", "looking at my history").request().get();
         assertEquals(SC_BAD_REQUEST, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetVersionNotFound() {
+    void testGetVersionNotFound() {
         final Response res = target(NON_EXISTENT_PATH).queryParam("version", "1496260729").request().get();
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetTimemapNotFound() {
+    void testGetTimemapNotFound() {
         final Response res = target(NON_EXISTENT_PATH).queryParam("ext", "timemap").request().get();
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetTimegateNotFound() {
+    void testGetTimegateNotFound() {
         final Response res = target(NON_EXISTENT_PATH).request()
             .header(ACCEPT_DATETIME, "Wed, 16 May 2018 13:18:57 GMT").get();
         assertEquals(SC_NOT_ACCEPTABLE, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetBinaryVersion() throws IOException {
+    void testGetBinaryVersion() throws IOException {
         final Response res = target(BINARY_PATH).queryParam("version", timestamp).request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -453,7 +452,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPrefer() throws IOException {
+    void testPrefer() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .header("Prefer", "return=representation; include=\"" + PreferServerManaged.getIRIString() + "\"")
             .accept("application/ld+json; profile=\"http://www.w3.org/ns/json-ld#compacted\"").get();
@@ -465,11 +464,11 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
         assertAll("Check JSON-LD structure",
                 checkJsonStructure(obj, asList("@context", "title"), asList("mode", "created")));
-        assertEquals("A title", (String) obj.get("title"), "Incorrect title value!");
+        assertEquals("A title", obj.get("title"), "Incorrect title value!");
     }
 
     @Test
-    public void testPrefer2() throws IOException {
+    void testPrefer2() throws IOException {
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockResource.stream()).thenAnswer(inv -> getPreferQuads());
 
@@ -484,11 +483,11 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
         assertAll("Check JSON-LD structure", checkJsonStructure(obj, asList("@context", "title"),
                     asList("mode", "created", "contains", "member")));
-        assertEquals("A title", (String) obj.get("title"), "Incorrect title value!");
+        assertEquals("A title", obj.get("title"), "Incorrect title value!");
     }
 
     @Test
-    public void testPrefer3() throws IOException {
+    void testPrefer3() throws IOException {
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockResource.stream()).thenAnswer(inv -> getPreferQuads());
 
@@ -506,7 +505,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPrefer4() throws IOException {
+    void testPrefer4() throws IOException {
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockResource.stream()).thenAnswer(inv -> getPreferQuads());
 
@@ -521,11 +520,11 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
         assertAll("Check JSON-LD structure", checkJsonStructure(obj, asList("@context", "title", "contains", "member"),
                     asList("mode", "created")));
-        assertEquals("A title", (String) obj.get("title"), "Incorrect title value!");
+        assertEquals("A title", obj.get("title"), "Incorrect title value!");
     }
 
     @Test
-    public void testGetJsonCompact() throws IOException {
+    void testGetJsonCompact() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .accept("application/ld+json; profile=\"http://www.w3.org/ns/json-ld#compacted\"").get();
 
@@ -535,13 +534,13 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         final String entity = IOUtils.toString((InputStream) res.getEntity(), UTF_8);
         final Map<String, Object> obj = MAPPER.readValue(entity, new TypeReference<Map<String, Object>>(){});
 
-        assertEquals("A title", (String) obj.get("title"), "Incorrect title property in JSON!");
+        assertEquals("A title", obj.get("title"), "Incorrect title property in JSON!");
         assertAll("Check JSON-LD structure",
                 checkJsonStructure(obj, asList("@context", "title"), asList("mode", "created")));
     }
 
     @Test
-    public void testGetTimeMapLinkDefaultFormat() {
+    void testGetTimeMapLinkDefaultFormat() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
 
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request().get();
@@ -551,7 +550,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetTimeMapLinkDefaultFormat2() {
+    void testGetTimeMapLinkDefaultFormat2() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
 
         final Response res = target("resource").queryParam("ext", "timemap").request().get();
@@ -561,7 +560,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetTimeMapLinkInvalidFormat() {
+    void testGetTimeMapLinkInvalidFormat() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
 
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
@@ -571,7 +570,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetTimeMapLink() throws IOException {
+    void testGetTimeMapLink() throws IOException {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
                 ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
@@ -600,7 +599,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetTimeMapJsonDefault() throws IOException {
+    void testGetTimeMapJsonDefault() throws IOException {
         when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
                 ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
 
@@ -644,7 +643,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetTimeMapJson() throws IOException {
+    void testGetTimeMapJson() throws IOException {
         when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
                 ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
 
@@ -690,7 +689,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetVersionJson() {
+    void testGetVersionJson() {
         final Response res = target(RESOURCE_PATH).queryParam("version", timestamp).request()
             .accept("application/ld+json; profile=\"http://www.w3.org/ns/json-ld#compacted\"").get();
 
@@ -705,7 +704,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetVersionContainerJson() {
+    void testGetVersionContainerJson() {
         when(mockVersionedResource.getInteractionModel()).thenReturn(LDP.Container);
         final Response res = target(RESOURCE_PATH).queryParam("version", timestamp).request()
             .accept("application/ld+json; profile=\"http://www.w3.org/ns/json-ld#compacted\"").get();
@@ -721,14 +720,14 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetNoAcl() {
+    void testGetNoAcl() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request().get();
 
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetBinaryAcl() {
+    void testGetBinaryAcl() {
         when(mockBinaryResource.hasAcl()).thenReturn(true);
         final Response res = target(BINARY_PATH).queryParam("ext", "acl").request().get();
 
@@ -741,7 +740,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinaryLinks() {
+    void testGetBinaryLinks() {
         final Response res = target(BINARY_PATH).request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -752,7 +751,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetBinaryDescriptionLinks() {
+    void testGetBinaryDescriptionLinks() {
         final Response res = target(BINARY_PATH).request().accept("text/turtle").get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
@@ -764,7 +763,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetAclJsonCompact() throws IOException {
+    void testGetAclJsonCompact() throws IOException {
         when(mockResource.hasAcl()).thenReturn(true);
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request()
             .accept("application/ld+json; profile=\"http://www.w3.org/ns/json-ld#compacted\"").get();
@@ -779,37 +778,38 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         final String entity = IOUtils.toString((InputStream) res.getEntity(), UTF_8);
         final Map<String, Object> obj = MAPPER.readValue(entity, new TypeReference<Map<String, Object>>(){});
 
-        assertEquals(ACL.Control.getIRIString(), (String) obj.get("mode"), "Incorrect ACL mode property!");
+        assertEquals(ACL.Control.getIRIString(), obj.get("mode"), "Incorrect ACL mode property!");
         assertAll("Check Simple JSON-LD", checkSimpleJsonLdResponse(res, LDP.RDFSource));
         assertAll("Check allowed methods", checkAllowedMethods(res, asList(PATCH, GET, HEAD, OPTIONS)));
-        assertAll("Check Vary headers", checkVary(res, asList(ACCEPT_DATETIME)));
+        assertAll("Check Vary headers", checkVary(res, singletonList(ACCEPT_DATETIME)));
         assertAll("Check null headers", checkNullHeaders(res, asList(ACCEPT_POST, ACCEPT_RANGES)));
-        assertAll("Check JSON-LD structure", checkJsonStructure(obj, asList("@context", "mode"), asList("title")));
+        assertAll("Check JSON-LD structure", checkJsonStructure(obj, asList("@context", "mode"),
+                    singletonList("title")));
     }
 
     @Test
-    public void testGetResource() {
+    void testGetResource() {
         final Response res = target(RESOURCE_PATH).request().get();
 
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetNotFound() {
+    void testGetNotFound() {
         final Response res = target(NON_EXISTENT_PATH).request().get();
 
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetGone() {
+    void testGetGone() {
         final Response res = target(DELETED_PATH).request().get();
 
         assertEquals(SC_GONE, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testGetCORSInvalid() {
+    void testGetCORSInvalid() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", "http://foo.com")
             .header("Access-Control-Request-Method", "PUT")
             .header("Access-Control-Request-Headers", "Content-Type, Link").get();
@@ -821,7 +821,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testGetException() {
+    void testGetException() {
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> supplyAsync(() -> {
             throw new RuntimeTrellisException("Expected exception");
         }));
@@ -833,18 +833,18 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      *            OPTIONS Tests
      * ******************************* */
     @Test
-    public void testOptionsLDPRS() {
+    void testOptionsLDPRS() {
         final Response res = target(RESOURCE_PATH).request().options();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
         assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
         assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.RDFSource));
         assertAll("Check allowed methods", checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS)));
-        assertAll("Check null headers", checkNullHeaders(res, asList(MEMENTO_DATETIME)));
+        assertAll("Check null headers", checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
     }
 
     @Test
-    public void testOptionsLDPNR() {
+    void testOptionsLDPNR() {
         final Response res = target(BINARY_PATH).request().options();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -855,7 +855,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsLDPC() {
+    void testOptionsLDPC() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         final Response res = target(RESOURCE_PATH).request().options();
 
@@ -865,7 +865,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         assertAll("Check allowed methods",
                 checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS, POST)));
         assertAll("Check LDP type Link headers", checkLdpTypeHeaders(res, LDP.Container));
-        assertAll("Check null headers", checkNullHeaders(res, asList(MEMENTO_DATETIME)));
+        assertAll("Check null headers", checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
 
         final List<String> acceptPost = asList(res.getHeaderString(ACCEPT_POST).split(","));
         assertEquals(4L, acceptPost.size(), "Accept-Post header has wrong number of elements!");
@@ -876,7 +876,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsACL() {
+    void testOptionsACL() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request().options();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -886,7 +886,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsACLBinary() {
+    void testOptionsACLBinary() {
         final Response res = target(BINARY_PATH).queryParam("ext", "acl").request().options();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -896,27 +896,27 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsNonexistent() {
+    void testOptionsNonexistent() {
         final Response res = target(NON_EXISTENT_PATH).request().options();
 
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testOptionsVersionNotFound() {
+    void testOptionsVersionNotFound() {
         final Response res = target(NON_EXISTENT_PATH).queryParam("version", "1496260729").request().options();
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testOptionsGone() {
+    void testOptionsGone() {
         final Response res = target(DELETED_PATH).request().options();
 
         assertEquals(SC_GONE, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testOptionsSlash() {
+    void testOptionsSlash() {
         final Response res = target(RESOURCE_PATH + "/").request().options();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -926,7 +926,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsTimemap() {
+    void testOptionsTimemap() {
         when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
                 ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
 
@@ -938,7 +938,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsTimemapBinary() {
+    void testOptionsTimemapBinary() {
         when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
                 ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
 
@@ -950,7 +950,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsVersion() {
+    void testOptionsVersion() {
         final Response res = target(RESOURCE_PATH).queryParam("version", timestamp).request().options();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -959,7 +959,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsVersionBinary() {
+    void testOptionsVersionBinary() {
         final Response res = target(BINARY_PATH).queryParam("version", timestamp).request().options();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -968,7 +968,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testOptionsException() {
+    void testOptionsException() {
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> supplyAsync(() -> {
             throw new RuntimeTrellisException("Expected exception");
         }));
@@ -980,7 +980,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      *            POST Tests
      * ******************************* */
     @Test
-    public void testPost() {
+    void testPost() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE)),
                     eq(MAX))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -997,7 +997,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostRoot() {
+    void testPostRoot() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
@@ -1016,7 +1016,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostInvalidLink() {
+    void testPostInvalidLink() {
         final Response res = target(RESOURCE_PATH).request().header("Link", "I never really liked his friends")
             .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1024,7 +1024,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostToTimemap() {
+    void testPostToTimemap() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
             .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1032,7 +1032,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostTypeWrongType() {
+    void testPostTypeWrongType() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1045,7 +1045,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostTypeMismatch() {
+    void testPostTypeMismatch() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1058,7 +1058,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostConflict() {
+    void testPostConflict() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(mockResource));
@@ -1071,7 +1071,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostUnknownLinkType() {
+    void testPostUnknownLinkType() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1087,7 +1087,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostBadContent() {
+    void testPostBadContent() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1099,7 +1099,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostToLdpRs() {
+    void testPostToLdpRs() {
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
                 .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
 
@@ -1110,7 +1110,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostSlug() {
+    void testPostSlug() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
@@ -1125,7 +1125,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostSlugWithSlash() {
+    void testPostSlugWithSlash() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/child_grandchild"))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1140,7 +1140,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostEncodedSlugWithSlash() {
+    void testPostEncodedSlugWithSlash() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/child_grandchild"))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1155,7 +1155,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostSlugWithWhitespace() {
+    void testPostSlugWithWhitespace() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/child_grandchild"))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1170,7 +1170,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostEncodedSlugWithEncodedWhitespace() {
+    void testPostEncodedSlugWithEncodedWhitespace() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/child_grandchild"))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1185,7 +1185,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostEncodedSlugWithInvalidEncoding() {
+    void testPostEncodedSlugWithInvalidEncoding() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1202,7 +1202,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostEmptySlug() {
+    void testPostEmptySlug() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1219,7 +1219,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostEmptyEncodedSlug() {
+    void testPostEmptyEncodedSlug() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1236,7 +1236,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostSlugWithHashURI() {
+    void testPostSlugWithHashURI() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
 
         final Response res = target(RESOURCE_PATH).request().header(SLUG, "child#hash")
@@ -1248,7 +1248,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostSlugWithEncodedHashURI() {
+    void testPostSlugWithEncodedHashURI() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
 
         final Response res = target(RESOURCE_PATH).request().header(SLUG, "child%23hash")
@@ -1260,7 +1260,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostSlugWithQuestionMark() {
+    void testPostSlugWithQuestionMark() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
 
         final Response res = target(RESOURCE_PATH).request().header(SLUG, "child?foo=bar")
@@ -1272,7 +1272,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostSlugWithEncodedQuestionMark() {
+    void testPostSlugWithEncodedQuestionMark() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
 
         final Response res = target(RESOURCE_PATH).request().header(SLUG, "child%3Ffoo=bar")
@@ -1284,7 +1284,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostVersion() {
+    void testPostVersion() {
         final Response res = target(RESOURCE_PATH).queryParam("version", timestamp).request().header(SLUG, "test")
             .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1292,7 +1292,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostAcl() {
+    void testPostAcl() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request().header(SLUG, "test")
             .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1300,7 +1300,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostIndirectContainer() {
+    void testPostIndirectContainer() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
@@ -1316,7 +1316,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostIndirectContainerHashUri() {
+    void testPostIndirectContainerHashUri() {
         final IRI hashResourceId = rdf.createIRI(TRELLIS_DATA_PREFIX + NEW_RESOURCE + "#foo");
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
@@ -1333,7 +1333,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostIndirectContainerSelf() {
+    void testPostIndirectContainerSelf() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
@@ -1349,7 +1349,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostIndirectContainerResource() {
+    void testPostIndirectContainerResource() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
@@ -1365,7 +1365,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostDirectContainer() {
+    void testPostDirectContainer() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
@@ -1381,7 +1381,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostDirectContainerSelf() {
+    void testPostDirectContainerSelf() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
@@ -1397,7 +1397,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostDirectContainerResource() {
+    void testPostDirectContainerResource() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
@@ -1413,7 +1413,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostBadJsonLdSemantics() {
+    void testPostBadJsonLdSemantics() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1425,7 +1425,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostBadJsonLdSyntax() {
+    void testPostBadJsonLdSyntax() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1436,7 +1436,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostConstraint() {
+    void testPostConstraint() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1451,7 +1451,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostIgnoreContains() {
+    void testPostIgnoreContains() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1464,7 +1464,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostNonexistent() {
+    void testPostNonexistent() {
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + NON_EXISTENT_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
         final Response res = target(NON_EXISTENT_PATH).request()
@@ -1474,7 +1474,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostGone() {
+    void testPostGone() {
         when(mockResourceService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + DELETED_PATH + "/" + RANDOM_VALUE))))
             .thenAnswer(inv -> completedFuture(DELETED_RESOURCE));
         final Response res = target(DELETED_PATH).request()
@@ -1484,7 +1484,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostBinary() {
+    void testPostBinary() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockMementoService.get(eq(rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/newresource")),
                     any(Instant.class))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1497,7 +1497,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostTimeMap() {
+    void testPostTimeMap() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
             .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1505,7 +1505,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostSlash() {
+    void testPostSlash() {
         final Response res = target(RESOURCE_PATH + "/").request().header(SLUG, "test")
             .post(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1513,7 +1513,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPostException() {
+    void testPostException() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> supplyAsync(() -> {
             throw new RuntimeTrellisException("Expected exception");
@@ -1526,7 +1526,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      *            PUT Tests
      * ******************************* */
     @Test
-    public void testPutExisting() {
+    void testPutExisting() {
         final Response res = target(RESOURCE_PATH).request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1538,7 +1538,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutTypeWrongType() {
+    void testPutTypeWrongType() {
         final Response res = target(RESOURCE_PATH).request()
             .header("Link", "<http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"non-existent\"")
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
@@ -1551,7 +1551,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutUncontainedIndirectContainer() {
+    void testPutUncontainedIndirectContainer() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
@@ -1566,7 +1566,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutUncontainedIndirectContainerSelf() {
+    void testPutUncontainedIndirectContainerSelf() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
@@ -1586,7 +1586,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutUncontainedIndirectContainerResource() {
+    void testPutUncontainedIndirectContainerResource() {
         final EventService myEventService = mock(EventService.class);
         final Resource mockChildResource = mock(Resource.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
@@ -1603,7 +1603,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIndirectContainer() {
+    void testPutIndirectContainer() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
@@ -1617,7 +1617,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIndirectContainerSelf() {
+    void testPutIndirectContainerSelf() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
@@ -1631,7 +1631,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIndirectContainerResource() {
+    void testPutIndirectContainerResource() {
         final EventService myEventService = mock(EventService.class);
         final Resource mockChildResource = mock(Resource.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
@@ -1649,7 +1649,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutDirectContainer() {
+    void testPutDirectContainer() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
@@ -1663,7 +1663,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutDirectContainerSelf() {
+    void testPutDirectContainerSelf() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
@@ -1677,7 +1677,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutDirectContainerResource() {
+    void testPutDirectContainerResource() {
         final EventService myEventService = mock(EventService.class);
         when(mockBundler.getEventService()).thenReturn(myEventService);
         when(mockRootResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
@@ -1691,7 +1691,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutExistingBinaryDescription() {
+    void testPutExistingBinaryDescription() {
         final Response res = target(BINARY_PATH).request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1701,7 +1701,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutExistingUnknownLink() {
+    void testPutExistingUnknownLink() {
         final Response res = target(RESOURCE_PATH).request()
             .header("Link", "<http://example.com/types/Foo>; rel=\"type\"")
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
@@ -1712,7 +1712,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutExistingIgnoreProperties() {
+    void testPutExistingIgnoreProperties() {
         final Response res = target(RESOURCE_PATH).request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" ;"
                         + " <http://example.com/foo> <http://www.w3.org/ns/ldp#IndirectContainer> ;"
@@ -1725,7 +1725,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutExistingSubclassLink() {
+    void testPutExistingSubclassLink() {
         final Response res = target(RESOURCE_PATH).request()
             .header("Link", LDP.Container + "; rel=\"type\"")
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
@@ -1736,7 +1736,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutExistingMalformed() {
+    void testPutExistingMalformed() {
         final Response res = target(RESOURCE_PATH).request()
             .put(entity("<> <http://purl.org/dc/terms/title \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1744,7 +1744,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutConstraint() {
+    void testPutConstraint() {
         final Response res = target(RESOURCE_PATH).request()
             .put(entity("<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \"Some literal\" .",
                     TEXT_TURTLE_TYPE));
@@ -1755,7 +1755,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIgnoreContains() {
+    void testPutIgnoreContains() {
         final Response res = target(RESOURCE_PATH).request()
             .put(entity("<> <http://www.w3.org/ns/ldp#contains> <./other> . ",
                     TEXT_TURTLE_TYPE));
@@ -1764,7 +1764,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutNew() {
+    void testPutNew() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test");
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
         when(mockMementoService.get(eq(identifier), eq(MAX))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -1780,7 +1780,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutDeleted() {
+    void testPutDeleted() {
         final Response res = target(DELETED_PATH).request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1791,7 +1791,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutVersion() {
+    void testPutVersion() {
         final Response res = target(RESOURCE_PATH).queryParam("version", timestamp).request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1799,7 +1799,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutAcl() {
+    void testPutAcl() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -1808,7 +1808,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutAclOnDc() {
+    void testPutAclOnDc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
@@ -1818,7 +1818,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutAclOnIc() {
+    void testPutAclOnIc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
@@ -1828,7 +1828,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutOnDc() {
+    void testPutOnDc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
         final Response res = target(RESOURCE_PATH).request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
@@ -1839,7 +1839,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutOnIc() {
+    void testPutOnIc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         final Response res = target(RESOURCE_PATH).request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
@@ -1850,7 +1850,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutBinary() {
+    void testPutBinary() {
         final Response res = target(BINARY_PATH).request().put(entity("some data.", TEXT_PLAIN_TYPE));
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -1859,7 +1859,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutBinaryToACL() {
+    void testPutBinaryToACL() {
         final Response res = target(BINARY_PATH).queryParam("ext", "acl").request()
             .put(entity("some data.", TEXT_PLAIN_TYPE));
 
@@ -1867,7 +1867,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfMatch() {
+    void testPutIfMatch() {
         final String etag = target(BINARY_PATH).request().get().getEntityTag().getValue();
 
         final Response res = target(BINARY_PATH).request().header("If-Match", "\"" + etag + "\"")
@@ -1877,7 +1877,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfMatchWeak() {
+    void testPutIfMatchWeak() {
         final String etag = target("").request().get().getEntityTag().getValue();
 
         final Response res = target("").request().header("If-Match", "W/\"" + etag + "\"")
@@ -1887,7 +1887,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfNoneMatchEtag() {
+    void testPutIfNoneMatchEtag() {
         final String etag = target(BINARY_PATH).request().get().getEntityTag().getValue();
 
         final Response res = target(BINARY_PATH).request().header("If-None-Match", "\"" + etag + "\"")
@@ -1897,7 +1897,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfNoneMatchRdfEtag() {
+    void testPutIfNoneMatchRdfEtag() {
         final String etag = target("").request().get().getEntityTag().getValue();
 
         final Response res = target("").request().header("If-None-Match", "\"" + etag + "\"")
@@ -1907,7 +1907,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfNoneMatchRdfWeakEtag() {
+    void testPutIfNoneMatchRdfWeakEtag() {
         final String etag = target("").request().get().getEntityTag().getValue();
 
         final Response res = target("").request().header("If-None-Match", "W/\"" + etag + "\"")
@@ -1917,7 +1917,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfNoneMatchWeakEtag() {
+    void testPutIfNoneMatchWeakEtag() {
         final String etag = target(BINARY_PATH).request().get().getEntityTag().getValue();
 
         final Response res = target(BINARY_PATH).request().header("If-None-Match", "W/\"" + etag + "\"")
@@ -1927,7 +1927,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfNoneMatch() {
+    void testPutIfNoneMatch() {
         final Response res = target(BINARY_PATH).request().header("If-None-Match", "\"foo\", \"bar\"")
             .put(entity("some different data.", TEXT_PLAIN_TYPE));
 
@@ -1935,7 +1935,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfMatchStar() {
+    void testPutIfMatchStar() {
         final Response res = target(BINARY_PATH).request().header("If-Match", "*")
             .put(entity("some different data.", TEXT_PLAIN_TYPE));
 
@@ -1943,7 +1943,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfMatchMultiple() {
+    void testPutIfMatchMultiple() {
         final String etag = target(BINARY_PATH).request().get().getEntityTag().getValue();
         final Response res = target(BINARY_PATH).request().header("If-Match", "\"blah\", \"" + etag + "\"")
             .put(entity("some different data.", TEXT_PLAIN_TYPE));
@@ -1952,7 +1952,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfNoneMatchStar() {
+    void testPutIfNoneMatchStar() {
         final Response res = target(BINARY_PATH).request().header("If-None-Match", "*")
             .put(entity("some different data.", TEXT_PLAIN_TYPE));
 
@@ -1960,7 +1960,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutBadIfMatch() {
+    void testPutBadIfMatch() {
         final Response res = target(BINARY_PATH).request().header("If-Match", "4db2c60044c906361ac212ae8684e8ad")
             .put(entity("some different data.", TEXT_PLAIN_TYPE));
 
@@ -1968,7 +1968,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutIfUnmodified() {
+    void testPutIfUnmodified() {
         final Response res = target(BINARY_PATH).request()
             .header("If-Unmodified-Since", "Tue, 29 Aug 2017 07:14:52 GMT")
             .put(entity("some different data.", TEXT_PLAIN_TYPE));
@@ -1977,7 +1977,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutPreconditionFailed() {
+    void testPutPreconditionFailed() {
         final Response res = target(BINARY_PATH).request().header("If-Match", "\"blahblahblah\"")
             .put(entity("some different data.", TEXT_PLAIN_TYPE));
 
@@ -1985,7 +1985,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutPreconditionFailed2() {
+    void testPutPreconditionFailed2() {
         final Response res = target(BINARY_PATH).request()
             .header("If-Unmodified-Since", "Wed, 19 Oct 2016 10:15:00 GMT")
             .put(entity("some different data.", TEXT_PLAIN_TYPE));
@@ -1994,7 +1994,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutSlash() {
+    void testPutSlash() {
         final Response res = target(RESOURCE_PATH + "/").request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -2003,7 +2003,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutTimeMap() {
+    void testPutTimeMap() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
             .put(entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -2011,7 +2011,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPutException() {
+    void testPutException() {
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> supplyAsync(() -> {
             throw new RuntimeTrellisException("Expected exception");
         }));
@@ -2023,7 +2023,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      *            DELETE Tests
      * ******************************* */
     @Test
-    public void testDeleteExisting() {
+    void testDeleteExisting() {
         final Response res = target(RESOURCE_PATH).request().delete();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -2031,21 +2031,21 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testDeleteNonexistent() {
+    void testDeleteNonexistent() {
         final Response res = target(NON_EXISTENT_PATH).request().delete();
 
         assertEquals(SC_NOT_FOUND, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testDeleteDeleted() {
+    void testDeleteDeleted() {
         final Response res = target(DELETED_PATH).request().delete();
 
         assertEquals(SC_GONE, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testDeleteVersion() {
+    void testDeleteVersion() {
         final Response res = target(RESOURCE_PATH).queryParam("version", timestamp).request().delete();
 
         assertEquals(SC_METHOD_NOT_ALLOWED, res.getStatus(), "Unexpected response code!");
@@ -2053,7 +2053,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testDeleteNonExistant() {
+    void testDeleteNonExistant() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test");
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
         when(mockMementoService.get(eq(identifier), eq(MAX))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -2065,7 +2065,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testDeleteWithChildren() {
+    void testDeleteWithChildren() {
         when(mockVersionedResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockVersionedResource.stream(eq(LDP.PreferContainment))).thenAnswer(inv -> Stream.of(
                     rdf.createTriple(identifier, LDP.contains, rdf.createIRI(identifier.getIRIString() + "/child"))));
@@ -2076,7 +2076,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testDeleteNoChildren1() {
+    void testDeleteNoChildren1() {
         when(mockVersionedResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockVersionedResource.stream(eq(LDP.PreferContainment))).thenAnswer(inv -> Stream.empty());
 
@@ -2086,7 +2086,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testDeleteNoChildren2() {
+    void testDeleteNoChildren2() {
         when(mockVersionedResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockVersionedResource.stream(eq(LDP.PreferContainment))).thenAnswer(inv -> Stream.empty());
 
@@ -2096,7 +2096,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testDeleteAcl() {
+    void testDeleteAcl() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request().delete();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -2104,13 +2104,13 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testDeleteTimeMap() {
+    void testDeleteTimeMap() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request().delete();
         assertEquals(SC_METHOD_NOT_ALLOWED, res.getStatus(), "Unexpected response code!");
     }
 
     @Test
-    public void testDeleteSlash() {
+    void testDeleteSlash() {
         final Response res = target(RESOURCE_PATH + "/").request().delete();
 
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
@@ -2121,7 +2121,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testDeleteException() {
+    void testDeleteException() {
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> supplyAsync(() -> {
             throw new RuntimeTrellisException("Expected exception");
         }));
@@ -2133,7 +2133,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      *      PATCH tests
      * ********************* */
     @Test
-    public void testPatchVersion() {
+    void testPatchVersion() {
         final Response res = target(RESOURCE_PATH).queryParam("version", timestamp).request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2142,7 +2142,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchTimeMap() {
+    void testPatchTimeMap() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2151,7 +2151,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchExisting() {
+    void testPatchExisting() {
         final Response res = target(RESOURCE_PATH).request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2162,7 +2162,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchRoot() {
+    void testPatchRoot() {
         final Response res = target().request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2173,7 +2173,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchMissing() {
+    void testPatchMissing() {
         final Response res = target(NON_EXISTENT_PATH).request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2181,7 +2181,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchGone() {
+    void testPatchGone() {
         final Response res = target(DELETED_PATH).request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2189,7 +2189,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchExistingIgnoreLdpType() throws IOException {
+    void testPatchExistingIgnoreLdpType() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .header("Prefer", "return=representation; include=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"")
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" ;"
@@ -2206,7 +2206,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchExistingJsonLd() throws IOException {
+    void testPatchExistingJsonLd() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .header("Prefer", "return=representation")
             .header("Accept", "application/ld+json; profile=\"http://www.w3.org/ns/json-ld#compacted\"")
@@ -2222,11 +2222,11 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
         assertAll("Check JSON-LD structure",
                 checkJsonStructure(obj, asList("@context", "title"), asList("mode", "created")));
-        assertEquals("A new title", (String) obj.get("title"), "Incorrect title value!");
+        assertEquals("A new title", obj.get("title"), "Incorrect title value!");
     }
 
     @Test
-    public void testPatchExistingBinary() {
+    void testPatchExistingBinary() {
         final Response res = target(BINARY_PATH).request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2237,7 +2237,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchExistingResponse() throws IOException {
+    void testPatchExistingResponse() throws IOException {
         final Response res = target(RESOURCE_PATH).request()
             .header("Prefer", "return=representation; include=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"")
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
@@ -2251,7 +2251,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchConstraint() {
+    void testPatchConstraint() {
         final Response res = target(RESOURCE_PATH).request()
             .method("PATCH", entity("INSERT { <> a \"Some literal\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2262,7 +2262,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchToTimemap() {
+    void testPatchToTimemap() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "timemap").request()
             .method("PATCH", entity("<> <http://purl.org/dc/terms/title> \"A title\" .", TEXT_TURTLE_TYPE));
 
@@ -2270,7 +2270,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchNew() {
+    void testPatchNew() {
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH + "/test");
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
         when(mockMementoService.get(eq(identifier), eq(MAX))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -2284,7 +2284,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchAcl() {
+    void testPatchAcl() {
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2295,7 +2295,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchOnDc() {
+    void testPatchOnDc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
         final Response res = target(RESOURCE_PATH).request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
@@ -2307,7 +2307,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchOnIc() {
+    void testPatchOnIc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         final Response res = target(RESOURCE_PATH).request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
@@ -2319,7 +2319,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchAclOnDc() {
+    void testPatchAclOnDc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.DirectContainer);
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
@@ -2330,7 +2330,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchAclOnIc() {
+    void testPatchAclOnIc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         final Response res = target(RESOURCE_PATH).queryParam("ext", "acl").request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
@@ -2341,7 +2341,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchInvalidContent() {
+    void testPatchInvalidContent() {
         final Response res = target(RESOURCE_PATH).request().method("PATCH", entity("blah blah blah", "invalid/type"));
 
         assertEquals(SC_UNSUPPORTED_MEDIA_TYPE, res.getStatus(), "Unexpected response code!");
@@ -2349,7 +2349,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchSlash() {
+    void testPatchSlash() {
         final Response res = target(RESOURCE_PATH + "/").request()
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2359,7 +2359,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchNotAcceptable() {
+    void testPatchNotAcceptable() {
         final Response res = target(RESOURCE_PATH).request().accept("text/foo")
             .method("PATCH", entity("INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}",
                         APPLICATION_SPARQL_UPDATE));
@@ -2368,7 +2368,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testPatchException() {
+    void testPatchException() {
         when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> supplyAsync(() -> {
             throw new RuntimeTrellisException("Expected exception");
         }));
@@ -2380,7 +2380,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      * Some other method
      */
     @Test
-    public void testOtherMethod() {
+    void testOtherMethod() {
         final Response res = target(RESOURCE_PATH).request().method("FOO");
         assertEquals(SC_METHOD_NOT_ALLOWED, res.getStatus(), "Unexpected response code!");
     }
@@ -2389,7 +2389,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
      *      Test cache control headers
      * ************************************ */
     @Test
-    public void testCacheControl() {
+    void testCacheControl() {
         final Response res = target(RESOURCE_PATH).request().get();
         assertEquals(SC_OK, res.getStatus(), "Unexpected response code!");
         assertNotNull(res.getHeaderString(CACHE_CONTROL), "Missing Cache-Control header!");
@@ -2397,13 +2397,13 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
-    public void testCacheControlOptions() {
+    void testCacheControlOptions() {
         final Response res = target(RESOURCE_PATH).request().options();
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
         assertNull(res.getHeaderString(CACHE_CONTROL), "Unexpected Cache-Control header!");
     }
 
-    protected static List<Link> getLinks(final Response res) {
+    static List<Link> getLinks(final Response res) {
         // Jersey's client doesn't parse complex link headers correctly
         final List<String> links = res.getStringHeaders().get(LINK);
         if (links != null) {
@@ -2422,11 +2422,11 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
                 l.getRel().contains("original") && l.getUri().toString().equals(getBaseUrl() + path));
     }
 
-    protected static Predicate<Link> hasLink(final IRI iri, final String rel) {
+    static Predicate<Link> hasLink(final IRI iri, final String rel) {
         return link -> rel.equals(link.getRel()) && iri.getIRIString().equals(link.getUri().toString());
     }
 
-    protected static Predicate<Link> hasType(final IRI iri) {
+    static Predicate<Link> hasType(final IRI iri) {
         return hasLink(iri, "type");
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/BaseCrossOriginResourceSharingFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseCrossOriginResourceSharingFilterTest.java
@@ -36,9 +36,9 @@ import org.junit.jupiter.api.function.Executable;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class BaseCrossOriginResourceSharingFilterTest extends BaseTrellisHttpResourceTest {
 
-    protected static final String ORIGIN = "http://example.com";
+    static final String ORIGIN = "http://example.com";
 
-    protected void init() {
+    void init() {
         initMocks(this);
     }
 
@@ -49,7 +49,7 @@ abstract class BaseCrossOriginResourceSharingFilterTest extends BaseTrellisHttpR
         return ClientBuilder.newClient(clientConfig);
     }
 
-    protected Stream<Executable> checkAllowMethods(final Response res, final List<String> expected) {
+    Stream<Executable> checkAllowMethods(final Response res, final List<String> expected) {
         final List<String> actual = stream(res.getHeaderString("Access-Control-Allow-Methods").split(","))
             .collect(toList());
         return Stream.concat(
@@ -59,7 +59,7 @@ abstract class BaseCrossOriginResourceSharingFilterTest extends BaseTrellisHttpR
                         "Method " + method + " not in expected -Allow-Methods header!")));
     }
 
-    protected Stream<Executable> checkNoCORSHeaders(final Response res) {
+    Stream<Executable> checkNoCORSHeaders(final Response res) {
         return Stream.of(
                 () -> assertNull(res.getHeaderString("Access-Control-Allow-Origin"), "Unexpected -Allow-Origin!"),
                 () -> assertNull(res.getHeaderString("Access-Control-Allow-Credentials"),

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -24,7 +24,6 @@ import static java.util.Optional.of;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.commons.io.IOUtils.readLines;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
@@ -81,52 +80,37 @@ import org.trellisldp.vocabulary.XSD;
 
 abstract class BaseTrellisHttpResourceTest extends JerseyTest {
 
-    protected static final IOService ioService = new JenaIOService();
+    static final int timestamp = 1496262729;
+    static final RDF rdf = getInstance();
+    static final Instant time = ofEpochSecond(timestamp);
+    static final ObjectMapper MAPPER = new ObjectMapper();
+    static final String RANDOM_VALUE = "randomValue";
+    static final String RESOURCE_PATH = "resource";
+    static final String CHILD_PATH = RESOURCE_PATH + "/child";
+    static final String BINARY_PATH = "binary";
+    static final String NON_EXISTENT_PATH = "nonexistent";
+    static final String DELETED_PATH = "deleted";
+    static final String NEW_RESOURCE = RESOURCE_PATH + "/newresource";
+    static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH);
+    static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
+    static final IRI binaryInternalIdentifier = rdf.createIRI("file:///some/file");
+    static final IRI newresourceIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + NEW_RESOURCE);
+    static final IRI childIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH);
+    static final String HUB = "http://hub.example.org/";
 
-    protected static final AuditService auditService = new NoopAuditService();
-
-    protected static final int timestamp = 1496262729;
-
-    protected static final Instant time = ofEpochSecond(timestamp);
-
-    protected static final ObjectMapper MAPPER = new ObjectMapper();
-
-    protected static final RDF rdf = getInstance();
-
-    protected static final IRI agent = rdf.createIRI("user:agent");
-
-    protected static final BlankNode bnode = rdf.createBlankNode();
-
-    protected static final String BINARY_MIME_TYPE = "text/plain";
-
-    protected static final String RANDOM_VALUE = "randomValue";
-
-    protected static final String RESOURCE_PATH = "resource";
-    protected static final String CHILD_PATH = RESOURCE_PATH + "/child";
-    protected static final String BINARY_PATH = "binary";
-    protected static final String NON_EXISTENT_PATH = "nonexistent";
-    protected static final String DELETED_PATH = "deleted";
-    protected static final String USER_DELETED_PATH = "userdeleted";
-    protected static final String NEW_RESOURCE = RESOURCE_PATH + "/newresource";
-
-    protected static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH);
-    protected static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
-    protected static final IRI binaryIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + BINARY_PATH);
-    protected static final IRI binaryInternalIdentifier = rdf.createIRI("file:///some/file");
-    protected static final IRI nonexistentIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + NON_EXISTENT_PATH);
-    protected static final IRI newresourceIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + NEW_RESOURCE);
-    protected static final IRI childIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH);
-    protected static final IRI deletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + DELETED_PATH);
-    protected static final IRI userDeletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + USER_DELETED_PATH);
-    protected static final Set<IRI> allInteractionModels = new HashSet<>(asList(LDP.Resource, LDP.RDFSource,
-                LDP.NonRDFSource, LDP.Container, LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer));
-
-    protected static final String BASE_URL = "http://example.org/";
-
-    protected static final String HUB = "http://hub.example.org/";
-
-    protected static final BinaryMetadata testBinary = BinaryMetadata.builder(binaryInternalIdentifier)
-        .mimeType(BINARY_MIME_TYPE).build();
+    private static final IOService ioService = new JenaIOService();
+    private static final AuditService auditService = new NoopAuditService();
+    private static final String USER_DELETED_PATH = "userdeleted";
+    private static final String BINARY_MIME_TYPE = "text/plain";
+    private static final IRI deletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + DELETED_PATH);
+    private static final IRI userDeletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + USER_DELETED_PATH);
+    private static final Set<IRI> allInteractionModels = new HashSet<>(asList(LDP.Resource, LDP.RDFSource,
+            LDP.NonRDFSource, LDP.Container, LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer));
+    private static final IRI binaryIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + BINARY_PATH);
+    private static final IRI nonexistentIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + NON_EXISTENT_PATH);
+    private static final String BASE_URL = "http://example.org/";
+    private static final BinaryMetadata testBinary = BinaryMetadata.builder(binaryInternalIdentifier)
+            .mimeType(BINARY_MIME_TYPE).build();
 
     @Mock
     protected ServiceBundler mockBundler;
@@ -153,12 +137,12 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     @Mock
     protected InputStream mockInputStream;
 
-    protected String getBaseUrl() {
+    String getBaseUrl() {
         return BASE_URL;
     }
 
     @BeforeAll
-    public void before() throws Exception {
+    void initialize() throws Exception {
         super.setUp();
     }
 
@@ -168,12 +152,12 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     }
 
     @AfterAll
-    public void after() throws Exception {
+    void cleanup() throws Exception {
         super.tearDown();
     }
 
     @BeforeEach
-    public void setUpMocks() throws Exception {
+    void setUpMocks() {
         setUpBundler();
         setUpResourceService();
         setUpMementoService();
@@ -255,7 +239,7 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
         doCallRealMethod().when(mockMementoService).put(any(ResourceService.class), any(IRI.class));
     }
 
-    private void setUpBinaryService() throws Exception {
+    private void setUpBinaryService() {
         when(mockBinaryService.get(eq(binaryInternalIdentifier))).thenAnswer(inv -> completedFuture(mockBinary));
         when(mockBinary.getContent(eq(3), eq(10)))
                         .thenReturn(new ByteArrayInputStream("e input".getBytes(UTF_8)));

--- a/core/http/src/test/java/org/trellisldp/http/CacheControlFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CacheControlFilterTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class CacheControlFilterTest {
+class CacheControlFilterTest {
 
     @Mock
     private ContainerRequestContext mockRequest;
@@ -41,12 +41,12 @@ public class CacheControlFilterTest {
     private MultivaluedMap<String, Object> mockHeaders;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void testCacheControlNull() throws Exception {
+    void testCacheControlNull() {
 
         when(mockRequest.getMethod()).thenReturn(GET);
         when(mockResponse.getStatusInfo()).thenReturn(OK);
@@ -58,7 +58,7 @@ public class CacheControlFilterTest {
     }
 
     @Test
-    public void testCacheControlHead() throws Exception {
+    void testCacheControlHead() {
 
         when(mockRequest.getMethod()).thenReturn(HEAD);
         when(mockResponse.getStatusInfo()).thenReturn(OK);

--- a/core/http/src/test/java/org/trellisldp/http/CrossOriginResourceSharingFilterAnyOriginTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CrossOriginResourceSharingFilterAnyOriginTest.java
@@ -16,6 +16,7 @@ package org.trellisldp.http;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
@@ -32,15 +33,15 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class CrossOriginResourceSharingFilterAnyOriginTest extends BaseCrossOriginResourceSharingFilterTest {
+class CrossOriginResourceSharingFilterAnyOriginTest extends BaseCrossOriginResourceSharingFilterTest {
 
     @Override
-    public Application configure() {
+    protected Application configure() {
         init();
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler));
-        config.register(new CrossOriginResourceSharingFilter(asList("*"),
+        config.register(new CrossOriginResourceSharingFilter(singletonList("*"),
                     asList("GET", "HEAD", "PATCH", "POST", "PUT"),
                     asList("Link", "Content-Type", "Accept", "Accept-Language", "Accept-Datetime"),
                     emptyList(), false, 0));
@@ -48,7 +49,7 @@ public class CrossOriginResourceSharingFilterAnyOriginTest extends BaseCrossOrig
     }
 
     @Test
-    public void testGetCORS() {
+    void testGetCORS() {
         final String baseUri = getBaseUri().toString();
         final String origin = baseUri.substring(0, baseUri.length() - 1);
         final Response res = target(RESOURCE_PATH).request().header("Origin", origin)
@@ -64,7 +65,7 @@ public class CrossOriginResourceSharingFilterAnyOriginTest extends BaseCrossOrig
     }
 
     @Test
-    public void testGetCORSSimple() {
+    void testGetCORSSimple() {
         final String baseUri = getBaseUri().toString();
         final String origin = baseUri.substring(0, baseUri.length() - 1);
         final Response res = target(RESOURCE_PATH).request().header("Origin", origin)
@@ -80,7 +81,7 @@ public class CrossOriginResourceSharingFilterAnyOriginTest extends BaseCrossOrig
     }
 
     @Test
-    public void testOptionsPreflightSimple() {
+    void testOptionsPreflightSimple() {
         final String baseUri = getBaseUri().toString();
         final String origin = baseUri.substring(0, baseUri.length() - 1);
         final Response res = target(RESOURCE_PATH).request().header("Origin", origin)
@@ -101,7 +102,7 @@ public class CrossOriginResourceSharingFilterAnyOriginTest extends BaseCrossOrig
 
 
     @Test
-    public void testCorsPreflight() {
+    void testCorsPreflight() {
         final String baseUri = getBaseUri().toString();
         final String origin = baseUri.substring(0, baseUri.length() - 1);
         final Response res = target(RESOURCE_PATH).request().header("Origin", origin)
@@ -131,7 +132,7 @@ public class CrossOriginResourceSharingFilterAnyOriginTest extends BaseCrossOrig
     }
 
     @Test
-    public void testCorsPreflightNoMatch() {
+    void testCorsPreflightNoMatch() {
         final String baseUri = getBaseUri().toString();
         final String origin = baseUri.substring(0, baseUri.length() - 1);
         final Response res = target(RESOURCE_PATH).request().header("Origin", origin)

--- a/core/http/src/test/java/org/trellisldp/http/CrossOriginResourceSharingFilterDefaultTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CrossOriginResourceSharingFilterDefaultTest.java
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOriginResourceSharingFilterTest {
+class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOriginResourceSharingFilterTest {
 
     @Override
-    public Application configure() {
+    protected Application configure() {
         init();
 
         final ResourceConfig config = new ResourceConfig();
@@ -44,7 +44,7 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
     }
 
     @Test
-    public void testGetCORS() {
+    void testGetCORS() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PATCH")
             .header("Access-Control-Request-Headers", "Content-Type, Link").get();
@@ -60,7 +60,7 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
     }
 
     @Test
-    public void testGetCORSSimple() {
+    void testGetCORSSimple() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PATCH")
             .header("Access-Control-Request-Headers", "Accept").get();
@@ -76,7 +76,7 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
     }
 
     @Test
-    public void testOptionsPreflightSimple() {
+    void testOptionsPreflightSimple() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PATCH")
             .header("Access-Control-Request-Headers", "Accept").options();
@@ -95,7 +95,7 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
     }
 
     @Test
-    public void testCorsPreflight() {
+    void testCorsPreflight() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PATCH")
             .header("Access-Control-Request-Headers", "Content-Language, Content-Type, Link").options();
@@ -118,7 +118,7 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
    }
 
     @Test
-    public void testCorsPreflightNoRequestHeaders() {
+    void testCorsPreflightNoRequestHeaders() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PATCH").options();
 
@@ -133,7 +133,7 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
     }
 
     @Test
-    public void testCorsPreflightNoMatch() {
+    void testCorsPreflightNoMatch() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PATCH")
             .header("Access-Control-Request-Headers", "Content-Language").options();
@@ -149,7 +149,7 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
     }
 
     @Test
-    public void testOptionsPreflightInvalid2() {
+    void testOptionsPreflightInvalid2() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PATCH")
             .header("Access-Control-Request-Headers", "Content-Type, Link, Bar").options();
@@ -159,7 +159,7 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
     }
 
     @Test
-    public void testOptionsPreflightInvalid3() {
+    void testOptionsPreflightInvalid3() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "BAR")
             .header("Access-Control-Request-Headers", "Content-Type, Link").options();
@@ -167,5 +167,4 @@ public class CrossOriginResourceSharingFilterDefaultTest extends BaseCrossOrigin
         assertEquals(SC_NO_CONTENT, res.getStatus(), "Unexpected response code!");
         assertAll("Check that there are no CORS headers", checkNoCORSHeaders(res));
     }
-
 }

--- a/core/http/src/test/java/org/trellisldp/http/CrossOriginResourceSharingFilterSpecificOriginTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CrossOriginResourceSharingFilterSpecificOriginTest.java
@@ -15,6 +15,7 @@ package org.trellisldp.http;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
@@ -31,26 +32,26 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCrossOriginResourceSharingFilterTest {
+class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCrossOriginResourceSharingFilterTest {
 
     private static final String MAX_AGE = "180";
     private static final String TRUE = "true";
 
     @Override
-    public Application configure() {
+    protected Application configure() {
         init();
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler));
-        config.register(new CrossOriginResourceSharingFilter(asList(ORIGIN),
+        config.register(new CrossOriginResourceSharingFilter(singletonList(ORIGIN),
                     asList("GET", "HEAD", "PATCH", "POST", "PUT"),
                     asList("Link", "Content-Type", "Accept", "Accept-Language", "Accept-Patch"),
-                    asList("Accept-Patch"), true, 180));
+                    singletonList("Accept-Patch"), true, 180));
         return config;
     }
 
     @Test
-    public void testGetCORSInvalid() {
+    void testGetCORSInvalid() {
         final String baseUri = getBaseUri().toString();
         final String origin = baseUri.substring(0, baseUri.length() - 1);
         final Response res = target(RESOURCE_PATH).request().header("Origin", origin)
@@ -62,7 +63,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
     }
 
     @Test
-    public void testGetCORS() {
+    void testGetCORS() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PUT")
             .header("Access-Control-Request-Headers", "Content-Type, Link").get();
@@ -78,7 +79,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
     }
 
     @Test
-    public void testGetCORSSimple() {
+    void testGetCORSSimple() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "POST")
             .header("Access-Control-Request-Headers", "Accept").get();
@@ -94,7 +95,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
     }
 
     @Test
-    public void testOptionsPreflightSimple() {
+    void testOptionsPreflightSimple() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "POST")
             .header("Access-Control-Request-Headers", "Accept").options();
@@ -113,7 +114,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
     }
 
     @Test
-    public void testCorsPreflight() {
+    void testCorsPreflight() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PUT")
             .header("Access-Control-Request-Headers", "Content-Language, Content-Type, Link").options();
@@ -135,7 +136,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
    }
 
     @Test
-    public void testCorsPreflightNoRequestHeaders() {
+    void testCorsPreflightNoRequestHeaders() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PUT").options();
 
@@ -149,7 +150,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
     }
 
     @Test
-    public void testCorsPreflightNoMatch() {
+    void testCorsPreflightNoMatch() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PUT")
             .header("Access-Control-Request-Headers", "Content-Language").options();
@@ -164,7 +165,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
     }
 
     @Test
-    public void testOptionsPreflightInvalid() {
+    void testOptionsPreflightInvalid() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", "http://foo.com")
             .header("Access-Control-Request-Method", "PUT")
             .header("Access-Control-Request-Headers", "Content-Type, Link").options();
@@ -174,7 +175,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
     }
 
     @Test
-    public void testOptionsPreflightInvalid2() {
+    void testOptionsPreflightInvalid2() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "PUT")
             .header("Access-Control-Request-Headers", "Content-Type, Link, Bar").options();
@@ -184,7 +185,7 @@ public class CrossOriginResourceSharingFilterSpecificOriginTest extends BaseCros
     }
 
     @Test
-    public void testOptionsPreflightInvalid3() {
+    void testOptionsPreflightInvalid3() {
         final Response res = target(RESOURCE_PATH).request().header("Origin", ORIGIN)
             .header("Access-Control-Request-Method", "FOO")
             .header("Access-Control-Request-Headers", "Content-Type, Link").options();

--- a/core/http/src/test/java/org/trellisldp/http/TestAuthenticationFilter.java
+++ b/core/http/src/test/java/org/trellisldp/http/TestAuthenticationFilter.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.http;
 
-import java.io.IOException;
 import java.security.Principal;
 
 import javax.annotation.Priority;
@@ -32,22 +31,17 @@ class TestAuthenticationFilter implements ContainerRequestFilter {
     private final String principal;
     private final String userRole;
 
-    public TestAuthenticationFilter(final String principal, final String role) {
+    TestAuthenticationFilter(final String principal, final String role) {
         this.principal = principal;
         this.userRole = role;
     }
 
     @Override
-    public void filter(final ContainerRequestContext requestContext) throws IOException {
+    public void filter(final ContainerRequestContext requestContext) {
         requestContext.setSecurityContext(new SecurityContext() {
             @Override
             public Principal getUserPrincipal() {
-                return new Principal() {
-                    @Override
-                    public String getName() {
-                        return principal;
-                    }
-                };
+                return () -> principal;
             }
 
             @Override

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpFilterTest.java
@@ -13,7 +13,6 @@
  */
 package org.trellisldp.http;
 
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -25,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class TrellisHttpFilterTest {
+class TrellisHttpFilterTest {
 
     @Mock
     private ContainerRequestContext mockContext;
@@ -34,12 +33,12 @@ public class TrellisHttpFilterTest {
     private UriInfo mockUriInfo;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void testTestRootSlash() throws Exception {
+    void testTestRootSlash() {
 
         when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         when(mockUriInfo.getPath()).thenReturn("/");

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
@@ -14,6 +14,7 @@
 package org.trellisldp.http;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import javax.ws.rs.core.Application;
@@ -23,15 +24,15 @@ import org.glassfish.jersey.server.ResourceConfig;
 /**
  * @author acoburn
  */
-public class TrellisHttpResourceAdminTest extends AbstractTrellisHttpResourceTest {
+class TrellisHttpResourceAdminTest extends AbstractTrellisHttpResourceTest {
 
     @Override
-    protected String getBaseUrl() {
+    String getBaseUrl() {
         return getBaseUri().toString();
     }
 
     @Override
-    public Application configure() {
+    protected Application configure() {
 
         initMocks(this);
 
@@ -44,7 +45,7 @@ public class TrellisHttpResourceAdminTest extends AbstractTrellisHttpResourceTes
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
-        config.register(new CrossOriginResourceSharingFilter(asList(origin),
+        config.register(new CrossOriginResourceSharingFilter(singletonList(origin),
                     asList("PATCH", "POST", "PUT"),
                     asList("Link", "Content-Type", "Accept", "Accept-Datetime"),
                     asList("Link", "Content-Type", "Pragma", "Memento-Datetime"), true, 100));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
@@ -14,6 +14,7 @@
 package org.trellisldp.http;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import javax.ws.rs.core.Application;
@@ -23,19 +24,19 @@ import org.glassfish.jersey.server.ResourceConfig;
 /**
  * @author acoburn
  */
-public class TrellisHttpResourceBaseUrlTest extends AbstractTrellisHttpResourceTest {
+class TrellisHttpResourceBaseUrlTest extends AbstractTrellisHttpResourceTest {
 
     // The absence of trailing slash is intentional here; it tests configuration overrides
     // that lack a trailing slash.
     private static final String URL = "http://example.com";
 
     @Override
-    protected String getBaseUrl() {
+    String getBaseUrl() {
         return URL + "/";
     }
 
     @Override
-    public Application configure() {
+    protected Application configure() {
 
         // Junit runner doesn't seem to work very well with JerseyTest
         initMocks(this);
@@ -49,7 +50,7 @@ public class TrellisHttpResourceBaseUrlTest extends AbstractTrellisHttpResourceT
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
-        config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),
+        config.register(new CrossOriginResourceSharingFilter(singletonList(origin), asList("PATCH", "POST", "PUT"),
                         asList("Link", "Content-Type", "Accept-Datetime", "Accept"),
                         asList("Link", "Content-Type", "Memento-Datetime"), true, 100));
         return config;

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
@@ -14,6 +14,7 @@
 package org.trellisldp.http;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import javax.ws.rs.core.Application;
@@ -23,15 +24,15 @@ import org.glassfish.jersey.server.ResourceConfig;
 /**
  * @author acoburn
  */
-public class TrellisHttpResourceNoAgentTest extends AbstractTrellisHttpResourceTest {
+class TrellisHttpResourceNoAgentTest extends AbstractTrellisHttpResourceTest {
 
     @Override
-    protected String getBaseUrl() {
+    String getBaseUrl() {
         return getBaseUri().toString();
     }
 
     @Override
-    public Application configure() {
+    protected Application configure() {
 
         // Junit runner doesn't seem to work very well with JerseyTest
         initMocks(this);
@@ -44,7 +45,7 @@ public class TrellisHttpResourceNoAgentTest extends AbstractTrellisHttpResourceT
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
-        config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),
+        config.register(new CrossOriginResourceSharingFilter(singletonList(origin), asList("PATCH", "POST", "PUT"),
                         asList("Link", "Content-Type", "Accept-Datetime", "Accept"),
                         asList("Link", "Content-Type", "Memento-Datetime"), true, 100));
         return config;

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -14,13 +14,13 @@
 package org.trellisldp.http;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.stream.Stream.of;
 import static javax.ws.rs.core.MediaType.WILDCARD_TYPE;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
@@ -52,7 +52,7 @@ import org.trellisldp.http.core.TrellisRequest;
 /**
  * @author acoburn
  */
-public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
+class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
 
     @Mock
     private AsyncResponse mockResponse;
@@ -73,12 +73,12 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
     private ArgumentCaptor<Response> captor;
 
     @Override
-    protected String getBaseUrl() {
+    String getBaseUrl() {
         return getBaseUri().toString();
     }
 
     @Override
-    public Application configure() {
+    protected Application configure() {
 
         initMocks(this);
 
@@ -91,21 +91,21 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
-        config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),
+        config.register(new CrossOriginResourceSharingFilter(singletonList(origin), asList("PATCH", "POST", "PUT"),
                         asList("Link", "Content-Type", "Accept-Datetime", "Accept"),
                         asList("Link", "Content-Type", "Memento-Datetime"), true, 100));
         return config;
     }
 
     @Test
-    public void testNoBaseURL() throws Exception {
+    void testNoBaseURL() throws Exception {
         final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler, null);
 
         when(mockUriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>(singletonMap("path", "resource")));
         when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://my.example.com/"));
         when(mockUriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
         when(mockHttpHeaders.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
-        when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(asList(WILDCARD_TYPE));
+        when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(WILDCARD_TYPE));
 
         matcher.getResourceHeaders(mockResponse, mockRequest, mockUriInfo, mockHttpHeaders);
         verify(mockResponse).resume(captor.capture());
@@ -117,7 +117,7 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
     }
 
     @Test
-    public void testInitializeExistingLdpResourceWithFailure() throws Exception {
+    void testInitializeExistingLdpResourceWithFailure() {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> runAsync(() -> {
@@ -130,7 +130,7 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
     }
 
     @Test
-    public void testInitializeExistingLdpResource() throws Exception {
+    void testInitializeExistingLdpResource() {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(mockRootResource));
@@ -141,7 +141,7 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
     }
 
     @Test
-    public void testInitializeoNoLdpResource() throws Exception {
+    void testInitializeoNoLdpResource() {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
@@ -158,7 +158,7 @@ public class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
     }
 
     @Test
-    public void testInitializeoDeletedLdpResource() throws Exception {
+    void testInitializeoDeletedLdpResource() {
         final ResourceService mockService = mock(ResourceService.class);
         when(mockBundler.getResourceService()).thenReturn(mockService);
         when(mockService.get(eq(root))).thenAnswer(inv -> completedFuture(DELETED_RESOURCE));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUserTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUserTest.java
@@ -14,6 +14,7 @@
 package org.trellisldp.http;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import javax.ws.rs.core.Application;
@@ -23,10 +24,10 @@ import org.glassfish.jersey.server.ResourceConfig;
 /**
  * @author acoburn
  */
-public class TrellisHttpResourceUserTest extends AbstractTrellisHttpResourceTest {
+class TrellisHttpResourceUserTest extends AbstractTrellisHttpResourceTest {
 
     @Override
-    public Application configure() {
+    protected Application configure() {
 
         // Junit runner doesn't seem to work very well with JerseyTest
         initMocks(this);
@@ -40,7 +41,7 @@ public class TrellisHttpResourceUserTest extends AbstractTrellisHttpResourceTest
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
-        config.register(new CrossOriginResourceSharingFilter(asList(origin), asList("PATCH", "POST", "PUT"),
+        config.register(new CrossOriginResourceSharingFilter(singletonList(origin), asList("PATCH", "POST", "PUT"),
                         asList("Link", "Content-Type", "Accept-Datetime", "Accept"),
                         asList("Link", "Content-Type", "Memento-Datetime"), true, 100));
         return config;

--- a/core/http/src/test/java/org/trellisldp/http/WebSubHeaderFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/WebSubHeaderFilterTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-public class WebSubHeaderFilterTest {
+class WebSubHeaderFilterTest {
 
     @Mock
     private ContainerRequestContext mockRequest;
@@ -41,12 +41,12 @@ public class WebSubHeaderFilterTest {
     private MultivaluedMap<String, Object> mockHeaders;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void testWebSubNull() throws Exception {
+    void testWebSubNull() {
 
         when(mockRequest.getMethod()).thenReturn(GET);
         when(mockResponse.getStatusInfo()).thenReturn(OK);
@@ -58,7 +58,7 @@ public class WebSubHeaderFilterTest {
     }
 
     @Test
-    public void testWebSubHead() throws Exception {
+    void testWebSubHead() {
 
         when(mockRequest.getMethod()).thenReturn(HEAD);
         when(mockResponse.getStatusInfo()).thenReturn(OK);

--- a/core/http/src/test/java/org/trellisldp/http/core/AcceptDatetimeTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/AcceptDatetimeTest.java
@@ -20,22 +20,22 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class AcceptDatetimeTest {
+class AcceptDatetimeTest {
 
     @Test
-    public void testDatetime() {
+    void testDatetime() {
         final AcceptDatetime datetime = AcceptDatetime.valueOf("Mon, 1 May 2017 13:43:22 GMT");
         assertEquals("2017-05-01T13:43:22Z", datetime.toString(), "Incorrect datetime string!");
         assertEquals("2017-05-01T13:43:22Z", datetime.getInstant().toString(), "Incorrect stringified datetime!");
     }
 
     @Test
-    public void testInvalidDatetime() {
+    void testInvalidDatetime() {
         assertNull(AcceptDatetime.valueOf("Mon, 2 May 2017 13:43:22 GMT"), "Unexpected invalid datetime!");
     }
 
     @Test
-    public void testNullDatetime() {
+    void testNullDatetime() {
         assertNull(AcceptDatetime.valueOf(null), "Check null datetime");
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/core/DefaultTimemapGeneratorTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/DefaultTimemapGeneratorTest.java
@@ -26,12 +26,11 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class DefaultTimemapGeneratorTest {
-
-    private final String url = "http://example.com/resource/memento";
+class DefaultTimemapGeneratorTest {
 
     @Test
-    public void testIsMementoLink() {
+    void testIsMementoLink() {
+        final String url = "http://example.com/resource/memento";
         final TimemapGenerator svc = new DefaultTimemapGenerator();
         final List<Link> links = asList(
             fromUri(url).rel("memento").param("datetime", "Fri, 11 May 2018 15:29:25 GMT").build(),

--- a/core/http/src/test/java/org/trellisldp/http/core/HttpSessionTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/HttpSessionTest.java
@@ -26,10 +26,10 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * @author acoburn
  */
-public class HttpSessionTest {
+class HttpSessionTest {
 
     @Test
-    public void testHttpSession() {
+    void testHttpSession() {
         final Instant time = now();
         final Session session = new HttpSession();
         assertEquals(Trellis.AnonymousAgent, session.getAgent(), "Incorrect agent in default session!");

--- a/core/http/src/test/java/org/trellisldp/http/core/PreferTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/PreferTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.function.Executable;
 /**
  * @author acoburn
  */
-public class PreferTest {
+class PreferTest {
 
     @Test
-    public void testPreferNullValues() {
+    void testPreferNullValues() {
         final Prefer prefer = new Prefer(null, null, null, null, null);
         assertFalse(prefer.getPreference().isPresent());
         assertFalse(prefer.getHandling().isPresent());
@@ -37,31 +37,31 @@ public class PreferTest {
     }
 
     @Test
-    public void testPrefer1() {
+    void testPrefer1() {
         final Prefer prefer = Prefer.valueOf("return=representation; include=\"http://example.org/test\"");
         assertAll("Check simple Prefer parsing", checkPreferInclude(prefer, "http://example.org/test"));
     }
 
     @Test
-    public void testPrefer1b() {
+    void testPrefer1b() {
         final Prefer prefer = Prefer.ofInclude("http://example.org/test");
         assertAll("Check simple Prefer parsing", checkPreferInclude(prefer, "http://example.org/test"));
     }
 
     @Test
-    public void testPrefer1c() {
+    void testPrefer1c() {
         final Prefer prefer = Prefer.valueOf("return=representation; include=http://example.org/test");
         assertAll("Check simple Prefer parsing", checkPreferInclude(prefer, "http://example.org/test"));
     }
 
     @Test
-    public void testPrefer2() {
+    void testPrefer2() {
         final Prefer prefer = Prefer.valueOf("return  =  representation;   include =  \"http://example.org/test\"");
         assertAll("Check simple Prefer parsing", checkPreferInclude(prefer, "http://example.org/test"));
     }
 
     @Test
-    public void testPrefer3() {
+    void testPrefer3() {
         final Prefer prefer = Prefer.valueOf("return=minimal");
         assertEquals(of("minimal"), prefer.getPreference(), "Check preference value");
         assertTrue(prefer.getInclude().isEmpty(), "Check that there are no includes");
@@ -71,7 +71,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPrefer4() {
+    void testPrefer4() {
         final Prefer prefer = Prefer.valueOf("return=other");
         assertTrue(prefer.getInclude().isEmpty(), "Check includes is empty");
         assertTrue(prefer.getOmit().isEmpty(), "Check omits is empty");
@@ -81,7 +81,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPrefer5() {
+    void testPrefer5() {
         final Prefer prefer = Prefer.valueOf("return=representation; omit=\"http://example.org/test\"");
         assertEquals(of("representation"), prefer.getPreference(), "Check preference value");
         assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
@@ -92,7 +92,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPrefer5b() {
+    void testPrefer5b() {
         final Prefer prefer = Prefer.ofOmit("http://example.org/test");
         assertEquals(of("representation"), prefer.getPreference(), "Check preference value");
         assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
@@ -103,7 +103,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPrefer6() {
+    void testPrefer6() {
         final Prefer prefer = Prefer.valueOf("handling=lenient; return=minimal");
         assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
         assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
@@ -113,7 +113,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPrefer7() {
+    void testPrefer7() {
         final Prefer prefer = Prefer.valueOf("respond-async; random-param");
         assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
         assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
@@ -123,7 +123,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPrefer8() {
+    void testPrefer8() {
         final Prefer prefer = Prefer.valueOf("handling=strict; return=minimal");
         assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
         assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
@@ -133,7 +133,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPrefer9() {
+    void testPrefer9() {
         final Prefer prefer = Prefer.valueOf("handling=blah; return=minimal");
         assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
         assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
@@ -143,7 +143,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testStaticInclude() {
+    void testStaticInclude() {
         final Prefer prefer = Prefer.ofInclude();
         assertEquals(of("representation"), prefer.getPreference(), "Check preference type");
         assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
@@ -151,7 +151,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testStaticOmit() {
+    void testStaticOmit() {
         final Prefer prefer = Prefer.ofOmit();
         assertEquals(of("representation"), prefer.getPreference(), "Check preference type");
         assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
@@ -159,7 +159,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPreferBadQuotes() {
+    void testPreferBadQuotes() {
         final Prefer prefer = Prefer.valueOf("return=representation; include=\"http://example.org/test");
         assertEquals(of("representation"), prefer.getPreference(), "Check preference type");
         assertEquals(1L, prefer.getInclude().size(), "Check includes count");
@@ -170,7 +170,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testPreferBadQuotes2() {
+    void testPreferBadQuotes2() {
         final Prefer prefer = Prefer.valueOf("return=representation; include=\"");
         assertEquals(of("representation"), prefer.getPreference(), "Check preference type");
         assertEquals(1L, prefer.getInclude().size(), "Check for includes size");
@@ -181,7 +181,7 @@ public class PreferTest {
     }
 
     @Test
-    public void testNullPrefer() {
+    void testNullPrefer() {
         assertNull(Prefer.valueOf(null), "Check null value");
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/core/RangeTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/RangeTest.java
@@ -20,42 +20,43 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class RangeTest {
+class RangeTest {
 
     @Test
-    public void testRange() {
+    void testRange() {
         final Range range = Range.valueOf("bytes=1-10");
+        assertNotNull(range, "Range is not null!");
         assertEquals(1, range.getFrom(), "Check 'from' value");
         assertEquals(10, range.getTo(), "Check 'to' value");
     }
 
     @Test
-    public void testInvalidRange() {
+    void testInvalidRange() {
         assertNull(Range.valueOf("bytes=10-1"), "Check invalid range");
     }
 
     @Test
-    public void testInvalidNumbers() {
+    void testInvalidNumbers() {
         assertNull(Range.valueOf("bytes=1-15.5"), "Check invalid numbers");
     }
 
     @Test
-    public void testInvalidRange2() {
+    void testInvalidRange2() {
         assertNull(Range.valueOf("bytes=1-15, 20-24"), "Check invalid multiple ranges");
     }
 
     @Test
-    public void testInvalidNumbers3() {
+    void testInvalidNumbers3() {
         assertNull(Range.valueOf("bytes=1-foo"), "Check invalid values");
     }
 
     @Test
-    public void testBadInput() {
+    void testBadInput() {
         assertNull(Range.valueOf("blahblahblah"), "Check invalid input");
     }
 
     @Test
-    public void testNullInput() {
+    void testNullInput() {
         assertNull(Range.valueOf(null), "Check null input");
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/core/SimpleEventTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/SimpleEventTest.java
@@ -35,7 +35,7 @@ import org.trellisldp.vocabulary.SKOS;
 /**
  * @author acoburn
  */
-public class SimpleEventTest {
+class SimpleEventTest {
 
     private static final RDF rdf = getInstance();
 
@@ -43,7 +43,7 @@ public class SimpleEventTest {
     private final IRI agent = rdf.createIRI("http://example.org/agent");
 
     @Test
-    public void testSimpleEvent() {
+    void testSimpleEvent() {
         final IRI resource = rdf.createIRI(identifier);
         final Instant time = now();
 
@@ -66,7 +66,7 @@ public class SimpleEventTest {
     }
 
     @Test
-    public void testEmptyEvent() {
+    void testEmptyEvent() {
         final IRI resource = rdf.createIRI(identifier);
 
         final Event event = new SimpleEvent(identifier, agent, emptyList(), emptyList());

--- a/core/http/src/test/java/org/trellisldp/http/core/SlugTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/SlugTest.java
@@ -20,57 +20,57 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class SlugTest {
+class SlugTest {
 
     @Test
-    public void testSlug() {
+    void testSlug() {
         final Slug slug = Slug.valueOf("slugValue");
         assertEquals("slugValue", slug.getValue(), "Check slug value");
     }
 
     @Test
-    public void testEncodedInput() {
+    void testEncodedInput() {
         final Slug slug = Slug.valueOf("slug%3Avalue");
         assertEquals("slug:value", slug.getValue(), "Check decoding slug value");
     }
 
     @Test
-    public void testSpaceNormalization() {
+    void testSpaceNormalization() {
         final Slug slug = Slug.valueOf("slug  value");
         assertEquals("slug_value", slug.getValue(), "Check slug value");
     }
 
     @Test
-    public void testSlashNormalization() {
+    void testSlashNormalization() {
         final Slug slug = Slug.valueOf("slug/value");
         assertEquals("slug_value", slug.getValue(), "Check slug value");
     }
 
     @Test
-    public void testSpaceSlashNormalization() {
+    void testSpaceSlashNormalization() {
         final Slug slug = Slug.valueOf("slug\t/ value");
         assertEquals("slug_value", slug.getValue(), "Check slug value");
     }
 
     @Test
-    public void testHashUri() {
+    void testHashUri() {
         final Slug slug = Slug.valueOf("slugValue#foo");
         assertEquals("slugValue", slug.getValue(), "Check slug value");
     }
 
     @Test
-    public void testQueryParam() {
+    void testQueryParam() {
         final Slug slug = Slug.valueOf("slugValue?bar=baz");
         assertEquals("slugValue", slug.getValue(), "Check slug value");
     }
 
     @Test
-    public void testBadInput() {
+    void testBadInput() {
         assertNull(Slug.valueOf("An invalid % value"), "Check invalid input");
     }
 
     @Test
-    public void testNullInput() {
+    void testNullInput() {
         assertNull(Slug.valueOf(null), "Check null input");
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/core/VersionTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/VersionTest.java
@@ -20,27 +20,27 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class VersionTest {
+class VersionTest {
 
     @Test
-    public void testVersion() {
+    void testVersion() {
         final Version v = Version.valueOf("1493646202");
         assertEquals("2017-05-01T13:43:22Z", v.getInstant().toString(), "Check datetime string");
         assertEquals("2017-05-01T13:43:22Z", v.toString(), "Check stringified version");
     }
 
     @Test
-    public void testInvalidVersion() {
+    void testInvalidVersion() {
         assertNull(Version.valueOf("blah"), "Check parsing an invalid version");
     }
 
     @Test
-    public void testBadValue() {
+    void testBadValue() {
         assertNull(Version.valueOf("-13.12"), "Check parsing an invalid date");
     }
 
     @Test
-    public void testNullValue() {
+    void testNullValue() {
         assertNull(Version.valueOf(null), "Check parsing a null value");
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -19,7 +19,6 @@ import static javax.ws.rs.core.Link.fromUri;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.trellisldp.http.core.HttpConstants.ACL;
 import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE;
@@ -41,10 +40,10 @@ import org.trellisldp.vocabulary.LDP;
 /**
  * @author acoburn
  */
-public class DeleteHandlerTest extends BaseTestHandler {
+class DeleteHandlerTest extends BaseTestHandler {
 
     @Test
-    public void testDelete() {
+    void testDelete() {
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, null);
         final Response res = handler.deleteResource(handler.initialize(mockParent, mockResource))
             .toCompletableFuture().join().build();
@@ -52,7 +51,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testBadAudit() {
+    void testBadAudit() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.BasicContainer.getIRIString()).rel("type").build());
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
@@ -67,7 +66,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDeleteError() {
+    void testDeleteError() {
         when(mockResourceService.delete(any(Metadata.class))).thenReturn(asyncException());
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
         assertThrows(CompletionException.class, () ->
@@ -76,7 +75,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDeletePersistenceSupport() {
+    void testDeletePersistenceSupport() {
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
         final Response res = assertThrows(WebApplicationException.class, () ->
@@ -88,7 +87,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDeleteACLError() {
+    void testDeleteACLError() {
         when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getExt()).thenReturn(ACL);
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
@@ -98,7 +97,7 @@ public class DeleteHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDeleteACLAuditError() {
+    void testDeleteACLAuditError() {
         when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getExt()).thenReturn(ACL);

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -87,13 +87,13 @@ import org.trellisldp.vocabulary.SKOS;
 /**
  * @author acoburn
  */
-public class GetHandlerTest extends BaseTestHandler {
+class GetHandlerTest extends BaseTestHandler {
 
-    private BinaryMetadata testBinary = BinaryMetadata.builder(rdf.createIRI("file:///testResource.txt"))
+    private final BinaryMetadata testBinary = BinaryMetadata.builder(rdf.createIRI("file:///testResource.txt"))
         .mimeType("text/plain").build();
 
     @Test
-    public void testGetLdprs() {
+    void testGetLdprs() {
         when(mockTrellisRequest.getBaseUrl()).thenReturn("http://example.org");
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
@@ -122,7 +122,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetPreferLdprs() {
+    void testGetPreferLdprs() {
         when(mockIoService.supportedUpdateSyntaxes()).thenReturn(singletonList(LD_PATCH));
         when(mockTrellisRequest.getPrefer())
             .thenReturn(Prefer.valueOf("return=representation; include=\"http://www.w3.org/ns/ldp#PreferContainment"));
@@ -143,7 +143,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetVersionedLdprs() {
+    void testGetVersionedLdprs() {
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, true, true, true, null, null);
         final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build();
@@ -172,7 +172,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testExtraLinks() {
+    void testExtraLinks() {
         final String inbox = "http://ldn.example.com/inbox";
         final String annService = "http://annotation.example.com/resource";
 
@@ -193,7 +193,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testNotAcceptableLdprs() {
+    void testNotAcceptableLdprs() {
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(APPLICATION_JSON_TYPE));
 
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
@@ -205,7 +205,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testMinimalLdprs() {
+    void testMinimalLdprs() {
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(APPLICATION_LD_JSON_TYPE));
         when(mockTrellisRequest.getPrefer()).thenReturn(Prefer.valueOf("return=minimal"));
 
@@ -235,7 +235,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetLdpc() {
+    void testGetLdpc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockIoService.supportedWriteSyntaxes()).thenReturn(Stream.of(TURTLE, NTRIPLES, JSONLD).collect(toList()));
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(
@@ -278,7 +278,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetHTML() {
+    void testGetHTML() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockTrellisRequest.getAcceptableMediaTypes())
             .thenReturn(singletonList(MediaType.valueOf(RDFA.mediaType())));
@@ -297,7 +297,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetBinaryDescription() {
+    void testGetBinaryDescription() {
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
 
@@ -309,7 +309,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetBinaryDescription2() {
+    void testGetBinaryDescription2() {
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getExt()).thenReturn(DESCRIPTION);
@@ -337,7 +337,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetBinary() {
+    void testGetBinary() {
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(WILDCARD_TYPE));
@@ -360,7 +360,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testGetAcl() {
+    void testGetAcl() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         when(mockResource.hasAcl()).thenReturn(true);
         when(mockTrellisRequest.getExt()).thenReturn("acl");
@@ -375,7 +375,7 @@ public class GetHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testFilterMementoLink() {
+    void testFilterMementoLink() {
         final Instant time1 = now();
         final Instant time2 = time1.plusSeconds(10L);
         final SortedSet<Instant> mementos = new TreeSet<>();
@@ -387,11 +387,11 @@ public class GetHandlerTest extends BaseTestHandler {
                 mementos).build();
 
         assertAll("Check MementoHeaders",
-                checkMementoLinks(res.getStringHeaders().get(LINK).stream().map(Link::valueOf).collect(toList()), 2L));
+                checkMementoLinks(res.getStringHeaders().get(LINK).stream().map(Link::valueOf).collect(toList())));
     }
 
     @Test
-    public void testLimitMementoHeaders() {
+    void testLimitMementoHeaders() {
         final Instant time1 = now();
         final Instant time2 = time1.plusSeconds(10L);
         final Instant time3 = time1.plusSeconds(20L);
@@ -409,12 +409,12 @@ public class GetHandlerTest extends BaseTestHandler {
                 mementos).build();
 
         assertAll("Check MementoHeaders",
-                checkMementoLinks(res.getStringHeaders().get(LINK).stream().map(Link::valueOf).collect(toList()), 2L));
+                checkMementoLinks(res.getStringHeaders().get(LINK).stream().map(Link::valueOf).collect(toList())));
     }
 
-    private Stream<Executable> checkMementoLinks(final List<Link> links, final long mementos) {
+    private Stream<Executable> checkMementoLinks(final List<Link> links) {
         return Stream.of(
-                () -> assertEquals(mementos, links.stream().filter(link -> link.getRels().contains("memento")).count()),
+                () -> assertEquals(2L, links.stream().filter(link -> link.getRels().contains("memento")).count()),
                 () -> assertEquals(1L, links.stream().filter(link -> link.getRels().contains("first")).count()),
                 () -> assertEquals(1L, links.stream().filter(link -> link.getRels().contains("last")).count()));
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/HttpUtilsTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/HttpUtilsTest.java
@@ -22,7 +22,6 @@ import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.TrellisUtils.TRELLIS_BNODE_PREFIX;
@@ -65,7 +64,7 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * @author acoburn
  */
-public class HttpUtilsTest {
+class HttpUtilsTest {
 
     private static final RDF rdf = getInstance();
     private static final IOService ioService = new JenaIOService();
@@ -81,12 +80,12 @@ public class HttpUtilsTest {
     private Dataset mockDataset;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void testGetSyntax() {
+    void testGetSyntax() {
         final List<MediaType> types = asList(
                 new MediaType("application", "json"),
                 new MediaType("text", "xml"),
@@ -96,13 +95,13 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testGetSyntaxEmpty() {
+    void testGetSyntaxEmpty() {
         assertNull(HttpUtils.getSyntax(ioService, emptyList(), "some/type"), "Syntax not rejected!");
         assertEquals(TURTLE, HttpUtils.getSyntax(ioService, emptyList(), null), "Turtle not default syntax!");
     }
 
     @Test
-    public void testGetSyntaxFallback() {
+    void testGetSyntaxFallback() {
         final List<MediaType> types = asList(
                 new MediaType("application", "json"),
                 new MediaType("text", "xml"),
@@ -113,7 +112,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testCheckIfModifiedSince() {
+    void testCheckIfModifiedSince() {
         final String time = "Wed, 21 Oct 2015 07:28:00 GMT";
         assertThrows(RedirectionException.class, () ->
                 HttpUtils.checkIfModifiedSince("GET", time, ofEpochSecond(1445412479)));
@@ -121,14 +120,14 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testDefaultProfile() {
+    void testDefaultProfile() {
         final String defaultProfile = "http://example.com/profile";
         final IRI profile = HttpUtils.getDefaultProfile(JSONLD, identifier, defaultProfile);
         assertEquals(rdf.createIRI(defaultProfile), profile);
     }
 
     @Test
-    public void testGetSyntaxError() {
+    void testGetSyntaxError() {
         final List<MediaType> types = asList(
                 new MediaType("application", "json"),
                 new MediaType("text", "xml"));
@@ -138,7 +137,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testFilterPrefer1() {
+    void testFilterPrefer1() {
         final Set<IRI> filtered = HttpUtils.triplePreferences(
                     Prefer.valueOf("return=representation; include=\"" +
                         Trellis.PreferServerManaged.getIRIString() + "\""));
@@ -149,7 +148,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testFilterPrefer2() {
+    void testFilterPrefer2() {
         final Set<IRI> filtered2 = HttpUtils.triplePreferences(Prefer.valueOf("return=representation"));
 
         assertTrue(filtered2.contains(Trellis.PreferUserManaged), "Prefer filter omits quad!");
@@ -157,7 +156,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testFilterPrefer3() {
+    void testFilterPrefer3() {
         final Set<IRI> filtered3 = HttpUtils.triplePreferences(Prefer.valueOf("return=representation; include=\"" +
                         Trellis.PreferAudit.getIRIString() + "\""));
 
@@ -168,7 +167,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testFilterPrefer4() {
+    void testFilterPrefer4() {
         final Set<IRI> filtered4 = HttpUtils.triplePreferences(Prefer.valueOf("return=representation; include=\"" +
                         Trellis.PreferUserManaged.getIRIString() + "\""));
 
@@ -179,7 +178,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testSkolemize() {
+    void testSkolemize() {
         final String baseUrl = "http://example.org/";
         final Literal literal = rdf.createLiteral("A title");
         final BlankNode bnode = rdf.createBlankNode("foo");
@@ -194,10 +193,10 @@ public class HttpUtilsTest {
                 if (uri.startsWith(TRELLIS_BNODE_PREFIX)) {
                     return bnode;
                 }
-                return (IRI) inv.getArgument(0);
+                return inv.getArgument(0);
             });
         when(mockResourceService.toExternal(any(RDFTerm.class), eq(baseUrl))).thenAnswer(inv -> {
-            final RDFTerm term = (RDFTerm) inv.getArgument(0);
+            final RDFTerm term = inv.getArgument(0);
             if (term instanceof IRI) {
                 final String identifierString = ((IRI) term).getIRIString();
                 if (identifierString.startsWith(TRELLIS_DATA_PREFIX)) {
@@ -207,7 +206,7 @@ public class HttpUtilsTest {
             return term;
         });
         when(mockResourceService.toInternal(any(RDFTerm.class), eq(baseUrl))).thenAnswer(inv -> {
-            final RDFTerm term = (RDFTerm) inv.getArgument(0);
+            final RDFTerm term = inv.getArgument(0);
             if (term instanceof IRI) {
                 final String identifierString = ((IRI) term).getIRIString();
                 if (identifierString.startsWith(baseUrl)) {
@@ -239,7 +238,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testProfile() {
+    void testProfile() {
         final List<MediaType> types = asList(
                 new MediaType("application", "json"),
                 new MediaType("text", "xml"),
@@ -248,7 +247,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testMultipleProfiles() {
+    void testMultipleProfiles() {
         final List<MediaType> types = asList(
                 new MediaType("application", "json"),
                 new MediaType("text", "xml"),
@@ -257,7 +256,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testNoProfile() {
+    void testNoProfile() {
         final List<MediaType> types = asList(
                 new MediaType("application", "json"),
                 new MediaType("text", "xml"),
@@ -266,7 +265,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testCloseInputStreamWithError() throws IOException {
+    void testCloseInputStreamWithError() throws IOException {
         doThrow(new IOException()).when(mockInputStream).close();
         assertThrows(UncheckedIOException.class, () ->
                 HttpUtils.closeInputStreamAsync(mockInputStream).accept(null, null),
@@ -274,7 +273,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testRequirePreconditions() {
+    void testRequirePreconditions() {
         assertDoesNotThrow(() -> HttpUtils.checkRequiredPreconditions(true, "*", null));
         assertDoesNotThrow(() -> HttpUtils.checkRequiredPreconditions(true, null, "Mon, 17 Dec 2018 07:28:00 GMT"));
         assertDoesNotThrow(() -> HttpUtils.checkRequiredPreconditions(false, null, null));
@@ -284,7 +283,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void testCloseDataset() throws Exception {
+    void testCloseDataset() throws Exception {
         doThrow(new IOException()).when(mockDataset).close();
         assertThrows(RuntimeTrellisException.class, () -> HttpUtils.closeDataset(mockDataset));
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/MementoResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/MementoResourceTest.java
@@ -36,43 +36,40 @@ import javax.ws.rs.core.Link;
 
 import org.junit.jupiter.api.Test;
 
-public class MementoResourceTest {
+class MementoResourceTest {
 
     @Test
-    public void testFilteredMementoLink() {
+    void testFilteredMementoLink() {
         final Link link = fromUri("http://example.com/resource/memento/1").rel(MEMENTO)
             .param(DATETIME, ofInstant(now(), UTC).format(RFC_1123_DATE_TIME)).build();
-        final boolean filter = true;
-        assertTrue(MementoResource.filterLinkParams(link, !filter).getParams().containsKey(DATETIME));
-        assertFalse(MementoResource.filterLinkParams(link, filter).getParams().containsKey(DATETIME));
+        assertTrue(MementoResource.filterLinkParams(link, false).getParams().containsKey(DATETIME));
+        assertFalse(MementoResource.filterLinkParams(link, true).getParams().containsKey(DATETIME));
     }
 
     @Test
-    public void testFilteredTimemapLink() {
+    void testFilteredTimemapLink() {
         final Link link = fromUri("http://example.com/resource/timemap").rel(TIMEMAP)
             .param(FROM, ofInstant(now().minusSeconds(1000), UTC).format(RFC_1123_DATE_TIME))
             .param(UNTIL, ofInstant(now(), UTC).format(RFC_1123_DATE_TIME)).build();
-        final boolean filter = true;
-        assertTrue(MementoResource.filterLinkParams(link, !filter).getParams().containsKey(FROM));
-        assertFalse(MementoResource.filterLinkParams(link, filter).getParams().containsKey(FROM));
-        assertTrue(MementoResource.filterLinkParams(link, !filter).getParams().containsKey(UNTIL));
-        assertFalse(MementoResource.filterLinkParams(link, filter).getParams().containsKey(UNTIL));
+        assertTrue(MementoResource.filterLinkParams(link, false).getParams().containsKey(FROM));
+        assertFalse(MementoResource.filterLinkParams(link, true).getParams().containsKey(FROM));
+        assertTrue(MementoResource.filterLinkParams(link, false).getParams().containsKey(UNTIL));
+        assertFalse(MementoResource.filterLinkParams(link, true).getParams().containsKey(UNTIL));
     }
 
     @Test
-    public void testFilteredOtherLink() {
+    void testFilteredOtherLink() {
         final Link link = fromUri("http://example.com/resource").rel(TYPE)
             .param(FROM, ofInstant(now().minusSeconds(1000), UTC).format(RFC_1123_DATE_TIME))
             .param(UNTIL, ofInstant(now(), UTC).format(RFC_1123_DATE_TIME)).build();
-        final boolean filter = true;
-        assertTrue(MementoResource.filterLinkParams(link, !filter).getParams().containsKey(FROM));
-        assertTrue(MementoResource.filterLinkParams(link, filter).getParams().containsKey(FROM));
-        assertTrue(MementoResource.filterLinkParams(link, !filter).getParams().containsKey(UNTIL));
-        assertTrue(MementoResource.filterLinkParams(link, filter).getParams().containsKey(UNTIL));
+        assertTrue(MementoResource.filterLinkParams(link, false).getParams().containsKey(FROM));
+        assertTrue(MementoResource.filterLinkParams(link, true).getParams().containsKey(FROM));
+        assertTrue(MementoResource.filterLinkParams(link, false).getParams().containsKey(UNTIL));
+        assertTrue(MementoResource.filterLinkParams(link, true).getParams().containsKey(UNTIL));
     }
 
     @Test
-    public void testFilterLinkFromConfiguration() {
+    void testFilterLinkFromConfiguration() {
         final MementoResource mr = new MementoResource(null, false);
         final Link link = fromUri("http://example.com/resource/memento/1").rel(MEMENTO)
             .param(DATETIME, ofInstant(now(), UTC).format(RFC_1123_DATE_TIME)).build();
@@ -80,7 +77,7 @@ public class MementoResourceTest {
     }
 
     @Test
-    public void testMementoHeadersSingle() {
+    void testMementoHeadersSingle() {
         final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
@@ -92,7 +89,7 @@ public class MementoResourceTest {
     }
 
     @Test
-    public void testMementoHeadersMultipleFirst() {
+    void testMementoHeadersMultipleFirst() {
         final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
@@ -108,7 +105,7 @@ public class MementoResourceTest {
 
 
     @Test
-    public void testMementoHeadersMultipleMiddle() {
+    void testMementoHeadersMultipleMiddle() {
         final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
@@ -123,7 +120,7 @@ public class MementoResourceTest {
     }
 
     @Test
-    public void testMementoHeadersMultipleLast() {
+    void testMementoHeadersMultipleLast() {
         final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
@@ -138,7 +135,7 @@ public class MementoResourceTest {
     }
 
     @Test
-    public void testMementoHeadersMultipleBeyond() {
+    void testMementoHeadersMultipleBeyond() {
         final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
@@ -153,7 +150,7 @@ public class MementoResourceTest {
     }
 
     @Test
-    public void testMementoHeadersMultiplePrecede() {
+    void testMementoHeadersMultiplePrecede() {
         final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
@@ -168,7 +165,7 @@ public class MementoResourceTest {
 }
 
     @Test
-    public void testMementoLinksEmpty() {
+    void testMementoLinksEmpty() {
         final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final List<Link> links = MementoResource.getMementoLinks(identifier, mementos).collect(toList());
@@ -176,7 +173,7 @@ public class MementoResourceTest {
     }
 
     @Test
-    public void testMementoLinksSingle() {
+    void testMementoLinksSingle() {
         final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
@@ -196,5 +193,4 @@ public class MementoResourceTest {
         assertEquals(next, links.stream().filter(l -> l.getRels().contains("next")).count());
         assertEquals(mementos, links.stream().filter(l -> l.getRels().contains("memento")).count());
     }
-
 }

--- a/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
@@ -42,10 +42,10 @@ import org.trellisldp.vocabulary.LDP;
 /**
  * @author acoburn
  */
-public class OptionsHandlerTest extends BaseTestHandler {
+class OptionsHandlerTest extends BaseTestHandler {
 
     @Test
-    public void testOptionsLdprs() {
+    void testOptionsLdprs() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, null);
@@ -58,7 +58,7 @@ public class OptionsHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testOptionsLdpc() {
+    void testOptionsLdpc() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         when(mockIoService.supportedWriteSyntaxes()).thenReturn(asList(TURTLE, JSONLD, NTRIPLES));
 
@@ -77,7 +77,7 @@ public class OptionsHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testOptionsLdpnr() {
+    void testOptionsLdpnr() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, null);
@@ -89,7 +89,7 @@ public class OptionsHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testOptionsAcl() {
+    void testOptionsAcl() {
         when(mockTrellisRequest.getExt()).thenReturn("acl");
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, baseUrl);
@@ -102,7 +102,7 @@ public class OptionsHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testOptionsMemento() {
+    void testOptionsMemento() {
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, true, null);
         final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build();
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -23,7 +23,6 @@ import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.rdf.api.RDFSyntax.RDFA;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.trellisldp.api.Syntax.SPARQL_UPDATE;
 import static org.trellisldp.http.core.HttpConstants.ACCEPT_POST;
@@ -59,12 +58,12 @@ import org.trellisldp.vocabulary.RDFS;
 /**
  * @author acoburn
  */
-public class PatchHandlerTest extends BaseTestHandler {
+class PatchHandlerTest extends BaseTestHandler {
 
     private static final String insert = "INSERT { <> <http://purl.org/dc/terms/title> \"A title\" } WHERE {}";
 
     @Test
-    public void testPatchNoSparql() {
+    void testPatchNoSparql() {
         final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, null, mockBundler, null, null);
         final Response res = assertThrows(BadRequestException.class, () ->
                 patchHandler.initialize(mockParent, mockResource),
@@ -73,7 +72,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testBadAudit() {
+    void testBadAudit() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.BasicContainer.getIRIString()).rel("type").build());
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
@@ -89,7 +88,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPatchLdprs() {
+    void testPatchLdprs() {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
 
@@ -101,7 +100,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testEntity() {
+    void testEntity() {
         final Quad quad = rdf.createQuad(PreferUserManaged, identifier, RDFS.label, rdf.createLiteral("A label"));
 
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
@@ -120,7 +119,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testAcl() {
+    void testAcl() {
         when(mockTrellisRequest.getExt()).thenReturn(ACL);
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
@@ -143,7 +142,7 @@ public class PatchHandlerTest extends BaseTestHandler {
 
 
     @Test
-    public void testPreferRepresentation() {
+    void testPreferRepresentation() {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         when(mockTrellisRequest.getPrefer()).thenReturn(Prefer.valueOf("return=representation"));
@@ -163,7 +162,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPreferHTMLRepresentation() {
+    void testPreferHTMLRepresentation() {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         when(mockTrellisRequest.getPrefer()).thenReturn(Prefer.valueOf("return=representation"));
@@ -185,7 +184,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testError() {
+    void testError() {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(asyncException());
@@ -197,7 +196,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testNoLdpRsSupport() {
+    void testNoLdpRsSupport() {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
 
@@ -212,7 +211,7 @@ public class PatchHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testError2() {
+    void testError2() {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         doThrow(RuntimeTrellisException.class).when(mockIoService)

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -25,7 +25,6 @@ import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
 import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
@@ -55,10 +54,10 @@ import org.trellisldp.vocabulary.LDP;
 /**
  * @author acoburn
  */
-public class PostHandlerTest extends BaseTestHandler {
+class PostHandlerTest extends BaseTestHandler {
 
     @Test
-    public void testPostLdprs() throws IOException {
+    void testPostLdprs() throws IOException {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel("type").build());
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
@@ -71,7 +70,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testBadAudit() throws IOException {
+    void testBadAudit() throws IOException {
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.BasicContainer.getIRIString()).rel("type").build());
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
@@ -86,7 +85,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDefaultType1() throws IOException {
+    void testDefaultType1() throws IOException {
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
         final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
             .toCompletableFuture().join().build();
@@ -97,7 +96,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDefaultType2() throws IOException {
+    void testDefaultType2() throws IOException {
         when(mockTrellisRequest.getContentType()).thenReturn("text/plain");
 
         final PostHandler handler = buildPostHandler("/simpleData.txt", "newresource", null);
@@ -110,7 +109,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDefaultType3() throws IOException {
+    void testDefaultType3() throws IOException {
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
@@ -123,7 +122,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDefaultType4() throws IOException {
+    void testDefaultType4() throws IOException {
         when(mockTrellisRequest.getContentType()).thenReturn("text/plain");
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
 
@@ -137,7 +136,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testDefaultType5() throws IOException {
+    void testDefaultType5() throws IOException {
         when(mockTrellisRequest.getContentType()).thenReturn("text/turtle");
 
         final PostHandler handler = buildPostHandler("/emptyData.txt", "newresource", null);
@@ -150,7 +149,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testUnsupportedType() throws IOException {
+    void testUnsupportedType() throws IOException {
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel("type").build());
 
@@ -166,7 +165,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testRdfEntity() throws IOException {
+    void testRdfEntity() throws IOException {
         final String path = "newresource";
         final Triple triple = rdf.createTriple(rdf.createIRI(baseUrl + path), DC.title,
                         rdf.createLiteral("A title"));
@@ -189,7 +188,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testBinaryEntity() throws IOException {
+    void testBinaryEntity() throws IOException {
         when(mockTrellisRequest.getContentType()).thenReturn("text/plain");
 
         final PostHandler handler = buildPostHandler("/simpleData.txt", "new-resource", null);
@@ -203,7 +202,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testBinaryEntityNoContentType() throws IOException {
+    void testBinaryEntityNoContentType() throws IOException {
         when(mockTrellisRequest.getContentType()).thenReturn(null);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
 
@@ -218,7 +217,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testError() throws IOException {
+    void testError() throws IOException {
         when(mockResourceService.create(any(Metadata.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getContentType()).thenReturn("text/turtle");
 
@@ -230,7 +229,7 @@ public class PostHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testBadRdfInputStream() throws IOException {
+    void testBadRdfInputStream() {
         final InputStream mockInputStream = mock(InputStream.class, inv -> {
             throw new IOException("Expected exception");
         });

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -24,7 +24,6 @@ import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE;
@@ -56,18 +55,18 @@ import org.trellisldp.vocabulary.LDP;
 /**
  * @author acoburn
  */
-public class PutHandlerTest extends BaseTestHandler {
+class PutHandlerTest extends BaseTestHandler {
 
     private final BinaryMetadata testBinary = BinaryMetadata.builder(rdf.createIRI("file:///binary.txt"))
         .mimeType("text/plain").build();
 
     @Test
-    public void testPutConflict() {
+    void testPutConflict() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.BasicContainer);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.DirectContainer.getIRIString()).rel("type").build());
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
 
-        final PutHandler handler = buildPutHandler("/simpleTriple.ttl", null);
+        final PutHandler handler = buildPutHandler("/simpleTriple.ttl", "http://example.com/");
 
         final Response res = assertThrows(WebApplicationException.class, () ->
                 handler.setResource(handler.initialize(mockParent, mockResource)).toCompletableFuture().join(),
@@ -76,7 +75,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testBadAudit() {
+    void testBadAudit() {
         when(mockBundler.getAuditService()).thenReturn(new DefaultAuditService() {});
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.BasicContainer.getIRIString()).rel("type").build());
@@ -91,7 +90,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpResourceDefaultType() {
+    void testPutLdpResourceDefaultType() {
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
@@ -108,7 +107,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpResourceContainer() {
+    void testPutLdpResourceContainer() {
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel("type").build());
@@ -125,7 +124,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpResourceContainerContained() throws IOException {
+    void testPutLdpResourceContainerContained() throws IOException {
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel("type").build());
@@ -143,7 +142,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpBinaryResourceWithLdprLink() {
+    void testPutLdpBinaryResourceWithLdprLink() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
@@ -157,7 +156,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpBinaryResource() {
+    void testPutLdpBinaryResource() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
@@ -172,7 +171,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpBinaryResourceNoContentType() {
+    void testPutLdpBinaryResourceNoContentType() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
@@ -187,7 +186,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpNRDescription() {
+    void testPutLdpNRDescription() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
@@ -202,7 +201,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpNRDescription2() {
+    void testPutLdpNRDescription2() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
@@ -216,7 +215,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testPutLdpResourceEmpty() {
+    void testPutLdpResourceEmpty() {
         final PutHandler handler = buildPutHandler("/emptyData.txt", null);
         final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
             .toCompletableFuture().join().build();
@@ -226,7 +225,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testRdfToNonRDFSource() {
+    void testRdfToNonRDFSource() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());
@@ -240,7 +239,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testUnsupportedType() {
+    void testUnsupportedType() {
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel("type").build());
@@ -257,7 +256,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testError() {
+    void testError() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getPath()).thenReturn("resource");
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
@@ -272,7 +271,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testMementoError() {
+    void testMementoError() {
         final MementoService mockMementoService = mock(MementoService.class);
         when(mockBundler.getMementoService()).thenReturn(mockMementoService);
         doCallRealMethod().when(mockMementoService).put(any(ResourceService.class), any(IRI.class));
@@ -288,7 +287,7 @@ public class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    public void testBinaryError() throws IOException {
+    void testBinaryError() throws IOException {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
         when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.NonRDFSource.getIRIString()).rel("type").build());

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/ACLTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/ACLTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the ACL Vocabulary Class
  * @author acoburn
  */
-public class ACLTest extends AbstractVocabularyTest {
+class ACLTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/ns/auth/acl#";
     }
 
     @Override
-    public Class<ACL> vocabulary() {
+    Class<ACL> vocabulary() {
         return ACL.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/ASTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/ASTest.java
@@ -25,20 +25,20 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class ASTest extends AbstractVocabularyTest {
+class ASTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "https://www.w3.org/ns/activitystreams#";
     }
 
     @Override
-    public Class<AS> vocabulary() {
+    Class<AS> vocabulary() {
         return AS.class;
     }
 
     @Override
-    protected Graph getVocabulary(final String url) {
+    Graph getVocabulary(final String url) {
         final Graph graph = createDefaultGraph();
         try {
             RDFParser.source(url).httpAccept("application/ld+json").parse(graph);
@@ -51,7 +51,7 @@ public class ASTest extends AbstractVocabularyTest {
 
     @Test
     @Override
-    public void testVocabularyRev() {
+    void testVocabularyRev() {
         assertEquals(namespace() + "Create", AS.Create.getIRIString(), "as:Create IRIs don't match!");
         assertEquals(namespace() + "Delete", AS.Delete.getIRIString(), "as:Delete IRIs don't match!");
         assertEquals(namespace() + "Update", AS.Update.getIRIString(), "as:Update IRIs don't match!");
@@ -59,12 +59,12 @@ public class ASTest extends AbstractVocabularyTest {
 
     @Test
     @Override
-    public void testVocabulary() {
+    void testVocabulary() {
         assertEquals(namespace() + "Activity", AS.Activity.getIRIString(), "as:Activity IRIs don't match!");
     }
 
     @Test
-    public void checkUri() {
+    void checkUri() {
         getVocabulary(namespace());
         assertEquals(namespace(), AS.getNamespace(), "AS namespace doesn't match expected value!");
     }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/DCTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/DCTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the DC Vocabulary Class
  * @author acoburn
  */
-public class DCTest extends AbstractVocabularyTest {
+class DCTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://purl.org/dc/terms/";
     }
 
     @Override
-    public Class<DC> vocabulary() {
+    Class<DC> vocabulary() {
         return DC.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/FOAFTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/FOAFTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the FOAF Vocabulary Class
  * @author acoburn
  */
-public class FOAFTest extends AbstractVocabularyTest {
+class FOAFTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://xmlns.com/foaf/0.1/";
     }
 
     @Override
-    public Class<FOAF> vocabulary() {
+    Class<FOAF> vocabulary() {
         return FOAF.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/JSONLDTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/JSONLDTest.java
@@ -17,20 +17,20 @@ package org.trellisldp.vocabulary;
  * Test the JSONLD Vocabulary Class
  * @author acoburn
  */
-public class JSONLDTest extends AbstractVocabularyTest {
+class JSONLDTest extends AbstractVocabularyTest {
 
     @Override
-    public boolean isStrict() {
+    boolean isStrict() {
         return false;
     }
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/ns/json-ld#";
     }
 
     @Override
-    public Class<JSONLD> vocabulary() {
+    Class<JSONLD> vocabulary() {
         return JSONLD.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/LDPTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/LDPTest.java
@@ -21,20 +21,20 @@ import org.junit.jupiter.api.Test;
  * Test the LDP Vocabulary Class
  * @author acoburn
  */
-public class LDPTest extends AbstractVocabularyTest {
+class LDPTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/ns/ldp#";
     }
 
     @Override
-    public Class<LDP> vocabulary() {
+    Class<LDP> vocabulary() {
         return LDP.class;
     }
 
     @Test
-    public void testSuperclass() {
+    void testSuperclass() {
         assertEquals(LDP.Resource, LDP.getSuperclassOf(LDP.NonRDFSource), "LDP-R isn't a superclass of LDP-NR!");
         assertEquals(LDP.Container, LDP.getSuperclassOf(LDP.BasicContainer), "LDP-C isn't a superclass of LDP-BC!");
         assertNull(LDP.getSuperclassOf(LDP.Resource), "Astonishingly, LDP-R has a superclass!");

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/MementoTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/MementoTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the Memento Vocabulary Class
  * @author acoburn
  */
-public class MementoTest extends AbstractVocabularyTest {
+class MementoTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://mementoweb.org/ns#";
     }
 
     @Override
-    public Class<Memento> vocabulary() {
+    Class<Memento> vocabulary() {
         return Memento.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/OATest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/OATest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the OA Vocabulary Class
  * @author acoburn
  */
-public class OATest extends AbstractVocabularyTest {
+class OATest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/ns/oa#";
     }
 
     @Override
-    public Class<OA> vocabulary() {
+    Class<OA> vocabulary() {
         return OA.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/PROVTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/PROVTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the PROV Ontology Class
  * @author acoburn
  */
-public class PROVTest extends AbstractVocabularyTest {
+class PROVTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/ns/prov#";
     }
 
     @Override
-    public Class<PROV> vocabulary() {
+    Class<PROV> vocabulary() {
         return PROV.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/RDFSTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/RDFSTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the RDFS Vocabulary Class
  * @author acoburn
  */
-public class RDFSTest extends AbstractVocabularyTest {
+class RDFSTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/2000/01/rdf-schema#";
     }
 
     @Override
-    public Class<RDFS> vocabulary() {
+    Class<RDFS> vocabulary() {
         return RDFS.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/RDFTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/RDFTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the RDF Vocabulary Class
  * @author acoburn
  */
-public class RDFTest extends AbstractVocabularyTest {
+class RDFTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
     }
 
     @Override
-    public Class<RDF> vocabulary() {
+    Class<RDF> vocabulary() {
         return RDF.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/SKOSTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/SKOSTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the SKOS Vocabulary Class
  * @author acoburn
  */
-public class SKOSTest extends AbstractVocabularyTest {
+class SKOSTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/2004/02/skos/core#";
     }
 
     @Override
-    public Class<SKOS> vocabulary() {
+    Class<SKOS> vocabulary() {
         return SKOS.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TimeTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TimeTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the Time Vocabulary Class
  * @author acoburn
  */
-public class TimeTest extends AbstractVocabularyTest {
+class TimeTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/2006/time#";
     }
 
     @Override
-    public Class<Time> vocabulary() {
+    Class<Time> vocabulary() {
         return Time.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TrellisTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TrellisTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the Trellis Vocabulary Class
  * @author acoburn
  */
-public class TrellisTest extends AbstractVocabularyTest {
+class TrellisTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.trellisldp.org/ns/trellis#";
     }
 
     @Override
-    public Class<Trellis> vocabulary() {
+    Class<Trellis> vocabulary() {
         return Trellis.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/VCARDTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/VCARDTest.java
@@ -17,15 +17,15 @@ package org.trellisldp.vocabulary;
  * Test the VCARD Vocabulary Class
  * @author acoburn
  */
-public class VCARDTest extends AbstractVocabularyTest {
+class VCARDTest extends AbstractVocabularyTest {
 
     @Override
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/2006/vcard/ns#";
     }
 
     @Override
-    public Class<VCARD> vocabulary() {
+    Class<VCARD> vocabulary() {
         return VCARD.class;
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/XSDTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/XSDTest.java
@@ -24,14 +24,14 @@ import org.junit.jupiter.api.Test;
 /**
  * @author acoburn
  */
-public class XSDTest {
+class XSDTest {
 
-    public String namespace() {
+    String namespace() {
         return "http://www.w3.org/2001/XMLSchema#";
     }
 
     @Test
-    public void testVocabulary() {
+    void testVocabulary() {
         assertEquals(namespace() + "dateTime", XSD.dateTime.getIRIString(), "xsd:dateTime IRIs don't match");
         assertEquals(namespace() + "string", XSD.string_.getIRIString(), "xsd:string IRIs don't match!");
         assertEquals(dateTime.getURI(), XSD.dateTime.getIRIString(), "xsd:dateTime IRI doesn't match Jena's value!");
@@ -39,7 +39,7 @@ public class XSDTest {
     }
 
     @Test
-    public void checkUri() {
+    void checkUri() {
         assertEquals(namespace(), XSD.getNamespace(), "Namespace IRIs don't match!");
         assertEquals(NS, XSD.getNamespace(), "Namespace IRI doesn't match Jena's value!");
     }

--- a/notifications/amqp/src/test/java/org/trellisldp/amqp/AmqpEventServiceTest.java
+++ b/notifications/amqp/src/test/java/org/trellisldp/amqp/AmqpEventServiceTest.java
@@ -17,8 +17,6 @@ import static java.time.Instant.now;
 import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
@@ -51,7 +49,7 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * @author acoburn
  */
-public class AmqpEventServiceTest {
+class AmqpEventServiceTest {
 
     private static final RDF rdf = new SimpleRDF();
     private static final SystemLauncher broker = new SystemLauncher();
@@ -68,7 +66,7 @@ public class AmqpEventServiceTest {
     private Event mockEvent;
 
     @BeforeAll
-    public static void initialize() throws Exception {
+    static void initialize() throws Exception {
         final Map<String, Object> brokerOptions = new HashMap<>();
         brokerOptions.put("qpid.broker.defaultPreferenceStoreAttributes", "{\"type\": \"Noop\"}");
         brokerOptions.put(SystemConfig.TYPE, "Memory");
@@ -78,12 +76,12 @@ public class AmqpEventServiceTest {
     }
 
     @AfterAll
-    public static void cleanup() throws Exception {
+    static void cleanup() {
         broker.shutdown();
     }
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         initMocks(this);
         when(mockEvent.getAgents()).thenReturn(singleton(Trellis.AdministratorAgent));
         when(mockEvent.getCreated()).thenReturn(time);
@@ -97,7 +95,7 @@ public class AmqpEventServiceTest {
     }
 
     @Test
-    public void testAmqp() throws IOException {
+    void testAmqp() throws IOException {
         final EventService svc = new AmqpEventService(serializer, mockChannel, exchangeName, queueName);
         svc.emit(mockEvent);
 
@@ -106,7 +104,7 @@ public class AmqpEventServiceTest {
     }
 
     @Test
-    public void testAmqpConfiguration() throws IOException {
+    void testAmqpConfiguration() throws IOException {
         final EventService svc = new AmqpEventService(serializer, mockChannel);
         svc.emit(mockEvent);
 
@@ -115,7 +113,7 @@ public class AmqpEventServiceTest {
     }
 
     @Test
-    public void testError() throws IOException {
+    void testError() throws IOException {
         doThrow(IOException.class).when(mockChannel).basicPublish(eq(exchangeName), eq(queueName),
                 anyBoolean(), anyBoolean(), any(BasicProperties.class), any(byte[].class));
 

--- a/notifications/jms/src/test/java/org/trellisldp/jms/JmsEventServiceTest.java
+++ b/notifications/jms/src/test/java/org/trellisldp/jms/JmsEventServiceTest.java
@@ -18,8 +18,6 @@ import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static javax.jms.Session.AUTO_ACKNOWLEDGE;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
@@ -53,7 +51,7 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * @author acoburn
  */
-public class JmsEventServiceTest {
+class JmsEventServiceTest {
 
     private static final RDF rdf = new SimpleRDF();
     private static final BrokerService BROKER = new BrokerService();
@@ -85,18 +83,18 @@ public class JmsEventServiceTest {
     private MessageProducer mockProducer, mockTopicProducer;
 
     @BeforeAll
-    public static void initialize() throws Exception {
+    static void initialize() throws Exception {
         BROKER.setPersistent(false);
         BROKER.start();
     }
 
     @AfterAll
-    public static void cleanUp() throws Exception {
+    static void cleanUp() throws Exception {
         BROKER.stop();
     }
 
     @BeforeEach
-    public void setUp() throws JMSException {
+    void setUp() throws JMSException {
         initMocks(this);
         when(mockEvent.getAgents()).thenReturn(singleton(Trellis.AdministratorAgent));
         when(mockEvent.getCreated()).thenReturn(time);
@@ -117,7 +115,7 @@ public class JmsEventServiceTest {
     }
 
     @Test
-    public void testJms() throws JMSException {
+    void testJms() throws JMSException {
         final EventService svc = new JmsEventService(serializer, mockConnection);
         svc.emit(mockEvent);
 
@@ -125,7 +123,7 @@ public class JmsEventServiceTest {
     }
 
     @Test
-    public void testQueue() throws JMSException {
+    void testQueue() throws JMSException {
         final EventService svc = new JmsEventService(serializer, mockSession, queueName, true);
         svc.emit(mockEvent);
 
@@ -134,7 +132,7 @@ public class JmsEventServiceTest {
     }
 
     @Test
-    public void testTopic() throws JMSException {
+    void testTopic() throws JMSException {
         final EventService svc = new JmsEventService(serializer, mockSession, queueName, false);
         svc.emit(mockEvent);
 
@@ -143,7 +141,7 @@ public class JmsEventServiceTest {
     }
 
     @Test
-    public void testError() throws JMSException {
+    void testError() throws JMSException {
         doThrow(JMSException.class).when(mockProducer).send(eq(mockMessage));
 
         final EventService svc = new JmsEventService(serializer, mockSession, queueName);

--- a/notifications/kafka/src/test/java/org/trellisldp/kafka/KafkaEventServiceTest.java
+++ b/notifications/kafka/src/test/java/org/trellisldp/kafka/KafkaEventServiceTest.java
@@ -43,7 +43,7 @@ import org.trellisldp.vocabulary.Trellis;
 /**
  * Test the Kafka publisher
  */
-public class KafkaEventServiceTest {
+class KafkaEventServiceTest {
 
     private static final RDF rdf = new SimpleRDF();
     private static final ActivityStreamService serializer = new DefaultActivityStreamService();
@@ -59,7 +59,7 @@ public class KafkaEventServiceTest {
     private Event mockEvent;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
         when(mockEvent.getTarget()).thenReturn(of(rdf.createIRI("trellis:data/resource")));
         when(mockEvent.getAgents()).thenReturn(singleton(Trellis.AdministratorAgent));
@@ -71,7 +71,7 @@ public class KafkaEventServiceTest {
     }
 
     @Test
-    public void testKafka() {
+    void testKafka() {
         final EventService svc = new KafkaEventService(serializer, producer);
         svc.emit(mockEvent);
 
@@ -81,7 +81,7 @@ public class KafkaEventServiceTest {
     }
 
     @Test
-    public void testDefaultKafka() {
+    void testDefaultKafka() {
         assertDoesNotThrow(() -> new KafkaEventService(serializer));
     }
 }

--- a/notifications/reactive/src/test/java/org/trellisldp/reactive/ReactiveEventServiceTest.java
+++ b/notifications/reactive/src/test/java/org/trellisldp/reactive/ReactiveEventServiceTest.java
@@ -50,7 +50,7 @@ import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.Trellis;
 
 @ExtendWith(WeldJunit5Extension.class)
-public class ReactiveEventServiceTest {
+class ReactiveEventServiceTest {
 
     private static final RDF rdf = new SimpleRDF();
     private final Instant time = now();
@@ -77,7 +77,7 @@ public class ReactiveEventServiceTest {
     private Event mockEvent;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         initMocks(this);
 
         when(mockEvent.getTarget()).thenReturn(of(rdf.createIRI(TRELLIS_DATA_PREFIX + "resource")));
@@ -90,7 +90,7 @@ public class ReactiveEventServiceTest {
     }
 
     @Test
-    public void testReactiveStream() {
+    void testReactiveStream() {
         service.emit(mockEvent);
         await().atMost(5, SECONDS).until(() -> collector.getResults().size() == 1);
         assertEquals(1, collector.getResults().size(), "Incorrect number of messages!");

--- a/notifications/reactive/src/test/java/org/trellisldp/reactive/TestCollector.java
+++ b/notifications/reactive/src/test/java/org/trellisldp/reactive/TestCollector.java
@@ -23,7 +23,7 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 @ApplicationScoped
 public class TestCollector {
 
-    private List<String> list = new ArrayList<>();
+    private final List<String> list = new ArrayList<>();
 
     @Incoming(ReactiveEventService.REACTIVE_DESTINATION)
     public void sink(final String message) {

--- a/platform/app-mp-triplestore/src/main/java/org/trellisldp/app/mp/triplestore/WebApplication.java
+++ b/platform/app-mp-triplestore/src/main/java/org/trellisldp/app/mp/triplestore/WebApplication.java
@@ -71,8 +71,8 @@ public class WebApplication extends Application {
     private void printBanner(final String name) {
         try (final InputStream resourceStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("banner.txt");
-             final InputStreamReader inputStreamReader = new InputStreamReader(resourceStream);
-             final BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+            final InputStreamReader inputStreamReader = new InputStreamReader(resourceStream);
+            final BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
             final String banner = bufferedReader.lines().collect(joining(String.format("%n")));
             LOGGER.info("Starting {}\n{}", name, banner);
         } catch (final IllegalArgumentException | IOException ignored) {

--- a/platform/app-mp-triplestore/src/test/java/org/trellisldp/app/mp/triplestore/TrellisApplicationTest.java
+++ b/platform/app-mp-triplestore/src/test/java/org/trellisldp/app/mp/triplestore/TrellisApplicationTest.java
@@ -28,12 +28,12 @@ import org.trellisldp.test.AbstractApplicationMementoTests;
 @TestInstance(PER_CLASS)
 class TrellisApplicationTest {
 
-    protected final Client CLIENT = newBuilder().build();
-    protected final String TRELLIS_URL = "http://localhost:" + getInteger("trellis.port", 9080) + "/";
+    private final Client CLIENT = newBuilder().build();
+    private final String TRELLIS_URL = "http://localhost:" + getInteger("trellis.port", 9080) + "/";
 
     @Nested
     @DisplayName("Trellis LDP Tests")
-    public class LdpTests extends AbstractApplicationLdpTests {
+    class LdpTests extends AbstractApplicationLdpTests {
 
         @Override
         public Client getClient() {
@@ -48,7 +48,7 @@ class TrellisApplicationTest {
 
     @Nested
     @DisplayName("Trellis Memento Tests")
-    public class MementoTests extends AbstractApplicationMementoTests {
+    class MementoTests extends AbstractApplicationMementoTests {
 
         @Override
         public Client getClient() {

--- a/platform/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
+++ b/platform/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
@@ -25,8 +25,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDist
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.osgi.framework.Bundle.ACTIVE;
-import static org.osgi.framework.Constants.OBJECTCLASS;
-import static org.osgi.framework.FrameworkUtil.createFilter;
 
 import java.io.File;
 
@@ -43,9 +41,6 @@ import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.util.tracker.ServiceTracker;
-import org.trellisldp.api.RuntimeTrellisException;
 
 /**
  * Test OSGi provisioning.
@@ -278,22 +273,5 @@ public class OSGiTest {
     private void checkTrellisBundlesAreActive() {
         stream(bundleContext.getBundles()).filter(b -> b.getSymbolicName().startsWith("org.trellisldp")).forEach(b ->
                     assertEquals("Bundle " + b.getSymbolicName() + " is not active!", ACTIVE, b.getState()));
-    }
-
-    protected <T> T getOsgiService(final Class<T> type, final String filter, final long timeout) {
-        try {
-            final ServiceTracker<?, T> tracker = new ServiceTracker<>(bundleContext,
-                    createFilter("(&(" + OBJECTCLASS + "=" + type.getName() + ")" + filter + ")"), null);
-            tracker.open(true);
-            final T svc = tracker.waitForService(timeout);
-            if (svc == null) {
-                throw new RuntimeTrellisException("Gave up waiting for service " + filter);
-            }
-            return svc;
-        } catch (InvalidSyntaxException e) {
-            throw new IllegalArgumentException("Invalid filter", e);
-        } catch (InterruptedException e) {
-            throw new RuntimeTrellisException(e);
-        }
     }
 }


### PR DESCRIPTION
There are a lot of line changes here, but it's all just window dressing.

With JUnit 4, it was necessary for all test methods (annotated with `@Test`) to be public. JUnit 5 does not have that requirement, so most of the changes here relate to changing the visibility of the test methods.

In fact _all_ of the changes here involve test code.

Some of the other modifications involve changing `asList` => `singletonList` for single-item lists. Removing declared `throws` statements when the associated Exception is not actually thrown. And other similarly trivial issues.