### PR TITLE
Remove Provider annotation

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -57,7 +57,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
@@ -86,7 +85,6 @@ import org.trellisldp.vocabulary.LDP;
  *
  * @author acoburn
  */
-@Provider
 @ApplicationScoped
 @Path("{path: .*}")
 public class TrellisHttpResource {


### PR DESCRIPTION
The `@Provider` annotation is not relevant for `@Path`-annotated JAX-RS resources. Neither the JAX-RS runtime nor the CDI environment need it. It should be removed.
