### PR TITLE
Adjust WAC inheritance algorithm

### DIFF
--- a/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
@@ -329,21 +329,20 @@ public class WebAcService {
 
     private Stream<Authorization> getAllAuthorizationsFor(final Resource resource, final boolean inherited) {
         LOGGER.debug("Checking ACL for: {}", resource.getIdentifier());
-        if ( resource.hasAcl() ) {
+        if (resource.hasAcl()) {
             try (final Graph graph = resource.stream(Trellis.PreferAccessControl).map(Quad::asTriple)
                         .collect(toGraph())) {
                 final List<Authorization> authorizations = getAuthorizationFromGraph(graph);
                 // Check for any acl:default statements if checking for inheritance
-                if (inherited && authorizations.stream().anyMatch(getInheritedAuth(resource.getIdentifier()))) {
+                if (inherited) {
                     return authorizations.stream().filter(getInheritedAuth(resource.getIdentifier()));
-                // If not inheriting, just return the relevant Authorizations in the ACL
-                } else if (!inherited) {
-                    return authorizations.stream().filter(getAccessToAuth(resource.getIdentifier()));
                 }
+                // If not inheriting, just return the relevant Authorizations in the ACL
+                return authorizations.stream().filter(getAccessToAuth(resource.getIdentifier()));
             } catch (final Exception ex) {
                 throw new RuntimeTrellisException("Error closing graph", ex);
             }
-        } else if ( root.equals(resource.getIdentifier()) ) {
+        } else if (root.equals(resource.getIdentifier())) {
             return WebAcService.defaultRootAuthorizations.stream();
         }
         // Nothing here, check the parent

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcServiceTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcServiceTest.java
@@ -503,7 +503,7 @@ class WebAcServiceTest {
                 rdf.createQuad(PreferAccessControl, authIRI4, type, ACL.Authorization)));
 
         assertAll("Test default ACL writability",
-                checkCanWrite(resourceIRI),
+                checkCannotWrite(resourceIRI),
                 checkCanWrite(childIRI),
                 checkCanWrite(parentIRI),
                 checkCanWrite(rootIRI));
@@ -618,10 +618,9 @@ class WebAcServiceTest {
                 rdf.createQuad(PreferAccessControl, authIRI2, ACL.accessTo, childIRI),
 
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.mode, ACL.Read),
-                rdf.createQuad(PreferAccessControl, authIRI3, ACL.mode, ACL.Write),
-                rdf.createQuad(PreferAccessControl, authIRI3, ACL.mode, ACL.Control),
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.agentGroup, groupIRI),
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.accessTo, childIRI),
+                rdf.createQuad(PreferAccessControl, authIRI3, ACL.default_, childIRI),
 
                 rdf.createQuad(PreferAccessControl, authIRI4, ACL.agentGroup, groupIRI),
                 rdf.createQuad(PreferAccessControl, authIRI4, type, ACL.Authorization)));
@@ -658,10 +657,9 @@ class WebAcServiceTest {
                 rdf.createQuad(PreferAccessControl, authIRI2, ACL.mode, ACL.Control),
 
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.mode, ACL.Read),
-                rdf.createQuad(PreferAccessControl, authIRI3, ACL.mode, ACL.Write),
-                rdf.createQuad(PreferAccessControl, authIRI3, ACL.mode, ACL.Control),
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.agentGroup, groupIRI2),
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.accessTo, childIRI),
+                rdf.createQuad(PreferAccessControl, authIRI2, ACL.default_, childIRI),
 
                 rdf.createQuad(PreferAccessControl, authIRI4, ACL.agentGroup, groupIRI2),
                 rdf.createQuad(PreferAccessControl, authIRI4, type, ACL.Authorization)));


### PR DESCRIPTION
Resolves #522

This changes the inheritance algorithm to be in line with the SOLID
WebAccessControl specification. In particular, the WAC inheritance will
now stop at the first ACL document it encounters, not the first ACL
document with an acl:default property.