### PR TITLE
Add trellis-reactive to bom artifact

### DIFF
--- a/platform/bom/build.gradle
+++ b/platform/bom/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation project(':trellis-amqp')
     implementation project(':trellis-jms')
     implementation project(':trellis-kafka')
+    implementation project(':trellis-reactive')
 
     implementation project(':trellis-auth-basic')
     implementation project(':trellis-auth-oauth')


### PR DESCRIPTION
This is very minor: the `trellis-reactive` artifact is currently missing from the `trellis-bom`. This adds that subproject to make it easier to use in downstream apps.