### PR TITLE
Adjust dependency scopes for trellis-app

### DIFF
--- a/components/app/build.gradle
+++ b/components/app/build.gradle
@@ -10,13 +10,12 @@ ext {
 }
 
 dependencies {
+    api("javax.enterprise:cdi-api:$cdiApiVersion")
     api project(':trellis-api')
     api project(':trellis-http')
+    api project(':trellis-vocabulary')
 
-    implementation("javax.enterprise:cdi-api:$cdiApiVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
     implementation("org.slf4j:slf4j-api:$slf4jVersion")
-    implementation project(':trellis-vocabulary')
 
     testRuntime("javax.activation:javax.activation-api:$activationApiVersion")
 


### PR DESCRIPTION
This adjusts the dependency scopes to ensure that trellis-vocabulary
ends up in the right runtime scope. It also moves the cdi dependency to
api scope, since that should also be defined there. The mp-config
dependency is removed since it is not used.