### PR TITLE
Add no-arg constructors for CDI-managed beans

### DIFF
--- a/core/api/src/main/java/org/trellisldp/api/NoopActivityStreamService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopActivityStreamService.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.api;
+
+import java.util.Optional;
+
+/**
+ * For use when event serialization is not desired.
+ */
+@NoopImplementation
+public class NoopActivityStreamService implements ActivityStreamService {
+    @Override
+    public Optional<String> serialize(final Event event) {
+        return Optional.empty();
+    }
+}

--- a/core/api/src/test/java/org/trellisldp/api/NoopActivityStreamServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopActivityStreamServiceTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class NoopActivityStreamServiceTest {
+
+    @Test
+    void testNoopEventSerializationService() {
+        final Event event = mock(Event.class);
+        final ActivityStreamService svc = new NoopActivityStreamService();
+        assertFalse(svc.serialize(event).isPresent());
+    }
+}
+

--- a/notifications/kafka/src/main/java/org/trellisldp/kafka/KafkaEventService.java
+++ b/notifications/kafka/src/main/java/org/trellisldp/kafka/KafkaEventService.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.trellisldp.api.ActivityStreamService;
 import org.trellisldp.api.Event;
 import org.trellisldp.api.EventService;
+import org.trellisldp.api.NoopActivityStreamService;
 
 /**
  * A Kafka message producer capable of publishing messages to a Kafka cluster.
@@ -44,6 +45,15 @@ public class KafkaEventService implements EventService {
     private final ActivityStreamService serializer;
     private final Producer<String, String> producer;
     private final String topic;
+
+    /**
+     * Create a new Kafka Event Service with a no-op serializer.
+     *
+     * <p>Note: this is used by CDI proxies and should not be invoked directly.
+     */
+    public KafkaEventService() {
+        this(new NoopActivityStreamService());
+    }
 
     /**
      * Create a new Kafka Event Service.

--- a/notifications/kafka/src/test/java/org/trellisldp/kafka/KafkaEventServiceTest.java
+++ b/notifications/kafka/src/test/java/org/trellisldp/kafka/KafkaEventServiceTest.java
@@ -81,6 +81,12 @@ class KafkaEventServiceTest {
     }
 
     @Test
+    void testNoargCtor() {
+        final EventService svc = new KafkaEventService();
+        assertDoesNotThrow(() -> svc.emit(mockEvent));
+    }
+
+    @Test
     void testDefaultKafka() {
         assertDoesNotThrow(() -> new KafkaEventService(serializer));
     }

--- a/notifications/reactive/src/main/java/org/trellisldp/reactive/ReactiveEventService.java
+++ b/notifications/reactive/src/main/java/org/trellisldp/reactive/ReactiveEventService.java
@@ -13,6 +13,8 @@
  */
 package org.trellisldp.reactive;
 
+import static java.util.Objects.requireNonNull;
+
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.subjects.PublishSubject;
@@ -36,12 +38,21 @@ public class ReactiveEventService implements EventService {
     private final PublishSubject<Message<String>> subject = PublishSubject.create();
 
     /**
+     * Create a new Reactive Stream Event Service with a no-op serializer.
+     *
+     * <p>Note: this is used by CDI proxies and should not be invoked directly.
+     */
+    public ReactiveEventService() {
+        this(new NoopActivityStreamService());
+    }
+
+    /**
      * Create a new Reactive Stream Event Service.
      * @param serializer the event serializer
      */
     @Inject
     public ReactiveEventService(final ActivityStreamService serializer) {
-        this.serializer = serializer;
+        this.serializer = requireNonNull(serializer, "serializer may not be null!");
     }
 
     @Override

--- a/notifications/reactive/src/test/java/org/trellisldp/reactive/ReactiveEventServiceTest.java
+++ b/notifications/reactive/src/test/java/org/trellisldp/reactive/ReactiveEventServiceTest.java
@@ -92,6 +92,12 @@ class ReactiveEventServiceTest {
     }
 
     @Test
+    void testNoargCtor() {
+        final ReactiveEventService svc = new ReactiveEventService();
+        assertDoesNotThrow(() -> svc.emit(mockEvent));
+    }
+
+    @Test
     void testReactiveStream() {
         service.emit(mockEvent);
         await().atMost(5, SECONDS).until(() -> collector.getResults().size() == 1);


### PR DESCRIPTION
Resolves #537

In certain CDI environments, especially Quarkus, having no-arg
constructors is needed for creating proxy-able beans prior to actual
injection.

As such, this adds no-arg ctors to the -reactive and -kafka event
service implementations and also introduces a NoopActivityStreamService
that can be used by those ctors.