### PR TITLE
Add cdi annotation to namespaces, file components

### DIFF
--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.IRI;
@@ -43,6 +44,7 @@ import org.trellisldp.api.IdentifierService;
 /**
  * A {@link BinaryService} implementation that stores LDP-NR resources as files on a local filesystem.
  */
+@ApplicationScoped
 public class FileBinaryService implements BinaryService {
 
     /** The configuration key controlling the base filesystem path for the binary service. */

--- a/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
@@ -29,6 +29,7 @@ import java.util.TreeSet;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.io.FilenameUtils;
@@ -41,6 +42,7 @@ import org.trellisldp.api.Resource;
 /**
  * A file-based versioning system.
  */
+@ApplicationScoped
 public class FileMementoService implements MementoService {
 
     /** The configuration key controlling the base filesystem path for memento storage. */

--- a/components/namespaces/src/main/java/org/trellisldp/namespaces/JsonNamespaceService.java
+++ b/components/namespaces/src/main/java/org/trellisldp/namespaces/JsonNamespaceService.java
@@ -26,6 +26,7 @@ import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -37,6 +38,7 @@ import org.trellisldp.api.NamespaceService;
  *
  * @author acoburn
  */
+@ApplicationScoped
 public class JsonNamespaceService implements NamespaceService {
 
     /** The configuration key controlling the path to a JSON-formatted namespace file. */

--- a/platform/app-mp-triplestore/build.gradle
+++ b/platform/app-mp-triplestore/build.gradle
@@ -79,6 +79,11 @@ liberty {
         configFile = file("src/main/liberty/config/server.xml")
         bootstrapProperties = ['default.http.port': testServerHttpPort,
                                'default.https.port': testServerHttpsPort,
+                               'trellis.namespaces.path': "data/namespaces.json",
+                               'trellis.triplestore.rdf.location': 'data/resources',
+                               'trellis.file.memento.basepath': 'data/mementos',
+                               'trellis.file.binary.basepath': 'data/binary',
+
                                'app.context.root': warContext]
         packageLiberty {
             archive = "$buildDir/${appName}.zip"

--- a/platform/app-mp-triplestore/src/main/resources/META-INF/microprofile-config.properties
+++ b/platform/app-mp-triplestore/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,0 @@
-trellis.triplestore.ldp.type=false
-trellis.triplestore.rdf.location=resources
-trellis.file.memento.basepath=mementos
-trellis.file.binary.basepath=binary
-trellis.namespaces.path=namespaces.json


### PR DESCRIPTION
The `trellis-namespaces` and `trellis-file` components do not currently have CDI annotations. This adds those annotations.