### PR TITLE
Adjust named graph extension mechanism

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
@@ -55,6 +55,9 @@ public final class HttpConstants {
     /** Configuration key defining the server's base URL. */
     public static final String CONFIG_HTTP_BASE_URL = "trellis.http.baseUrl";
 
+    /** Configuration key defining the extension graph mapping. */
+    public static final String CONFIG_HTTP_EXTENSION_GRAPHS = "trellis.http.extension.graphs";
+
     /** Configuration key defining whether to include dates in memento headers. */
     public static final String CONFIG_HTTP_MEMENTO_HEADER_DATES = "trellis.http.memento.headerdates";
 

--- a/core/http/src/main/java/org/trellisldp/http/core/Prefer.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Prefer.java
@@ -55,6 +55,8 @@ public class Prefer {
 
     public static final String PREFER_HANDLING = "handling";
 
+    private static final String WS = " ";
+
     private final String preference;
 
     private final String handling;
@@ -152,6 +154,15 @@ public class Prefer {
         return omit;
     }
 
+    @Override
+    public String toString() {
+        final String includeParam = include.isEmpty() ? "" : "include=\"" + join(WS, include) + "\";";
+        final String omitParam = omit.isEmpty() ? "" : "omit=\"" + join(WS, omit) + "\";";
+        return getPreference().map(pref -> "return=" + pref + ";").orElse("") + includeParam + omitParam +
+            getHandling().map(pref -> "handling=" + pref + ";").orElse("") +
+            (getRespondAsync() ? "respond-async" : "");
+    }
+
     /**
      * Build a Prefer object with a set of included IRIs.
      *
@@ -164,7 +175,7 @@ public class Prefer {
             return valueOf(join("=", PREFER_RETURN, PREFER_REPRESENTATION));
         }
         return valueOf(join("=", PREFER_RETURN, PREFER_REPRESENTATION) + "; " + PREFER_INCLUDE + "=\"" +
-                join(" ", iris) + "\"");
+                join(WS, iris) + "\"");
     }
 
     /**
@@ -179,7 +190,7 @@ public class Prefer {
             return valueOf(join("=", PREFER_RETURN, PREFER_REPRESENTATION));
         }
         return valueOf(join("=", PREFER_RETURN, PREFER_REPRESENTATION) + "; " + PREFER_OMIT + "=\"" +
-                join(" ", iris) + "\"");
+                join(WS, iris) + "\"");
     }
 
     private static List<String> parseParameter(final String param) {

--- a/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
@@ -19,6 +19,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Arrays.stream;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.function.Predicate.isEqual;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static javax.ws.rs.core.Response.notModified;
@@ -39,6 +40,7 @@ import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -378,6 +380,17 @@ public final class HttpUtils {
         } catch (final Exception ex) {
             throw new RuntimeTrellisException("Error closing dataset", ex);
         }
+    }
+
+    /**
+     * Build a map suitable for extension graphs from a config string.
+     * @param extensions the config value
+     * @return the formatted map
+     */
+    public static Map<String, IRI> buildExtensionMap(final String extensions) {
+        return stream(extensions.split(",")).map(item -> item.split("=")).filter(kv -> kv.length == 2)
+            .filter(kv -> !kv[0].trim().isEmpty() && !kv[1].trim().isEmpty())
+            .collect(toMap(kv -> kv[0].trim(), kv -> rdf.createIRI(kv[1].trim())));
     }
 
     private HttpUtils() {

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -41,6 +41,7 @@ import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
@@ -88,11 +89,12 @@ public class PostHandler extends MutatingLdpHandler {
      * @param id the new resource's identifier
      * @param entity the entity
      * @param trellis the Trellis application bundle
+     * @param extensions the extension graph mapping
      * @param baseUrl the base URL
      */
     public PostHandler(final TrellisRequest req, final IRI parentIdentifier, final String id, final InputStream entity,
-            final ServiceBundler trellis, final String baseUrl) {
-        super(req, trellis, baseUrl, entity);
+            final ServiceBundler trellis, final Map<String, IRI> extensions, final String baseUrl) {
+        super(req, trellis, extensions, baseUrl, entity);
 
         final String separator = req.getPath().isEmpty() ? "" : "/";
 
@@ -144,7 +146,7 @@ public class PostHandler extends MutatingLdpHandler {
         } else if (DELETED_RESOURCE.equals(parent)) {
             // Can't POST to a deleted resource
             throw new ClientErrorException(GONE);
-        } else if (isAclRequest()
+        } else if (getExtensionGraphName() != null
                 || ldpResourceTypes(parent.getInteractionModel()).noneMatch(LDP.Container::equals)) {
             // Can't POST to an ACL resource or non-Container
             throw new NotAllowedException(GET, Stream.of(HEAD, OPTIONS, PATCH, PUT, DELETE).toArray(String[]::new));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
@@ -13,7 +13,10 @@
  */
 package org.trellisldp.http;
 
+import static java.util.Collections.singletonMap;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.trellisldp.http.core.HttpConstants.ACL;
+import static org.trellisldp.vocabulary.Trellis.PreferAccessControl;
 
 import javax.ws.rs.core.Application;
 
@@ -37,7 +40,7 @@ class TrellisHttpResourceAdminTest extends AbstractTrellisHttpResourceTest {
         final String baseUri = getBaseUri().toString();
 
         final ResourceConfig config = new ResourceConfig();
-        config.register(new TrellisHttpResource(mockBundler, baseUri));
+        config.register(new TrellisHttpResource(mockBundler, singletonMap(ACL, PreferAccessControl), baseUri));
         config.register(new TestAuthenticationFilter("testUser", ""));
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
@@ -13,7 +13,10 @@
  */
 package org.trellisldp.http;
 
+import static java.util.Collections.singletonMap;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.trellisldp.http.core.HttpConstants.ACL;
+import static org.trellisldp.vocabulary.Trellis.PreferAccessControl;
 
 import javax.ws.rs.core.Application;
 
@@ -40,7 +43,7 @@ class TrellisHttpResourceBaseUrlTest extends AbstractTrellisHttpResourceTest {
         initMocks(this);
 
         final ResourceConfig config = new ResourceConfig();
-        config.register(new TrellisHttpResource(mockBundler, URL));
+        config.register(new TrellisHttpResource(mockBundler, singletonMap(ACL, PreferAccessControl), URL));
         config.register(new TestAuthenticationFilter("testUser", "group"));
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
@@ -13,7 +13,10 @@
  */
 package org.trellisldp.http;
 
+import static java.util.Collections.singletonMap;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.trellisldp.http.core.HttpConstants.ACL;
+import static org.trellisldp.vocabulary.Trellis.PreferAccessControl;
 
 import javax.ws.rs.core.Application;
 
@@ -38,7 +41,7 @@ class TrellisHttpResourceNoAgentTest extends AbstractTrellisHttpResourceTest {
         final String baseUri = getBaseUri().toString();
 
         final ResourceConfig config = new ResourceConfig();
-        config.register(new TrellisHttpResource(mockBundler, baseUri));
+        config.register(new TrellisHttpResource(mockBundler, singletonMap(ACL, PreferAccessControl), baseUri));
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
+import static org.trellisldp.http.core.HttpConstants.ACL;
+import static org.trellisldp.vocabulary.Trellis.PreferAccessControl;
 
 import java.net.URI;
 import java.util.stream.Stream;
@@ -82,7 +84,7 @@ class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         initMocks(this);
 
         final ResourceConfig config = new ResourceConfig();
-        config.register(new TrellisHttpResource(mockBundler, null));
+        config.register(new TrellisHttpResource(mockBundler, singletonMap(ACL, PreferAccessControl), null));
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
@@ -96,7 +98,8 @@ class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
 
     @Test
     void testNoBaseURL() throws Exception {
-        final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler, null);
+        final TrellisHttpResource matcher = new TrellisHttpResource(mockBundler,
+                singletonMap(ACL, PreferAccessControl), null);
 
         when(mockUriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>(singletonMap("path", "resource")));
         when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://my.example.com/"));

--- a/core/http/src/test/java/org/trellisldp/http/core/PreferTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/PreferTest.java
@@ -47,31 +47,31 @@ class PreferTest {
 
     @Test
     void testPrefer1() {
-        final Prefer prefer = Prefer.valueOf("return=representation; include=\"http://example.org/test\"");
+        final Prefer prefer = valueOf("return=representation; include=\"http://example.org/test\"");
         assertAll(CHECK_SIMPLE_PARSING, checkPreferInclude(prefer, URL));
     }
 
     @Test
     void testPrefer1b() {
-        final Prefer prefer = Prefer.ofInclude(URL);
+        final Prefer prefer = ofInclude(URL);
         assertAll(CHECK_SIMPLE_PARSING, checkPreferInclude(prefer, URL));
     }
 
     @Test
     void testPrefer1c() {
-        final Prefer prefer = Prefer.valueOf("return=representation; include=http://example.org/test");
+        final Prefer prefer = valueOf("return=representation; include=http://example.org/test");
         assertAll(CHECK_SIMPLE_PARSING, checkPreferInclude(prefer, URL));
     }
 
     @Test
     void testPrefer2() {
-        final Prefer prefer = Prefer.valueOf("return  =  representation;   include =  \"http://example.org/test\"");
+        final Prefer prefer = valueOf("return  =  representation;   include =  \"http://example.org/test\"");
         assertAll(CHECK_SIMPLE_PARSING, checkPreferInclude(prefer, URL));
     }
 
     @Test
     void testPrefer3() {
-        final Prefer prefer = Prefer.valueOf("return=minimal");
+        final Prefer prefer = valueOf("return=minimal");
         assertEquals(of(PREFER_MINIMAL), prefer.getPreference(), CHECK_PREF_TYPE);
         assertTrue(prefer.getInclude().isEmpty(), "Check that there are no includes");
         assertTrue(prefer.getOmit().isEmpty(), "Check omits count is zero");
@@ -81,7 +81,7 @@ class PreferTest {
 
     @Test
     void testPrefer4() {
-        final Prefer prefer = Prefer.valueOf("return=other");
+        final Prefer prefer = valueOf("return=other");
         assertTrue(prefer.getInclude().isEmpty(), "Check includes is empty");
         assertTrue(prefer.getOmit().isEmpty(), "Check omits is empty");
         assertFalse(prefer.getPreference().isPresent(), CHECK_PREF_TYPE);
@@ -91,7 +91,7 @@ class PreferTest {
 
     @Test
     void testPrefer5() {
-        final Prefer prefer = Prefer.valueOf("return=representation; omit=\"http://example.org/test\"");
+        final Prefer prefer = valueOf("return=representation; omit=\"http://example.org/test\"");
         assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
         assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertFalse(prefer.getOmit().isEmpty(), "Check for omits");
@@ -102,7 +102,7 @@ class PreferTest {
 
     @Test
     void testPrefer5b() {
-        final Prefer prefer = Prefer.ofOmit(URL);
+        final Prefer prefer = ofOmit(URL);
         assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
         assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertFalse(prefer.getOmit().isEmpty(), "Check for omit values");
@@ -113,7 +113,7 @@ class PreferTest {
 
     @Test
     void testPrefer6() {
-        final Prefer prefer = Prefer.valueOf("handling=lenient; return=minimal");
+        final Prefer prefer = valueOf("handling=lenient; return=minimal");
         assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
         assertEquals(of(PREFER_MINIMAL), prefer.getPreference(), CHECK_PREF_TYPE);
@@ -123,7 +123,7 @@ class PreferTest {
 
     @Test
     void testPrefer7() {
-        final Prefer prefer = Prefer.valueOf("respond-async; random-param");
+        final Prefer prefer = valueOf("respond-async; random-param");
         assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
         assertFalse(prefer.getPreference().isPresent(), CHECK_PREF_TYPE);
@@ -133,7 +133,7 @@ class PreferTest {
 
     @Test
     void testPrefer8() {
-        final Prefer prefer = Prefer.valueOf("handling=strict; return=minimal");
+        final Prefer prefer = valueOf("handling=strict; return=minimal");
         assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
         assertEquals(of(PREFER_MINIMAL), prefer.getPreference(), CHECK_PREF_TYPE);
@@ -143,7 +143,7 @@ class PreferTest {
 
     @Test
     void testPrefer9() {
-        final Prefer prefer = Prefer.valueOf("handling=blah; return=minimal");
+        final Prefer prefer = valueOf("handling=blah; return=minimal");
         assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
         assertEquals(of(PREFER_MINIMAL), prefer.getPreference(), CHECK_PREF_TYPE);
@@ -152,8 +152,44 @@ class PreferTest {
     }
 
     @Test
+    void testRoundTrip1() {
+        final Prefer prefer = valueOf("return=minimal; handling=lenient; respond-async");
+        final String prefString = prefer.toString();
+        final Prefer prefer2 = valueOf(prefString);
+        assertEquals(prefer.getInclude(), prefer2.getInclude());
+        assertEquals(prefer.getOmit(), prefer2.getOmit());
+        assertEquals(prefer.getPreference(), prefer2.getPreference());
+        assertEquals(prefer.getHandling(), prefer2.getHandling());
+        assertEquals(prefer.getRespondAsync(), prefer2.getRespondAsync());
+    }
+
+    @Test
+    void testRoundTrip2() {
+        final Prefer prefer = valueOf("return=representation; include=\"https://example.com/Prefer\"");
+        final String prefString = prefer.toString();
+        final Prefer prefer2 = valueOf(prefString);
+        assertEquals(prefer.getInclude(), prefer2.getInclude());
+        assertEquals(prefer.getOmit(), prefer2.getOmit());
+        assertEquals(prefer.getPreference(), prefer2.getPreference());
+        assertEquals(prefer.getHandling(), prefer2.getHandling());
+        assertEquals(prefer.getRespondAsync(), prefer2.getRespondAsync());
+    }
+
+    @Test
+    void testRoundTrip3() {
+        final Prefer prefer = valueOf("return=representation; omit=\"https://example.com/Prefer\"");
+        final String prefString = prefer.toString();
+        final Prefer prefer2 = valueOf(prefString);
+        assertEquals(prefer.getInclude(), prefer2.getInclude());
+        assertEquals(prefer.getOmit(), prefer2.getOmit());
+        assertEquals(prefer.getPreference(), prefer2.getPreference());
+        assertEquals(prefer.getHandling(), prefer2.getHandling());
+        assertEquals(prefer.getRespondAsync(), prefer2.getRespondAsync());
+    }
+
+    @Test
     void testStaticInclude() {
-        final Prefer prefer = Prefer.ofInclude();
+        final Prefer prefer = ofInclude();
         assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
         assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
@@ -161,7 +197,7 @@ class PreferTest {
 
     @Test
     void testStaticOmit() {
-        final Prefer prefer = Prefer.ofOmit();
+        final Prefer prefer = ofOmit();
         assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
         assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
@@ -169,7 +205,7 @@ class PreferTest {
 
     @Test
     void testPreferBadQuotes() {
-        final Prefer prefer = Prefer.valueOf("return=representation; include=\"http://example.org/test");
+        final Prefer prefer = valueOf("return=representation; include=\"http://example.org/test");
         assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
         assertEquals(1L, prefer.getInclude().size(), "Check includes count");
         assertTrue(prefer.getInclude().contains("\"http://example.org/test"));
@@ -180,7 +216,7 @@ class PreferTest {
 
     @Test
     void testPreferBadQuotes2() {
-        final Prefer prefer = Prefer.valueOf("return=representation; include=\"");
+        final Prefer prefer = valueOf("return=representation; include=\"");
         assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
         assertEquals(1L, prefer.getInclude().size(), "Check for includes size");
         assertTrue(prefer.getInclude().contains("\""), "Check for weird quote in includes");
@@ -191,7 +227,7 @@ class PreferTest {
 
     @Test
     void testNullPrefer() {
-        assertNull(Prefer.valueOf(null), "Check null value");
+        assertNull(valueOf(null), "Check null value");
     }
 
     private Stream<Executable> checkPreferInclude(final Prefer prefer, final String url) {

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -17,6 +17,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -44,6 +45,7 @@ import static org.trellisldp.api.Syntax.SPARQL_UPDATE;
 import static org.trellisldp.api.TrellisUtils.TRELLIS_BNODE_PREFIX;
 import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.api.TrellisUtils.getInstance;
+import static org.trellisldp.http.core.HttpConstants.ACL;
 import static org.trellisldp.http.core.HttpConstants.PATCH;
 import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE_TYPE;
 
@@ -52,6 +54,7 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
@@ -93,6 +96,7 @@ import org.trellisldp.http.core.DefaultTimemapGenerator;
 import org.trellisldp.http.core.ServiceBundler;
 import org.trellisldp.http.core.TrellisRequest;
 import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.Trellis;
 
 /**
  * Base class for the HTTP handler tests.
@@ -111,6 +115,7 @@ class BaseTestHandler {
     static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
     static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_NAME);
     static final Instant time = ofEpochSecond(1496262729);
+    static final Map<String, IRI> extensions = singletonMap(ACL, Trellis.PreferAccessControl);
 
     private static final Set<IRI> allInteractionModels = new HashSet<>(asList(LDP.Resource, LDP.RDFSource,
             LDP.NonRDFSource, LDP.Container, LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer));

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -44,7 +44,7 @@ class DeleteHandlerTest extends BaseTestHandler {
 
     @Test
     void testDelete() {
-        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, null);
+        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, extensions, null);
         try (final Response res = handler.deleteResource(handler.initialize(mockParent, mockResource))
                 .toCompletableFuture().join().build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -60,7 +60,7 @@ class DeleteHandlerTest extends BaseTestHandler {
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(asyncException());
         final AuditService badAuditService = new DefaultAuditService() {};
         when(mockBundler.getAuditService()).thenReturn(badAuditService);
-        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, null);
+        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, extensions, null);
         assertThrows(CompletionException.class, () ->
                 unwrapAsyncError(handler.deleteResource(handler.initialize(mockParent, mockResource))),
                 "No exception thrown when the backend reports an exception!");
@@ -69,7 +69,7 @@ class DeleteHandlerTest extends BaseTestHandler {
     @Test
     void testDeleteError() {
         when(mockResourceService.delete(any(Metadata.class))).thenReturn(asyncException());
-        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
+        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, extensions, baseUrl);
         assertThrows(CompletionException.class, () ->
                 unwrapAsyncError(handler.deleteResource(handler.initialize(mockParent, mockResource))),
                 "No exception thrown when the backend reports an exception!");
@@ -78,7 +78,7 @@ class DeleteHandlerTest extends BaseTestHandler {
     @Test
     void testDeletePersistenceSupport() {
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
-        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
+        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, extensions, baseUrl);
         try (final Response res = assertThrows(WebApplicationException.class, () ->
                 handler.initialize(mockParent, mockResource)).getResponse()) {
             assertTrue(res.getLinks().stream().anyMatch(link ->
@@ -92,7 +92,7 @@ class DeleteHandlerTest extends BaseTestHandler {
     void testDeleteACLError() {
         when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getExt()).thenReturn(ACL);
-        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
+        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, extensions, baseUrl);
         assertThrows(CompletionException.class, () ->
                 unwrapAsyncError(handler.deleteResource(handler.initialize(mockParent, mockResource))),
                 "No exception thrown when an ACL couldn't be deleted!");
@@ -103,7 +103,7 @@ class DeleteHandlerTest extends BaseTestHandler {
         when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(completedFuture(null));
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(asyncException());
         when(mockTrellisRequest.getExt()).thenReturn(ACL);
-        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
+        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, extensions, baseUrl);
         assertThrows(CompletionException.class, () ->
                 unwrapAsyncError(handler.deleteResource(handler.initialize(mockParent, mockResource))),
                 "No exception thrown when an ACL audit stream couldn't be written!");

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -109,7 +109,8 @@ class GetHandlerTest extends BaseTestHandler {
     void testGetLdprs() {
         when(mockTrellisRequest.getBaseUrl()).thenReturn("http://example.org");
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, null);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                 .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -140,7 +141,8 @@ class GetHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getPrefer())
             .thenReturn(Prefer.valueOf("return=representation; include=\"http://www.w3.org/ns/ldp#PreferContainment"));
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, null);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -158,7 +160,8 @@ class GetHandlerTest extends BaseTestHandler {
 
     @Test
     void testGetVersionedLdprs() {
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, true, true, true, null, null);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, true, true, true,
+                null, null);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -195,7 +198,8 @@ class GetHandlerTest extends BaseTestHandler {
                 new SimpleEntry<>(SKOS.Concept.getIRIString(), "type"),
                 new SimpleEntry<>(inbox, "inbox")));
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, baseUrl);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -211,7 +215,8 @@ class GetHandlerTest extends BaseTestHandler {
     void testNotAcceptableLdprs() {
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(APPLICATION_JSON_TYPE));
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, baseUrl);
 
         try (final Response res = assertThrows(NotAcceptableException.class, () ->
                 handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource))),
@@ -225,7 +230,8 @@ class GetHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(APPLICATION_LD_JSON_TYPE));
         when(mockTrellisRequest.getPrefer()).thenReturn(Prefer.valueOf("return=minimal"));
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, baseUrl);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -258,7 +264,8 @@ class GetHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(
                     MediaType.valueOf(APPLICATION_LD_JSON + "; profile=\"" + compacted.getIRIString() + "\"")));
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, null);
 
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
@@ -301,7 +308,8 @@ class GetHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getAcceptableMediaTypes())
             .thenReturn(singletonList(MediaType.valueOf(RDFA.mediaType())));
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, null);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -319,7 +327,8 @@ class GetHandlerTest extends BaseTestHandler {
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true,
+                true, null, null);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertAll("Check binary description", checkBinaryDescription(res));
@@ -332,7 +341,8 @@ class GetHandlerTest extends BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getExt()).thenReturn(DESCRIPTION);
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, null);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, null);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertAll("Check binary description", checkBinaryDescription(res));
@@ -360,7 +370,8 @@ class GetHandlerTest extends BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getAcceptableMediaTypes()).thenReturn(singletonList(WILDCARD_TYPE));
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, baseUrl);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -381,7 +392,8 @@ class GetHandlerTest extends BaseTestHandler {
         when(mockResource.hasAcl()).thenReturn(true);
         when(mockTrellisRequest.getExt()).thenReturn("acl");
 
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, true, null, baseUrl);
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, true,
+                null, baseUrl);
         try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
                         .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -397,7 +409,7 @@ class GetHandlerTest extends BaseTestHandler {
         final SortedSet<Instant> mementos = new TreeSet<>();
         mementos.add(time1);
         mementos.add(time2);
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, false,
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, false,
                 null, baseUrl);
         try (final Response res = handler.addMementoHeaders(handler.standardHeaders(handler.initialize(mockResource)),
                 mementos).build()) {
@@ -419,7 +431,7 @@ class GetHandlerTest extends BaseTestHandler {
         mementos.add(time3);
         mementos.add(time4);
         mementos.add(time5);
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, false, true, false,
+        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, false, true, false,
                 null, baseUrl);
         try (final Response res = handler.addMementoHeaders(handler.standardHeaders(handler.initialize(mockResource)),
                 mementos).build()) {

--- a/core/http/src/test/java/org/trellisldp/http/impl/HttpUtilsTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/HttpUtilsTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.ClientErrorException;
@@ -280,5 +281,16 @@ class HttpUtilsTest {
     void testCloseDataset() throws Exception {
         doThrow(new IOException()).when(mockDataset).close();
         assertThrows(RuntimeTrellisException.class, () -> HttpUtils.closeDataset(mockDataset));
+    }
+
+    @Test
+    void testExtMapBuilder() {
+        assertTrue(HttpUtils.buildExtensionMap("").isEmpty());
+        assertTrue(HttpUtils.buildExtensionMap("    ").isEmpty());
+        assertTrue(HttpUtils.buildExtensionMap(", , = ,foo=  ,, =bar,baz").isEmpty());
+        final Map<String, IRI> data1 = HttpUtils.buildExtensionMap(
+                "ex = https://example.com/  ,acl=http://www.trellisldp.org/ns/trellis#PreferAccessControl");
+        assertEquals(rdf.createIRI("https://example.com/"), data1.get("ex"));
+        assertEquals(Trellis.PreferAccessControl, data1.get("acl"));
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
@@ -26,9 +26,7 @@ import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
-import static org.trellisldp.http.core.HttpConstants.ACCEPT_PATCH;
-import static org.trellisldp.http.core.HttpConstants.ACCEPT_POST;
-import static org.trellisldp.http.core.HttpConstants.PATCH;
+import static org.trellisldp.http.core.HttpConstants.*;
 import static org.trellisldp.http.core.RdfMediaType.APPLICATION_LD_JSON;
 import static org.trellisldp.http.core.RdfMediaType.APPLICATION_N_TRIPLES;
 import static org.trellisldp.http.core.RdfMediaType.APPLICATION_SPARQL_UPDATE;
@@ -51,7 +49,8 @@ class OptionsHandlerTest extends BaseTestHandler {
     void testOptionsLdprs() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
 
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, null);
+        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
+                false, null);
         try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
@@ -65,7 +64,8 @@ class OptionsHandlerTest extends BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
         when(mockIoService.supportedWriteSyntaxes()).thenReturn(asList(TURTLE, JSONLD, NTRIPLES));
 
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, baseUrl);
+        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
+                false, baseUrl);
         try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
@@ -83,7 +83,8 @@ class OptionsHandlerTest extends BaseTestHandler {
     void testOptionsLdpnr() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
 
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, null);
+        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
+                false, null);
         try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
@@ -95,7 +96,8 @@ class OptionsHandlerTest extends BaseTestHandler {
     void testOptionsAcl() {
         when(mockTrellisRequest.getExt()).thenReturn("acl");
 
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, baseUrl);
+        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
+                false, baseUrl);
         try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
@@ -106,7 +108,8 @@ class OptionsHandlerTest extends BaseTestHandler {
 
     @Test
     void testOptionsMemento() {
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, true, null);
+        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
+                true, null);
         try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header on Memento!");

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -68,7 +68,8 @@ class PatchHandlerTest extends BaseTestHandler {
 
     @Test
     void testPatchNoSparql() {
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, null, mockBundler, null, null);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, null, mockBundler, extensions,
+                null, null);
         try (final Response res = assertThrows(BadRequestException.class, () ->
                 patchHandler.initialize(mockParent, mockResource),
                 "No exception thrown with a null input!").getResponse()) {
@@ -85,7 +86,7 @@ class PatchHandlerTest extends BaseTestHandler {
         // will never store audit
         when(mockResourceService.add(any(IRI.class), any(Dataset.class))).thenReturn(asyncException());
 
-        final PatchHandler handler = new PatchHandler(mockTrellisRequest, "", mockBundler, null, null);
+        final PatchHandler handler = new PatchHandler(mockTrellisRequest, "", mockBundler, extensions, null, null);
 
         assertThrows(CompletionException.class, () ->
                 unwrapAsyncError(handler.updateResource(handler.initialize(mockParent, mockResource))),
@@ -97,7 +98,8 @@ class PatchHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockTrellisRequest.getPath()).thenReturn(RESOURCE_NAME);
 
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, baseUrl);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, extensions,
+                null, baseUrl);
         try (final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
                 .toCompletableFuture().join().build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -113,11 +115,11 @@ class PatchHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getPath()).thenReturn(RESOURCE_NAME);
         when(mockTrellisRequest.getBaseUrl()).thenReturn("http://localhost/");
 
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, extensions,
+                null, null);
         try (final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
                 .toCompletableFuture().join().build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
-
             verify(mockIoService).update(any(Graph.class), eq(insert), eq(SPARQL_UPDATE),
                     eq("http://localhost/resource"));
             verify(mockResourceService).replace(any(Metadata.class), any(Dataset.class));
@@ -131,7 +133,8 @@ class PatchHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getPath()).thenReturn(RESOURCE_NAME);
         when(mockTrellisRequest.getBaseUrl()).thenReturn("http://localhost/");
 
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, extensions,
+                null, null);
         try (final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
                 .toCompletableFuture().join().build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -153,7 +156,8 @@ class PatchHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getPath()).thenReturn(RESOURCE_NAME);
         when(mockTrellisRequest.getPrefer()).thenReturn(Prefer.valueOf(RETURN_REPRESENTATION));
 
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, extensions,
+                null, null);
         try (final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
                 .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -175,7 +179,8 @@ class PatchHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getAcceptableMediaTypes())
             .thenReturn(singletonList(MediaType.valueOf(RDFA.mediaType())));
 
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, extensions,
+                null, null);
         try (final Response res = patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
                 .toCompletableFuture().join().build()) {
             assertEquals(OK, res.getStatusInfo(), ERR_RESPONSE_CODE);
@@ -195,7 +200,8 @@ class PatchHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getPath()).thenReturn(RESOURCE_NAME);
         when(mockResourceService.replace(any(Metadata.class), any(Dataset.class))).thenReturn(asyncException());
 
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, extensions,
+                null, null);
         assertThrows(CompletionException.class, () ->
                 unwrapAsyncError(patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))),
                 "No exception thrown when the backend triggers an exception!");
@@ -206,7 +212,8 @@ class PatchHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getContentType()).thenReturn(APPLICATION_SPARQL_UPDATE);
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
 
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, null);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, extensions,
+                null, null);
         try (final Response res = assertThrows(BadRequestException.class, () ->
                 patchHandler.initialize(mockParent, mockResource),
                 "No exception for an unsupported IXN model!").getResponse()) {
@@ -224,7 +231,8 @@ class PatchHandlerTest extends BaseTestHandler {
         doThrow(RuntimeTrellisException.class).when(mockIoService)
             .update(any(Graph.class), eq(insert), eq(SPARQL_UPDATE), eq(baseUrl + RESOURCE_NAME));
 
-        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, null, baseUrl);
+        final PatchHandler patchHandler = new PatchHandler(mockTrellisRequest, insert, mockBundler, extensions,
+                null, baseUrl);
         try (final Response res = assertThrows(BadRequestException.class, () ->
                 patchHandler.updateResource(patchHandler.initialize(mockParent, mockResource))
                 .toCompletableFuture().join(), "No exception when the update triggers an error!").getResponse()) {

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -236,7 +236,7 @@ class PostHandlerTest extends BaseTestHandler {
     @Test
     void testBadRdfInputStream() {
         final PostHandler handler = new PostHandler(mockTrellisRequest, root, "bad-resource",
-                buildThrowingInputStream(), mockBundler, null);
+                buildThrowingInputStream(), mockBundler, extensions, null);
         try (final Response res = assertThrows(WebApplicationException.class, () ->
                 handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE)).toCompletableFuture().join())
                 .getResponse()) {
@@ -253,7 +253,7 @@ class PostHandlerTest extends BaseTestHandler {
     private PostHandler buildPostHandler(final String resourceName, final String id, final String baseUrl)
                     throws IOException {
         return new PostHandler(mockTrellisRequest, root, id, getClass().getResource(resourceName).openStream(),
-                mockBundler, baseUrl);
+                mockBundler, extensions, baseUrl);
     }
 
     private Stream<Executable> checkBinaryEntityResponse(final String contentType) {

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -318,8 +318,8 @@ class PutHandlerTest extends BaseTestHandler {
             .thenReturn(asyncException());
 
         try (final InputStream entity = getClass().getResource(RESOURCE_SIMPLE).openStream()) {
-            final PutHandler handler = new PutHandler(mockTrellisRequest, entity, mockBundler, false, true, null);
-
+            final PutHandler handler = new PutHandler(mockTrellisRequest, entity, mockBundler, extensions,
+                    false, true, null);
             assertThrows(CompletionException.class,
                             () -> unwrapAsyncError(handler.setResource(handler.initialize(mockParent, mockResource))),
                             "No exception when there's a problem with the backend binary service!");
@@ -333,7 +333,7 @@ class PutHandlerTest extends BaseTestHandler {
     private PutHandler buildPutHandler(final String resourceName, final String baseUrl, final boolean uncontained) {
         try {
             return new PutHandler(mockTrellisRequest, getClass().getResource(resourceName).openStream(), mockBundler,
-                            false, uncontained, baseUrl);
+                            extensions, false, uncontained, baseUrl);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Resolves #535

This generalizes the graph extension mechanism. By default, the
`acl` => `trellis:PreferAccessControl` mapping remains in place, but
this can be overridden/extended by configuration.

Note: this needs some more testing and refinement before merging, but this appears to work as advertised.