### PR TITLE
Adjust NoopImpl annotations

### DIFF
--- a/components/app/src/test/java/org/trellisldp/app/CDIServiceBundlerTest.java
+++ b/components/app/src/test/java/org/trellisldp/app/CDIServiceBundlerTest.java
@@ -48,15 +48,8 @@ class CDIServiceBundlerTest {
                                            FileMementoService.class,
                                            JenaIOService.class,
                                            LdpConstraintService.class,
-                                           NoopAuditService.class,
-                                           NoopEventService.class,
-                                           NoopNamespaceService.class,
                                            NoopProfileCache.class,
-                                           NoopResourceService.class)
-                                       .alternatives(NoopAuditService.class,
-                                           NoopEventService.class,
-                                           NoopNamespaceService.class,
-                                           NoopResourceService.class));
+                                           TestServices.class));
 
     @Inject
     private ServiceBundler serviceBundler;

--- a/components/app/src/test/java/org/trellisldp/app/TestServices.java
+++ b/components/app/src/test/java/org/trellisldp/app/TestServices.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.app;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import org.trellisldp.api.*;
+
+@ApplicationScoped
+class TestServices {
+
+    @Produces
+    NamespaceService namespaces = new NoopNamespaceService();
+
+    @Produces
+    ResourceService resources = new NoopResourceService();
+
+    @Produces
+    AuditService audit = new NoopAuditService();
+
+    @Produces
+    EventService events = new NoopEventService();
+}

--- a/core/api/src/main/java/org/trellisldp/api/NoopImplementation.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopImplementation.java
@@ -23,8 +23,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
-import javax.enterprise.inject.Stereotype;
 import javax.inject.Qualifier;
 
 /**
@@ -32,10 +30,8 @@ import javax.inject.Qualifier;
  *
  * <p>Such implementations are expected to avoid persisting any data beyond the lifetime of the running application.
  */
-@Stereotype
 @Qualifier
-@ApplicationScoped
-@Alternative
 @Retention(RUNTIME)
 @Target({TYPE, METHOD, FIELD, PARAMETER})
+@ApplicationScoped
 public @interface NoopImplementation {}

--- a/core/api/src/main/java/org/trellisldp/api/NoopImplementation.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopImplementation.java
@@ -13,6 +13,9 @@
  */
 package org.trellisldp.api;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -22,6 +25,7 @@ import java.lang.annotation.Target;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Stereotype;
+import javax.inject.Qualifier;
 
 /**
  * Marks a no-op implementation of a Trellis component.
@@ -29,8 +33,9 @@ import javax.enterprise.inject.Stereotype;
  * <p>Such implementations are expected to avoid persisting any data beyond the lifetime of the running application.
  */
 @Stereotype
+@Qualifier
 @ApplicationScoped
 @Alternative
 @Retention(RUNTIME)
-@Target(TYPE)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
 public @interface NoopImplementation {}


### PR DESCRIPTION
I have found that, with Quarkus, the CDI injection mechanism sees the no-op service implementation beans as if they have both `@Default` and `@All` qualifiers when viewed in the context of ctor injection. E.g.:

```java
@Inject
public JenaIOService(final NamespaceService namespaceService, ...) { ... }
```

leading to ambiguous dependency resolution errors. This change expands the `@Target` types of the `@NoopImplementation` stereotype and also adds an explicit `@Priority` annotation.
