### PR TITLE
Add json-b based event serializer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ ext {
     guavaVersion = '28.0-jre'
     jacksonVersion = '2.9.10'
     jaxbVersion = '2.4.0-b180830.0359'
+    jsonbVersion = '1.0'
     jenaVersion = '3.12.0'
     // version 2.28+ uses the jakarta-based jax-rs API
     jerseyVersion = '2.27'
@@ -60,6 +61,7 @@ ext {
     bouncycastleVersion = '1.63'
     commonsTextVersion = '1.8'
     cxfVersion = '3.3.3'
+    glassfishJsonVersion = '1.1.4'
     junitVersion = '5.5.2'
     junitLauncherVersion = '1.5.2'
     hamcrestVersion = '2.1'
@@ -72,6 +74,7 @@ ext {
     smallryeReactiveVersion = '1.0.6'
     smallryeReactiveOperatorsVersion = '1.0.9'
     weldVersion = '2.0.0.Final'
+    yassonVersion = '1.0.5'
 
     /* OSGi */
     glassfishInjectVersion = '2.5.0-b62'

--- a/notifications/event-jsonb/bnd.bnd
+++ b/notifications/event-jsonb/bnd.bnd
@@ -1,0 +1,19 @@
+Automatic-Module-Name:  ${project.ext.moduleName}
+Export-Package:         ${project.ext.moduleName}
+
+Bundle-Vendor:          ${project.vendor}
+Bundle-Version:         ${project.version}
+Bundle-License:         ${project.license}
+Bundle-DocURL:          ${project.docURL}
+Bundle-Name:            ${project.description}
+Bundle-SymbolicName:    ${project.group}.${project.name}
+Bundle-SCM:             url=https://github.com/trellis-ldp/trellis, \
+                        connection=scm:git:https://github.com/trellis-ldp/trellis.git, \
+                        developerConnection=scm:git:git@github.com:trellis-ldp/trellis.git
+
+Require-Capability:     osgi.extender; \
+                            filter:="(osgi.extender=osgi.serviceloader.registrar)"; \
+                            resolution:=optional
+Provide-Capability:     osgi.serviceloader; \
+                            osgi.serviceloader=org.trellisldp.api.ActivityStreamService
+

--- a/notifications/event-jsonb/build.gradle
+++ b/notifications/event-jsonb/build.gradle
@@ -1,0 +1,46 @@
+apply plugin: 'java-library'
+apply plugin: 'biz.aQute.bnd.builder'
+
+description = 'Trellis Activity Stream Serialization'
+
+configurations {
+    jsonb
+}
+
+ext {
+    moduleName = 'org.trellisldp.event.jsonb'
+    testModules = ['org.apache.commons.rdf.simple']
+}
+
+dependencies {
+    api project(':trellis-api')
+    api "javax.json.bind:javax.json.bind-api:$jsonbVersion"
+
+    implementation project(':trellis-vocabulary')
+
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "org.eclipse:yasson:$yassonVersion"
+
+    jsonb "org.glassfish:javax.json:$glassfishJsonVersion"
+
+    if (!project.sourceCompatibility.isJava11Compatible()) {
+        testImplementation "org.glassfish:javax.json:$glassfishJsonVersion"
+    }
+}
+
+if (project.sourceCompatibility.isJava11Compatible()) {
+    compileTestJava {
+        doFirst {
+            classpath = files(configurations.jsonb)
+        }
+    }
+
+    test {
+        inputs.property("moduleName", moduleName)
+        doFirst {
+            classpath = files(configurations.jsonb)
+        }
+    }
+
+}

--- a/notifications/event-jsonb/src/main/java/module-info.java
+++ b/notifications/event-jsonb/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module org.trellisldp.event.jsonb {
+    exports org.trellisldp.event.jsonb;
+
+    requires transitive org.trellisldp.api;
+    requires transitive org.trellisldp.vocabulary;
+
+    requires cdi.api;
+    requires java.json.bind;
+    requires org.apache.commons.rdf.api;
+
+    provides org.trellisldp.api.ActivityStreamService
+        with org.trellisldp.event.jsonb.DefaultActivityStreamService;
+}

--- a/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/ActivityStreamMessage.java
+++ b/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/ActivityStreamMessage.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.event.jsonb;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+
+import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbPropertyOrder;
+
+import org.apache.commons.rdf.api.IRI;
+import org.trellisldp.api.Event;
+import org.trellisldp.vocabulary.AS;
+
+/**
+ * A structure used for serializing an Event into an ActivityStream 2.0 JSON object.
+ *
+ * @see <a href="https://www.w3.org/TR/activitystreams-core/">Activity Streams 2.0</a>
+ *
+ * @author acoburn
+ */
+@JsonbPropertyOrder({"@context","id", "type", "inbox", "actor", "object", "published"})
+public class ActivityStreamMessage {
+
+    private String id;
+    private List<String> type;
+    private String inbox;
+    private List<String> actor;
+    private EventResource object;
+    private String published;
+
+    /**
+     * The JSON-LD context.
+     */
+    @JsonbProperty("@context")
+    public String context = "https://www.w3.org/ns/activitystreams";
+
+    /**
+     * The target resource of a message.
+     */
+    public static class EventResource {
+        private final String id;
+        private final List<String> type;
+
+        /**
+         * Create a new event resource target.
+         *
+         * @param id the identifier
+         * @param type the types
+         */
+        public EventResource(final String id, final List<String> type) {
+            this.id = id;
+            this.type = type.isEmpty() ? null : type;
+        }
+
+        /**
+         * @return the identifier
+         */
+        public String getId() {
+            return id;
+        }
+
+        /**
+         * @return the resource types
+         */
+        public List<String> getType() {
+            return type;
+        }
+    }
+
+    /**
+     * @return the event identifier
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return the event types
+     */
+    public List<String> getType() {
+        return type;
+    }
+
+    /**
+     * @return the inbox assocated with the resource
+     */
+    public String getInbox() {
+        return inbox;
+    }
+
+    /**
+     * @return the actors associated with this event
+     */
+    public List<String> getActor() {
+        return actor;
+    }
+
+    /**
+     * @return the target resource
+     */
+    public EventResource getObject() {
+        return object;
+    }
+
+    /**
+     * @return the created date
+     */
+    @JsonbProperty("published")
+    public String getPublished() {
+        return published;
+    }
+
+    /**
+     * Populate a ActivityStreamMessage from an Event.
+     *
+     * @param event The event
+     * @return an ActivityStreamMessage
+     */
+    public static ActivityStreamMessage from(final Event event) {
+
+        final ActivityStreamMessage msg = new ActivityStreamMessage();
+
+        msg.id = event.getIdentifier().getIRIString();
+        msg.type = event.getTypes().stream().map(IRI::getIRIString)
+            .map(type -> type.startsWith(AS.getNamespace()) ? type.substring(AS.getNamespace().length()) : type)
+            .collect(toList());
+
+        msg.published = event.getCreated().toString();
+
+        final List<String> actors = event.getAgents().stream().map(IRI::getIRIString).collect(toList());
+        msg.actor = actors.isEmpty() ? null : actors;
+
+        event.getInbox().map(IRI::getIRIString).ifPresent(inbox -> msg.inbox = inbox);
+        event.getTarget().map(IRI::getIRIString).ifPresent(target ->
+            msg.object = new EventResource(target,
+                    event.getTargetTypes().stream().map(IRI::getIRIString).collect(toList())));
+
+        return msg;
+    }
+}

--- a/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/DefaultActivityStreamService.java
+++ b/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/DefaultActivityStreamService.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.event.jsonb;
+
+import static java.util.Optional.of;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+import org.trellisldp.api.ActivityStreamService;
+import org.trellisldp.api.Event;
+
+/**
+ * An {@link ActivityStreamService} that serializes an {@link Event} object
+ * into an ActivityStream-compliant JSON string.
+ *
+ * @author acoburn
+ */
+@ApplicationScoped
+public class DefaultActivityStreamService implements ActivityStreamService {
+
+    private static Jsonb jsonb = JsonbBuilder.create();
+
+    @Override
+    public Optional<String> serialize(final Event event) {
+        return of(jsonb.toJson(ActivityStreamMessage.from(event)));
+    }
+}

--- a/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/package-info.java
+++ b/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Trellis Event Serialization Implementation
+ * 
+ * <p>A package used for serializing Events into an Activity Stream JSON-LD representation.</p>
+ *
+ * @see <a href="https://www.w3.org/TR/activitystreams-core/">Activity Streams 2.0</a>
+ *
+ * @author acoburn
+ */
+package org.trellisldp.event.jsonb;

--- a/notifications/event-jsonb/src/main/resources/META-INF/beans.xml
+++ b/notifications/event-jsonb/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>

--- a/notifications/event-jsonb/src/main/resources/META-INF/services/org.trellisldp.api.ActivityStreamService
+++ b/notifications/event-jsonb/src/main/resources/META-INF/services/org.trellisldp.api.ActivityStreamService
@@ -1,0 +1,1 @@
+org.trellisldp.event.jsonb.DefaultActivityStreamService

--- a/notifications/event-jsonb/src/test/java/org/trellisldp/event/jsonb/DefaultActivityStreamServiceTest.java
+++ b/notifications/event-jsonb/src/test/java/org/trellisldp/event/jsonb/DefaultActivityStreamServiceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.event.jsonb;
+
+import static java.time.Instant.now;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.trellisldp.vocabulary.AS.Create;
+import static org.trellisldp.vocabulary.LDP.Container;
+import static org.trellisldp.vocabulary.PROV.Activity;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.trellisldp.api.ActivityStreamService;
+import org.trellisldp.api.Event;
+import org.trellisldp.vocabulary.AS;
+
+/**
+ * @author acoburn
+ */
+class DefaultActivityStreamServiceTest {
+
+    private static final RDF rdf = new SimpleRDF();
+
+    private final ActivityStreamService svc = new DefaultActivityStreamService();
+
+    private final Instant time = now();
+
+    @Mock
+    private Event mockEvent;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        when(mockEvent.getIdentifier()).thenReturn(rdf.createIRI("info:event/12345"));
+        when(mockEvent.getAgents()).thenReturn(singleton(rdf.createIRI("info:user/test")));
+        when(mockEvent.getTarget()).thenReturn(of(rdf.createIRI("trellis:data/resource")));
+        when(mockEvent.getTypes()).thenReturn(singleton(Create));
+        when(mockEvent.getTargetTypes()).thenReturn(singleton(Container));
+        when(mockEvent.getInbox()).thenReturn(of(rdf.createIRI("info:ldn/inbox")));
+        when(mockEvent.getCreated()).thenReturn(time);
+    }
+
+    @Test
+    void testSerialization() {
+        final Optional<String> json = svc.serialize(mockEvent);
+        assertTrue(json.isPresent(), "Serialization not present!");
+        assertTrue(json.get().contains("\"inbox\":\"info:ldn/inbox\""), "ldp:inbox not in serialization!");
+    }
+
+    @Test
+    void testSerializationStructure() throws Exception {
+        when(mockEvent.getTypes()).thenReturn(asList(Create, Activity));
+
+        final Optional<String> json = svc.serialize(mockEvent);
+        assertTrue(json.isPresent(), "Serialization not present!");
+
+        final Jsonb jsonb = JsonbBuilder.create();
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> map = jsonb.fromJson(json.get(), Map.class);
+        assertTrue(map.containsKey("@context"), "@context property not in JSON structure!");
+        assertTrue(map.containsKey("id"), "id property not in JSON structure!");
+        assertTrue(map.containsKey("type"), "type property not in JSON structure!");
+        assertTrue(map.containsKey("inbox"), "inbox property not in JSON structure!");
+        assertTrue(map.containsKey("actor"), "actor property not in JSON structure!");
+        assertTrue(map.containsKey("object"), "object property not in JSON structure!");
+        assertTrue(map.containsKey("published"), "published property not in JSON structure!");
+
+        final List<?> types = (List<?>) map.get("type");
+        assertTrue(types.contains("Create"), "as:Create not in type list!");
+        assertTrue(types.contains(Activity.getIRIString()), "prov:Activity not in type list!");
+
+        assertTrue(AS.getNamespace().contains((String) map.get("@context")), "AS namespace not in @context!");
+
+        final List<?> actor = (List<?>) map.get("actor");
+        assertTrue(actor.contains("info:user/test"), "actor property has incorrect value!");
+
+        assertEquals("info:event/12345", map.get("id"), "id property has incorrect value!");
+        assertEquals("info:ldn/inbox", map.get("inbox"), "inbox property has incorrect value!");
+        assertEquals(time.toString(), map.get("published"), "published property has incorrect value!");
+    }
+
+    @Test
+    void testSerializationStructureNoEmptyElements() throws Exception {
+        when(mockEvent.getInbox()).thenReturn(empty());
+        when(mockEvent.getAgents()).thenReturn(emptyList());
+        when(mockEvent.getTargetTypes()).thenReturn(emptyList());
+
+        final Optional<String> json = svc.serialize(mockEvent);
+        assertTrue(json.isPresent(), "Serialization not present!");
+
+        final Jsonb jsonb = JsonbBuilder.create();
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> map = jsonb.fromJson(json.get(), Map.class);
+        assertTrue(map.containsKey("@context"), "@context property not in JSON structure!");
+        assertTrue(map.containsKey("id"), "id property not in JSON structure!");
+        assertTrue(map.containsKey("type"), "type property not in JSON strucutre!");
+        assertFalse(map.containsKey("inbox"), "inbox property unexpectedly in JSON structure!");
+        assertFalse(map.containsKey("actor"), "actor property unexpectedly in JSON structure!");
+        assertTrue(map.containsKey("object"), "object property not in JSON structure!");
+        assertTrue(map.containsKey("published"), "published property not in JSON structure!");
+
+        final List<?> types = (List<?>) map.get("type");
+        assertTrue(types.contains("Create"), "as:Create type not in type list!");
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> obj = (Map<String, Object>) map.get("object");
+        assertTrue(obj.containsKey("id"), "object id property not in JSON structure!");
+        assertFalse(obj.containsKey("type"), "empty object type unexpectedly in JSON structure!");
+
+        assertTrue(AS.getNamespace().contains((String) map.get("@context")), "AS namespace not in @context!");
+
+        assertEquals("info:event/12345", map.get("id"), "id property has incorrect value!");
+        assertEquals(time.toString(), map.get("published"), "published property has incorrect value!");
+    }
+}

--- a/platform/bom/build.gradle
+++ b/platform/bom/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     implementation project(':trellis-vocabulary')
 
     implementation project(':trellis-amqp')
+    implementation project(':trellis-event-jackson')
+    implementation project(':trellis-event-jsonb')
     implementation project(':trellis-jms')
     implementation project(':trellis-kafka')
     implementation project(':trellis-reactive')
@@ -16,7 +18,6 @@ dependencies {
     implementation project(':trellis-audit')
     implementation project(':trellis-constraint-rules')
     implementation project(':trellis-dropwizard')
-    implementation project(':trellis-event-jackson')
     implementation project(':trellis-file')
     implementation project(':trellis-io-jena')
     implementation project(':trellis-namespaces')

--- a/platform/openliberty/build.gradle
+++ b/platform/openliberty/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation project(':trellis-auth-basic')
     implementation project(':trellis-auth-oauth')
     implementation project(':trellis-constraint-rules')
-    implementation project(':trellis-event-jackson')
+    implementation project(':trellis-event-jsonb')
     implementation project(':trellis-file')
     implementation project(':trellis-http')
     implementation project(':trellis-io-jena')

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(":trellis-audit")
     implementation project(":trellis-auth-oauth")
     implementation project(":trellis-constraint-rules")
-    implementation project(":trellis-event-jackson")
+    implementation project(":trellis-event-jsonb")
     implementation project(":trellis-file")
     implementation project(":trellis-http")
     implementation project(":trellis-io-jena")
@@ -21,6 +21,7 @@ dependencies {
     implementation project(":trellis-vocabulary")
     implementation project(":trellis-webac")
 
+    implementation 'io.quarkus:quarkus-jsonb'
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,7 @@ include ':trellis-vocabulary'
 
 include ':trellis-amqp'
 include ':trellis-event-jackson'
+include ':trellis-event-jsonb'
 include ':trellis-jms'
 include ':trellis-kafka'
 include ':trellis-reactive'
@@ -54,6 +55,7 @@ project(':trellis-vocabulary').projectDir = "$rootDir/core/vocabulary" as File
 
 project(':trellis-amqp').projectDir = "$rootDir/notifications/amqp" as File
 project(':trellis-event-jackson').projectDir = "$rootDir/notifications/event-jackson" as File
+project(':trellis-event-jsonb').projectDir = "$rootDir/notifications/event-jsonb" as File
 project(':trellis-jms').projectDir = "$rootDir/notifications/jms" as File
 project(':trellis-kafka').projectDir = "$rootDir/notifications/kafka" as File
 project(':trellis-reactive').projectDir = "$rootDir/notifications/reactive" as File


### PR DESCRIPTION
Resolves #524

This is very similar to the existing trellis-event component except that
it doesn't depend on Jackson. This will generally be used by
microprofile-based systems.