### PR TITLE
Close resources after use in test suite

### DIFF
--- a/buildtools/src/main/resources/pmd/pmd.xml
+++ b/buildtools/src/main/resources/pmd/pmd.xml
@@ -9,7 +9,10 @@
         Trellis PMD rules
     </description>
 
-    <rule ref="category/java/bestpractices.xml"/>
+    <rule ref="category/java/bestpractices.xml">
+      <exclude name="JUnitTestContainsTooManyAsserts"/>
+      <exclude name="JUnitAssertionsShouldIncludeMessage"/>
+    </rule>
     <rule ref="category/java/multithreading.xml">
       <exclude name="UseConcurrentHashMap"/>
     </rule>

--- a/components/test/src/main/java/org/trellisldp/test/AuditTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuditTests.java
@@ -118,39 +118,42 @@ public interface AuditTests extends CommonTests {
 
     /**
      * Check the absense of audit triples.
+     * @throws Exception if the RDF resource didn't close cleanly
      */
     @Test
     @DisplayName("Check the absense of audit triples.")
-    default void testNoAuditTriples() {
-        try (final Response res = target(getResourceLocation()).request().get()) {
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
+    default void testNoAuditTriples() throws Exception {
+        try (final Response res = target(getResourceLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertEquals(2L, g.size(), "Check that the graph has 2 triples");
         }
     }
 
     /**
      * Check the explicit absense of audit triples.
+     * @throws Exception if the RDF resource didn't close cleanly
      */
     @Test
     @DisplayName("Check the explicit absense of audit triples.")
-    default void testOmitAuditTriples() {
+    default void testOmitAuditTriples() throws Exception {
         try (final Response res = target(getResourceLocation()).request().header("Prefer",
-                    "return=representation; omit=\"" + Trellis.PreferAudit.getIRIString() + "\"").get()) {
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
+                    "return=representation; omit=\"" + Trellis.PreferAudit.getIRIString() + "\"").get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertEquals(2L, g.size(), "Check that the graph has only 2 triples");
         }
     }
 
     /**
      * Check the presence of audit triples.
+     * @throws Exception if the RDF resource didn't close cleanly
      */
     @Test
     @DisplayName("Check the presence of audit triples.")
-    default void testAuditTriples() {
+    default void testAuditTriples() throws Exception {
         final RDF rdf = getInstance();
         try (final Response res = target(getResourceLocation()).request().header("Prefer",
-                    "return=representation; include=\"" + Trellis.PreferAudit.getIRIString() + "\"").get()) {
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
+                    "return=representation; include=\"" + Trellis.PreferAudit.getIRIString() + "\"").get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertEquals(3L, g.stream(rdf.createIRI(getResourceLocation()), PROV.wasGeneratedBy, null).count(),
                     "Check for the presence of audit triples in the graph");
             assertAll("Check the graph triples",

--- a/components/test/src/main/java/org/trellisldp/test/InMemoryBinaryService.java
+++ b/components/test/src/main/java/org/trellisldp/test/InMemoryBinaryService.java
@@ -81,6 +81,11 @@ public class InMemoryBinaryService implements BinaryService {
 
         private final byte[] data;
 
+        /**
+         * Create an in-memory binary object.
+         *
+         * @implNote The provided {@link InputStream} is consumed in the constructor of this object
+         */
         private InMemoryBinary(final InputStream data) throws IOException {
             this.data = toByteArray(data);
         }

--- a/components/test/src/main/java/org/trellisldp/test/InMemoryBinaryService.java
+++ b/components/test/src/main/java/org/trellisldp/test/InMemoryBinaryService.java
@@ -58,7 +58,7 @@ public class InMemoryBinaryService implements BinaryService {
     @Override
     public CompletionStage<Void> setContent(final BinaryMetadata meta, final InputStream bytes) {
         try {
-            final InMemoryBinary binary = new InMemoryBinary(toByteArray(bytes));
+            final InMemoryBinary binary = new InMemoryBinary(bytes);
             data.put(meta.getIdentifier(), binary);
             return DONE;
         } catch (final IOException e) {
@@ -81,8 +81,8 @@ public class InMemoryBinaryService implements BinaryService {
 
         private final byte[] data;
 
-        private InMemoryBinary(final byte[] data) {
-            this.data = data;
+        private InMemoryBinary(final InputStream data) throws IOException {
+            this.data = toByteArray(data);
         }
 
         @Override

--- a/components/test/src/main/java/org/trellisldp/test/LdpDirectContainerTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpDirectContainerTests.java
@@ -153,10 +153,11 @@ public interface LdpDirectContainerTests extends CommonTests {
 
     /**
      * Test fetch a self-contained direct container.
+     * @throws Exception if the RDF resource did not close cleanly
      */
     @Test
     @DisplayName("Test fetch a self-contained direct container")
-    default void testSimpleDirectContainer() {
+    default void testSimpleDirectContainer() throws Exception {
         final RDF rdf = getInstance();
         final String memberContent = getResourceAsString(SIMPLE_RESOURCE);
         final String child;
@@ -173,9 +174,9 @@ public interface LdpDirectContainerTests extends CommonTests {
         }
 
         // Fetch the member resource
-        try (final Response res = target(getDirectContainerLocation()).request().get()) {
+        try (final Response res = target(getDirectContainerLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the member resource", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             assertTrue(g.contains(rdf.createIRI(getDirectContainerLocation()), LDP.contains,
                         rdf.createIRI(child)), "Verify an ldp:contains triple");
             assertTrue(g.contains(rdf.createIRI(getDirectContainerLocation() + MEMBER_RESOURCE_HASH), LDP.member,
@@ -185,10 +186,11 @@ public interface LdpDirectContainerTests extends CommonTests {
 
     /**
      * Test adding resources to the direct container.
+     * @throws Exception if an RDF resource did not close cleanly
      */
     @Test
     @DisplayName("Test adding resources to the direct container")
-    default void testAddingMemberResources() {
+    default void testAddingMemberResources() throws Exception {
         final RDF rdf = getInstance();
         final String dcLocation;
         final String child1;
@@ -213,9 +215,9 @@ public interface LdpDirectContainerTests extends CommonTests {
         }
 
         // Fetch the member resource
-        try (final Response res = target(getMemberLocation()).request().get()) {
+        try (final Response res = target(getMemberLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the member resource", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             assertFalse(g.contains(rdf.createIRI(getMemberLocation()), LDP.member, null),
                     "Check that an ldp:contains triple is not present");
             etag1 = res.getEntityTag();
@@ -223,9 +225,9 @@ public interface LdpDirectContainerTests extends CommonTests {
         }
 
         // Fetch the container resource
-        try (final Response res = target(dcLocation).request().get()) {
+        try (final Response res = target(dcLocation).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the container resource", checkRdfResponse(res, LDP.DirectContainer, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             assertFalse(g.contains(rdf.createIRI(dcLocation), LDP.contains, null),
                     "Check that the given ldp:contains triple isn't present");
             etag4 = res.getEntityTag();
@@ -252,9 +254,9 @@ public interface LdpDirectContainerTests extends CommonTests {
         await().until(() -> !etag1.equals(getETag(getMemberLocation())));
 
         // Fetch the member resource
-        try (final Response res = target(getMemberLocation()).request().get()) {
+        try (final Response res = target(getMemberLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check fetching the member resource", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertTrue(g.contains(identifier, LDP.member, rdf.createIRI(child1)), "Check for a member property");
             assertTrue(g.contains(identifier, LDP.member, rdf.createIRI(child2)), "Check for another member property");
@@ -264,9 +266,9 @@ public interface LdpDirectContainerTests extends CommonTests {
         }
 
         // Fetch the container resource
-        try (final Response res = target(dcLocation).request().get()) {
+        try (final Response res = target(dcLocation).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the container resource", checkRdfResponse(res, LDP.DirectContainer, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(dcLocation);
             assertTrue(g.contains(identifier, LDP.contains, rdf.createIRI(child1)), "Check for an ldp:contains triple");
             assertTrue(g.contains(identifier, LDP.contains, rdf.createIRI(child2)), "Check for an ldp:contains triple");
@@ -289,9 +291,9 @@ public interface LdpDirectContainerTests extends CommonTests {
         }
 
         // Fetch the member resource
-        try (final Response res = target(getMemberLocation()).request().get()) {
+        try (final Response res = target(getMemberLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check fetching the member resource", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertFalse(g.contains(identifier, LDP.member, rdf.createIRI(child1)),
                     "Check for the absense of a member triple");
@@ -304,9 +306,9 @@ public interface LdpDirectContainerTests extends CommonTests {
         }
 
         // Fetch the container resource
-        try (final Response res = target(dcLocation).request().get()) {
+        try (final Response res = target(dcLocation).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the container resource", checkRdfResponse(res, LDP.DirectContainer, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(dcLocation);
             assertFalse(g.contains(identifier, LDP.contains, rdf.createIRI(child1)),
                     "Check that child1 is no longer contained by the parent");
@@ -332,9 +334,9 @@ public interface LdpDirectContainerTests extends CommonTests {
         }
 
         // Fetch the member resource
-        try (final Response res = target(getMemberLocation()).request().get()) {
+        try (final Response res = target(getMemberLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check fetching the member resource", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertTrue(g.contains(identifier, DC.relation, rdf.createIRI(child2)),
                     "Confirm that the graph contains a dc:relation member triple");
@@ -465,10 +467,11 @@ public interface LdpDirectContainerTests extends CommonTests {
 
     /**
      * Test fetching inverse member properties on a direct container.
+     * @throws Exception when the RDF resource did not close cleanly
      */
     @Test
     @DisplayName("Test with inverse direct containment")
-    default void testDirectContainerWithInverseMembership() {
+    default void testDirectContainerWithInverseMembership() throws Exception {
         final RDF rdf = getInstance();
         final String dcLocation;
         final String rsLocation;
@@ -490,9 +493,9 @@ public interface LdpDirectContainerTests extends CommonTests {
             rsLocation = res.getLocation().toString();
         }
 
-        try (final Response res = target(rsLocation).request().get()) {
+        try (final Response res = target(rsLocation).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the LDP-RS", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertTrue(g.contains(rdf.createIRI(rsLocation), DC.isPartOf, identifier),
                     "Check that dc:isPartOf is present in the graph");
@@ -501,15 +504,16 @@ public interface LdpDirectContainerTests extends CommonTests {
 
     /**
      * Test with ldp:PreferMinimalContainer Prefer header.
+     * @throws Exception when the RDF resource did not close cleanly
      */
     @Test
     @DisplayName("Test with ldp:PreferMinimalContainer Prefer header")
-    default void testGetEmptyMember() {
+    default void testGetEmptyMember() throws Exception {
         final RDF rdf = getInstance();
         try (final Response res = target(getMemberLocation()).request().header(PREFER,
-                    "return=representation; include=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"").get()) {
+                    "return=representation; include=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"").get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the LDP-RS with Prefer", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertTrue(g.contains(identifier, SKOS.prefLabel, null), "Check for a skos:prefLabel triple");
             assertFalse(g.contains(identifier, LDP.member, null), "Check for no ldp:member triples");
@@ -519,15 +523,16 @@ public interface LdpDirectContainerTests extends CommonTests {
 
     /**
      * Test with ldp:PreferMinimalContainer Prefer header.
+     * @throws Exception when the RDF resource did not close cleanly
      */
     @Test
     @DisplayName("Test with ldp:PreferMinimalContainer Prefer header")
-    default void testGetInverseEmptyMember() {
+    default void testGetInverseEmptyMember() throws Exception {
         final RDF rdf = getInstance();
         try (final Response res = target(getMemberLocation()).request().header(PREFER,
-                    "return=representation; omit=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"").get()) {
+                    "return=representation; omit=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"").get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the LDP-RS with Prefer", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertFalse(g.contains(identifier, SKOS.prefLabel, null), "Check for no skos:prefLabel triples");
             assertTrue(g.contains(identifier, LDP.member, null) || g.contains(identifier, DC.relation, null),

--- a/components/test/src/main/java/org/trellisldp/test/LdpIndirectContainerTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpIndirectContainerTests.java
@@ -151,10 +151,11 @@ public interface LdpIndirectContainerTests extends CommonTests {
 
     /**
      * Test adding resource to the indirect container.
+     * @throws Exception if the RDF resource did not close cleanly
      */
     @Test
     @DisplayName("Test adding resource to the indirect container")
-    default void testAddResourceWithMemberSubject() {
+    default void testAddResourceWithMemberSubject() throws Exception {
         final RDF rdf = getInstance();
         final String content = getResourceAsString(INDIRECT_CONTAINER_MEMBER_SUBJECT)
             + membershipResource(MEMBER_RESOURCE_HASH);
@@ -177,9 +178,9 @@ public interface LdpIndirectContainerTests extends CommonTests {
         }
 
         //Fetch the member resource
-        try (final Response res = target(location).request().get()) {
+        try (final Response res = target(location).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the member resource", checkRdfResponse(res, LDP.IndirectContainer, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             assertTrue(g.contains(rdf.createIRI(location), LDP.contains,
                         rdf.createIRI(child)), "Check for an ldp:contains triple");
             assertTrue(g.contains(rdf.createIRI(location + MEMBER_RESOURCE_HASH),
@@ -189,10 +190,11 @@ public interface LdpIndirectContainerTests extends CommonTests {
 
     /**
      * Test adding resources to the indirect container.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test adding resources to the indirect container")
-    default void testAddingMemberResources() {
+    default void testAddingMemberResources() throws Exception {
         final RDF rdf = getInstance();
         final String child1;
         final String child2;
@@ -206,18 +208,18 @@ public interface LdpIndirectContainerTests extends CommonTests {
         final String childContent = getResourceAsString("/childResource.ttl");
 
         // Fetch the member resource
-        try (final Response res = target(getMemberLocation()).request().get()) {
+        try (final Response res = target(getMemberLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the member LDP-RS", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             assertFalse(g.contains(rdf.createIRI(getMemberLocation()), LDP.member, null), "Check for no ldp:member");
             etag1 = res.getEntityTag();
             assertTrue(etag1.isWeak(), "Check that the ETag is weak");
         }
 
         // Fetch the container resource
-        try (final Response res = target(getIndirectContainerLocation()).request().get()) {
+        try (final Response res = target(getIndirectContainerLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the container resource", checkRdfResponse(res, LDP.IndirectContainer, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             assertFalse(g.contains(rdf.createIRI(getIndirectContainerLocation()), LDP.contains, null),
                     "Check for no ldp:contains property");
             etag4 = res.getEntityTag();
@@ -244,9 +246,9 @@ public interface LdpIndirectContainerTests extends CommonTests {
         }
 
         // Fetch the member resource
-        try (final Response res = target(getMemberLocation()).request().get()) {
+        try (final Response res = target(getMemberLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the member LDP-RS", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertTrue(g.contains(identifier, LDP.member, rdf.createIRI(child1 + hash)), "Check for a member triple");
             assertTrue(g.contains(identifier, LDP.member, rdf.createIRI(child2 + hash)), "Check for a member triple");
@@ -256,9 +258,9 @@ public interface LdpIndirectContainerTests extends CommonTests {
         }
 
         // Fetch the container resource
-        try (final Response res = target(getIndirectContainerLocation()).request().get()) {
+        try (final Response res = target(getIndirectContainerLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the container resource", checkRdfResponse(res, LDP.IndirectContainer, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getIndirectContainerLocation());
             assertTrue(g.contains(identifier, LDP.contains, rdf.createIRI(child1)), "Check for first ldp:contains");
             assertTrue(g.contains(identifier, LDP.contains, rdf.createIRI(child2)), "Check for second ldp:contains");
@@ -281,9 +283,9 @@ public interface LdpIndirectContainerTests extends CommonTests {
         }
 
         // Fetch the member resource
-        try (final Response res = target(getMemberLocation()).request().get()) {
+        try (final Response res = target(getMemberLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the member resource", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertFalse(g.contains(identifier, LDP.member, rdf.createIRI(child1 + hash)),
                     "Verify that the child is no longer contained");
@@ -296,9 +298,9 @@ public interface LdpIndirectContainerTests extends CommonTests {
         }
 
         // Fetch the container resource
-        try (final Response res = target(getIndirectContainerLocation()).request().get()) {
+        try (final Response res = target(getIndirectContainerLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the container resource", checkRdfResponse(res, LDP.IndirectContainer, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getIndirectContainerLocation());
             assertFalse(g.contains(identifier, LDP.contains, rdf.createIRI(child1)),
                     "Check the first child isn't contained");
@@ -324,9 +326,9 @@ public interface LdpIndirectContainerTests extends CommonTests {
         }
 
         // Fetch the member resource
-        try (final Response res = target(getMemberLocation()).request().get()) {
+        try (final Response res = target(getMemberLocation()).request().get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check the member resource", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertTrue(g.contains(identifier, DC.relation, rdf.createIRI(child2 + hash)),
                     "Confirm that a dc:relation triple is present");
@@ -477,15 +479,16 @@ public interface LdpIndirectContainerTests extends CommonTests {
 
     /**
      * Test with ldp:PreferMinimalContainer Prefer header.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test with ldp:PreferMinimalContainer Prefer header")
-    default void testGetEmptyMember() {
+    default void testGetEmptyMember() throws Exception {
         final RDF rdf = getInstance();
         try (final Response res = target(getMemberLocation()).request().header(PREFER,
-                    "return=representation; include=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"").get()) {
+                    "return=representation; include=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"").get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check a member resource with Prefer", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertTrue(g.contains(identifier, SKOS.prefLabel, null), "Check for a skos:prefLabel triple");
             assertFalse(g.contains(identifier, LDP.member, null), "Check for no ldp:member triple");
@@ -495,15 +498,16 @@ public interface LdpIndirectContainerTests extends CommonTests {
 
     /**
      * Test with ldp:PreferMinimalContainer Prefer header.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test with ldp:PreferMinimalContainer Prefer header")
-    default void testGetInverseEmptyMember() {
+    default void testGetInverseEmptyMember() throws Exception {
         final RDF rdf = getInstance();
         try (final Response res = target(getMemberLocation()).request().header(PREFER,
-                    "return=representation; omit=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"").get()) {
+                    "return=representation; omit=\"" + LDP.PreferMinimalContainer.getIRIString() + "\"").get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
             assertAll("Check a member resource with Prefer", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
-            final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE);
             final IRI identifier = rdf.createIRI(getMemberLocation());
             assertFalse(g.contains(identifier, SKOS.prefLabel, null), "Check for no skos:prefLabel triple");
             assertTrue(g.contains(identifier, LDP.member, null) || g.contains(identifier, DC.relation, null),

--- a/components/test/src/main/java/org/trellisldp/test/MementoBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoBinaryTests.java
@@ -37,10 +37,7 @@ import org.trellisldp.vocabulary.LDP;
 @TestInstance(PER_CLASS)
 public interface MementoBinaryTests extends MementoResourceTests {
 
-    /**
-     * Build a list of all Mementos.
-     * @return the resource mementos
-     */
+    @Override
     default Map<String, String> getMementos() {
         final Map<String, String> mementos = new HashMap<>();
         try (final Response res = target(getBinaryLocation()).request().head()) {
@@ -93,11 +90,8 @@ public interface MementoBinaryTests extends MementoResourceTests {
         });
     }
 
-    /**
-     * Test the content of a binary memento resource.
-     */
     @Test
-    @DisplayName("Test the content of memento resources")
+    @Override
     default void testMementoContent() {
         final Map<String, String> mementos = getMementos();
         final Map<String, String> responses = new HashMap<>();
@@ -115,11 +109,8 @@ public interface MementoBinaryTests extends MementoResourceTests {
         assertEquals(2L, values.size(), "Check the number of distinct Memento responses");
     }
 
-    /**
-     * Test that memento resources are also LDP resources.
-     */
     @Test
-    @DisplayName("Test that memento resources are also LDP resources")
+    @Override
     default void testMementoLdpResource() {
         getMementos().forEach((memento, date) -> {
             try (final Response res = target(memento).request().head()) {

--- a/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
@@ -151,47 +151,49 @@ public interface MementoResourceTests extends MementoCommonTests {
 
     /**
      * Test the content of memento resources.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test the content of memento resources")
-    default void testMementoContent() {
+    default void testMementoContent() throws Exception {
         final RDF rdf = getInstance();
-        final Dataset dataset = rdf.createDataset();
-        final Map<String, String> mementos = getMementos();
-        mementos.forEach((memento, date) -> {
-            try (final Response res = target(memento).request().get()) {
-                assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful request");
-                readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE).stream().forEach(triple ->
-                        dataset.add(rdf.createIRI(memento), triple.getSubject(), triple.getPredicate(),
-                            triple.getObject()));
-            }
-        });
+        try (final Dataset dataset = rdf.createDataset()) {
+            final Map<String, String> mementos = getMementos();
+            mementos.forEach((memento, date) -> {
+                try (final Response res = target(memento).request().get()) {
+                    assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful request");
+                    readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE).stream().forEach(triple ->
+                            dataset.add(rdf.createIRI(memento), triple.getSubject(), triple.getPredicate(),
+                                triple.getObject()));
+                }
+            });
 
-        final IRI subject = rdf.createIRI(getResourceLocation());
-        final List<IRI> urls = mementos.keySet().stream().sorted().map(rdf::createIRI).collect(toList());
-        assertEquals(2L, urls.size(), "Check that two mementos were found");
-        assertTrue(dataset.getGraph(urls.get(0)).isPresent(), "Check that the first graph is present");
-        dataset.getGraph(urls.get(0)).ifPresent(g -> {
-            assertTrue(g.contains(subject, type, SKOS.Concept), "Check for a skos:Concept type");
-            assertTrue(g.contains(subject, SKOS.prefLabel, rdf.createLiteral("Resource Name", "eng")),
-                    "Check for a skos:prefLabel property");
-            assertTrue(g.contains(subject, DC.subject, rdf.createIRI("http://example.org/subject/1")),
-                    "Check for a dc:subject property");
-            assertEquals(3L, g.size(), "Check for three triples");
-        });
+            final IRI subject = rdf.createIRI(getResourceLocation());
+            final List<IRI> urls = mementos.keySet().stream().sorted().map(rdf::createIRI).collect(toList());
+            assertEquals(2L, urls.size(), "Check that two mementos were found");
+            assertTrue(dataset.getGraph(urls.get(0)).isPresent(), "Check that the first graph is present");
+            dataset.getGraph(urls.get(0)).ifPresent(g -> {
+                assertTrue(g.contains(subject, type, SKOS.Concept), "Check for a skos:Concept type");
+                assertTrue(g.contains(subject, SKOS.prefLabel, rdf.createLiteral("Resource Name", "eng")),
+                        "Check for a skos:prefLabel property");
+                assertTrue(g.contains(subject, DC.subject, rdf.createIRI("http://example.org/subject/1")),
+                        "Check for a dc:subject property");
+                assertEquals(3L, g.size(), "Check for three triples");
+            });
 
-        assertTrue(dataset.getGraph(urls.get(1)).isPresent(), "Check that the last graph is present");
-        dataset.getGraph(urls.get(1)).ifPresent(g -> {
-            assertTrue(g.contains(subject, type, SKOS.Concept), "Check for a skos:Concept type");
-            assertTrue(g.contains(subject, SKOS.prefLabel, rdf.createLiteral("Resource Name", "eng")),
-                    "Check for a skos:prefLabel property");
-            assertTrue(g.contains(subject, DC.subject, rdf.createIRI("http://example.org/subject/1")),
-                    "Check for a dc:subject property");
-            assertTrue(g.contains(subject, DC.title, rdf.createLiteral("Title")),
-                    "Check for a dc:title property");
-            assertTrue(g.contains(subject, DC.alternative, rdf.createLiteral("Alternative Title")),
-                    "Check for a dc:alternative property");
-            assertEquals(5L, g.size(), "Check for five triples");
-        });
+            assertTrue(dataset.getGraph(urls.get(1)).isPresent(), "Check that the last graph is present");
+            dataset.getGraph(urls.get(1)).ifPresent(g -> {
+                assertTrue(g.contains(subject, type, SKOS.Concept), "Check for a skos:Concept type");
+                assertTrue(g.contains(subject, SKOS.prefLabel, rdf.createLiteral("Resource Name", "eng")),
+                        "Check for a skos:prefLabel property");
+                assertTrue(g.contains(subject, DC.subject, rdf.createIRI("http://example.org/subject/1")),
+                        "Check for a dc:subject property");
+                assertTrue(g.contains(subject, DC.title, rdf.createLiteral("Title")),
+                        "Check for a dc:title property");
+                assertTrue(g.contains(subject, DC.alternative, rdf.createLiteral("Alternative Title")),
+                        "Check for a dc:alternative property");
+                assertEquals(5L, g.size(), "Check for five triples");
+            });
+        }
     }
 }

--- a/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
@@ -77,278 +77,296 @@ public interface ResourceServiceTests {
 
     /**
      * Test creating a resource.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test creating resource")
-    default void testCreateResource() {
+    default void testCreateResource() throws Exception {
         final RDF rdf = getInstance();
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
-        final Dataset dataset = buildDataset(identifier, "Creation Test", SUBJECT1);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check for no pre-existing LDP-RS");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
-                .toCompletableFuture().join(), "Check that the resource was successfully created");
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check resource stream", res.stream(Trellis.PreferUserManaged)
-                .map(q -> () -> assertTrue(dataset.contains(q), "Verify that the quad is from the dataset: " + q)));
+        try (final Dataset dataset = buildDataset(identifier, "Creation Test", SUBJECT1)) {
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check for no pre-existing LDP-RS");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
+                    .toCompletableFuture().join(), "Check that the resource was successfully created");
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check resource stream", res.stream(Trellis.PreferUserManaged)
+                    .map(q -> () -> assertTrue(dataset.contains(q), "Verify that the quad is from the dataset: " + q)));
+        }
     }
 
     /**
      * Test replacing a resource.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test replacing resource")
-    default void testReplaceResource() {
+    default void testReplaceResource() throws Exception {
         final RDF rdf = getInstance();
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
-        final Dataset dataset = buildDataset(identifier, "Replacement Test", SUBJECT2);
+        try (final Dataset dataset = buildDataset(identifier, "Replacement Test", SUBJECT2)) {
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check for no pre-existing LDP-RS");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
+                    .toCompletableFuture().join(), "Check that the LDP-RS was successfully created");
 
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check for no pre-existing LDP-RS");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
-                .toCompletableFuture().join(), "Check that the LDP-RS was successfully created");
+            dataset.clear();
+            dataset.add(Trellis.PreferUserManaged, identifier, SKOS.prefLabel, rdf.createLiteral("preferred label"));
+            dataset.add(Trellis.PreferUserManaged, identifier, SKOS.altLabel, rdf.createLiteral("alternate label"));
+            dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
 
-        dataset.clear();
-        dataset.add(Trellis.PreferUserManaged, identifier, SKOS.prefLabel, rdf.createLiteral("preferred label"));
-        dataset.add(Trellis.PreferUserManaged, identifier, SKOS.altLabel, rdf.createLiteral("alternate label"));
-        dataset.add(Trellis.PreferUserManaged, identifier, type, SKOS.Concept);
-
-        assertDoesNotThrow(() -> getResourceService().replace(Metadata.builder(identifier)
-                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
-                .toCompletableFuture().join(), "Check that the LDP-RS was successfully replaced");
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check the replaced LDP-RS stream", res.stream(Trellis.PreferUserManaged)
+            assertDoesNotThrow(() -> getResourceService().replace(Metadata.builder(identifier)
+                        .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
+                    .toCompletableFuture().join(), "Check that the LDP-RS was successfully replaced");
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check the replaced LDP-RS stream", res.stream(Trellis.PreferUserManaged)
                 .map(q -> () -> assertTrue(dataset.contains(q), "Check that the quad comes from the dataset: " + q)));
-        assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the total user-managed triple count");
+            assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(),
+                    "Check the total user-managed triple count");
+        }
     }
 
     /**
      * Test deleting a resource.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test deleting resource")
-    default void testDeleteResource() {
+    default void testDeleteResource() throws Exception {
         final RDF rdf = getInstance();
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
-        final Dataset dataset = buildDataset(identifier, "Deletion Test", SUBJECT1);
+        try (final Dataset dataset = buildDataset(identifier, "Deletion Test", SUBJECT1)) {
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check that the resource doesn't exist");
 
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check that the resource doesn't exist");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                                .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
+                    .toCompletableFuture().join(), "Check that the resource was successfully created");
+            assertNotEquals(DELETED_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check that the resource isn't currently 'deleted'");
 
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                            .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
-                .toCompletableFuture().join(), "Check that the resource was successfully created");
-        assertNotEquals(DELETED_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check that the resource isn't currently 'deleted'");
-
-        assertDoesNotThrow(() -> getResourceService().delete(Metadata.builder(identifier)
+            assertDoesNotThrow(() -> getResourceService().delete(Metadata.builder(identifier)
                     .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build()).toCompletableFuture().join(),
-                "Check that the delete operation succeeded");
-        final Resource resource = getResourceService().get(identifier).toCompletableFuture().join();
-        assertTrue(DELETED_RESOURCE.equals(resource) || MISSING_RESOURCE.equals(resource),
-                        "Verify that the resource is marked as deleted or missing");
+                    "Check that the delete operation succeeded");
+            final Resource resource = getResourceService().get(identifier).toCompletableFuture().join();
+            assertTrue(DELETED_RESOURCE.equals(resource) || MISSING_RESOURCE.equals(resource),
+                            "Verify that the resource is marked as deleted or missing");
+        }
     }
 
     /**
      * Test adding immutable data.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test adding immutable data")
-    default void testAddImmutableData() {
+    default void testAddImmutableData() throws Exception {
         final RDF rdf = getInstance();
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
-        final Dataset dataset0 = buildDataset(identifier, "Immutable Resource Test", SUBJECT2);
+        try (final Dataset dataset0 = buildDataset(identifier, "Immutable Resource Test", SUBJECT2);
+             final Dataset dataset1 = rdf.createDataset(); final Dataset dataset2 = rdf.createDataset();
+             final Dataset combined = rdf.createDataset()) {
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset0)
+                    .toCompletableFuture().join(), "Check the successful creation of an LDP-RS");
 
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset0)
-                .toCompletableFuture().join(), "Check the successful creation of an LDP-RS");
+            final IRI audit1 = rdf.createIRI(TRELLIS_BNODE_PREFIX + getResourceService().generateIdentifier());
+            dataset1.add(Trellis.PreferAudit, identifier, PROV.wasGeneratedBy, audit1);
+            dataset1.add(Trellis.PreferAudit, audit1, type, PROV.Activity);
+            dataset1.add(Trellis.PreferAudit, audit1, type, AS.Create);
+            dataset1.add(Trellis.PreferAudit, audit1, PROV.atTime, rdf.createLiteral(now().toString(), XSD.dateTime));
 
-        final IRI audit1 = rdf.createIRI(TRELLIS_BNODE_PREFIX + getResourceService().generateIdentifier());
-        final Dataset dataset1 = rdf.createDataset();
-        dataset1.add(Trellis.PreferAudit, identifier, PROV.wasGeneratedBy, audit1);
-        dataset1.add(Trellis.PreferAudit, audit1, type, PROV.Activity);
-        dataset1.add(Trellis.PreferAudit, audit1, type, AS.Create);
-        dataset1.add(Trellis.PreferAudit, audit1, PROV.atTime, rdf.createLiteral(now().toString(), XSD.dateTime));
+            assertDoesNotThrow(() -> getResourceService().add(identifier, dataset1).toCompletableFuture().join(),
+                    "Check the successful addition of audit quads");
 
-        assertDoesNotThrow(() -> getResourceService().add(identifier, dataset1).toCompletableFuture().join(),
-                "Check the successful addition of audit quads");
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check the audit stream", res.stream(Trellis.PreferAudit)
+                    .map(q -> () -> assertTrue(dataset1.contains(q), "Check that the audit stream includes: " + q)));
+            assertEquals(4L, res.stream(Trellis.PreferAudit).count(), "Check the audit triple count");
 
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check the audit stream", res.stream(Trellis.PreferAudit)
-                .map(q -> () -> assertTrue(dataset1.contains(q), "Check that the audit stream includes: " + q)));
-        assertEquals(4L, res.stream(Trellis.PreferAudit).count(), "Check the audit triple count");
+            final IRI audit2 = rdf.createIRI(TRELLIS_BNODE_PREFIX + getResourceService().generateIdentifier());
+            dataset2.add(Trellis.PreferAudit, identifier, PROV.wasGeneratedBy, audit2);
+            dataset2.add(Trellis.PreferAudit, audit2, type, PROV.Activity);
+            dataset2.add(Trellis.PreferAudit, audit2, type, AS.Update);
+            dataset2.add(Trellis.PreferAudit, audit2, PROV.atTime, rdf.createLiteral(now().toString(), XSD.dateTime));
 
-        final IRI audit2 = rdf.createIRI(TRELLIS_BNODE_PREFIX + getResourceService().generateIdentifier());
-        final Dataset dataset2 = rdf.createDataset();
-        dataset2.add(Trellis.PreferAudit, identifier, PROV.wasGeneratedBy, audit2);
-        dataset2.add(Trellis.PreferAudit, audit2, type, PROV.Activity);
-        dataset2.add(Trellis.PreferAudit, audit2, type, AS.Update);
-        dataset2.add(Trellis.PreferAudit, audit2, PROV.atTime, rdf.createLiteral(now().toString(), XSD.dateTime));
+            assertDoesNotThrow(() -> getResourceService().add(identifier, dataset2).toCompletableFuture().join(),
+                    "Check that audit triples are added successfully");
 
-        assertDoesNotThrow(() -> getResourceService().add(identifier, dataset2).toCompletableFuture().join(),
-                "Check that audit triples are added successfully");
+            final Resource res2 = getResourceService().get(identifier).toCompletableFuture().join();
 
-        final Resource res2 = getResourceService().get(identifier).toCompletableFuture().join();
+            dataset1.stream().forEach(combined::add);
+            dataset2.stream().forEach(combined::add);
 
-        final Dataset combined = rdf.createDataset();
-        dataset1.stream().forEach(combined::add);
-        dataset2.stream().forEach(combined::add);
-
-        assertAll("Check the audit stream", res2.stream(Trellis.PreferAudit)
-                .map(q -> () -> assertTrue(combined.contains(q), "Check that the audit stream includes: " + q)));
-        assertEquals(8L, res2.stream(Trellis.PreferAudit).count(), "Check the audit triple count");
+            assertAll("Check the audit stream", res2.stream(Trellis.PreferAudit)
+                    .map(q -> () -> assertTrue(combined.contains(q), "Check that the audit stream includes: " + q)));
+            assertEquals(8L, res2.stream(Trellis.PreferAudit).count(), "Check the audit triple count");
+        }
     }
 
     /**
      * Test an LDP:RDFSource.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test LDP-RS")
-    default void testLdpRs() {
+    default void testLdpRs() throws Exception {
         final Instant time = now();
         final RDF rdf = getInstance();
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
-        final Dataset dataset = buildDataset(identifier, "Create LDP-RS Test", SUBJECT1);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check for no pre-existing LDP-RS");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
-                .toCompletableFuture().join(), "Check the creation of an LDP-RS");
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check the LDP-RS resource", checkResource(res, identifier, LDP.RDFSource, time, dataset));
-        assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user triple count");
+        try (final Dataset dataset = buildDataset(identifier, "Create LDP-RS Test", SUBJECT1)) {
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check for no pre-existing LDP-RS");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .interactionModel(LDP.RDFSource).container(ROOT_CONTAINER).build(), dataset)
+                    .toCompletableFuture().join(), "Check the creation of an LDP-RS");
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check the LDP-RS resource", checkResource(res, identifier, LDP.RDFSource, time, dataset));
+            assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user triple count");
+        }
     }
 
     /**
      * Test an LDP:NonRDFSource.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test LDP-NR")
-    default void testLdpNr() {
+    default void testLdpNr() throws Exception {
         final Instant time = now();
         final RDF rdf = getInstance();
         final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier());
-        final Dataset dataset = buildDataset(identifier, "Create LDP-NR Test", SUBJECT2);
+        try (final Dataset dataset = buildDataset(identifier, "Create LDP-NR Test", SUBJECT2)) {
+            final IRI binaryLocation = rdf.createIRI("binary:location/" + getResourceService().generateIdentifier());
+            final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType("text/plain").build();
 
-        final IRI binaryLocation = rdf.createIRI("binary:location/" + getResourceService().generateIdentifier());
-        final BinaryMetadata binary = BinaryMetadata.builder(binaryLocation).mimeType("text/plain").build();
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check for no pre-existing LDP-NR");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .interactionModel(LDP.NonRDFSource).container(ROOT_CONTAINER).binary(binary).build(), dataset)
-                .toCompletableFuture().join(), "Check the creation of an LDP-NR");
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check the LDP-NR resource", checkResource(res, identifier, LDP.NonRDFSource, time, dataset));
-        assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed count of the LDP-NR");
-        res.getBinaryMetadata().ifPresent(b -> {
-            assertEquals(binaryLocation, b.getIdentifier(), "Check the binary identifier");
-            assertEquals(of("text/plain"), b.getMimeType(), "Check the binary mimeType");
-        });
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check for no pre-existing LDP-NR");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .interactionModel(LDP.NonRDFSource).container(ROOT_CONTAINER).binary(binary).build(), dataset)
+                    .toCompletableFuture().join(), "Check the creation of an LDP-NR");
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check the LDP-NR resource", checkResource(res, identifier, LDP.NonRDFSource, time, dataset));
+            assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(),
+                    "Check the user-managed count of the LDP-NR");
+            res.getBinaryMetadata().ifPresent(b -> {
+                assertEquals(binaryLocation, b.getIdentifier(), "Check the binary identifier");
+                assertEquals(of("text/plain"), b.getMimeType(), "Check the binary mimeType");
+            });
+        }
     }
 
     /**
      * Test an LDP:Container.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test LDP-C")
-    default void testLdpC() {
+    default void testLdpC() throws Exception {
         final Instant time = now();
         final RDF rdf = getInstance();
         final String base = TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier();
         final IRI identifier = rdf.createIRI(base);
-        final Dataset dataset0 = buildDataset(identifier, "Container Test", SUBJECT0);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check for no pre-existing LDP-C");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .interactionModel(LDP.Container).container(ROOT_CONTAINER).build(), dataset0)
-                .toCompletableFuture().join(), "Check that the LDP-C is created successfully");
-
         final IRI child1 = rdf.createIRI(base + "/child01");
-        final Dataset dataset1 = buildDataset(child1, "Contained Child 1", SUBJECT1);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(child1).toCompletableFuture().join(),
-                "Check for no child1 resource");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1).interactionModel(LDP.RDFSource)
-                    .container(identifier).build(), dataset1).toCompletableFuture().join(),
-                "Check that the first child was successfully created in the LDP-C");
-
         final IRI child2 = rdf.createIRI(base + "/child02");
-        final Dataset dataset2 = buildDataset(child2, "Contained Child2", SUBJECT2);
 
-        assertEquals(MISSING_RESOURCE, getResourceService().get(child2).toCompletableFuture().join(),
-                "Check for no child2 resource");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2).interactionModel(LDP.RDFSource)
-                    .container(identifier).build(), dataset2).toCompletableFuture().join(),
-                "Check that the second child was successfully created in the LDP-C");
+        try (final Dataset dataset0 = buildDataset(identifier, "Container Test", SUBJECT0);
+             final Dataset dataset1 = buildDataset(child1, "Contained Child 1", SUBJECT1);
+             final Dataset dataset2 = buildDataset(child2, "Contained Child2", SUBJECT2);
+             final Graph graph = rdf.createGraph()) {
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check for no pre-existing LDP-C");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .interactionModel(LDP.Container).container(ROOT_CONTAINER).build(), dataset0)
+                    .toCompletableFuture().join(), "Check that the LDP-C is created successfully");
 
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check the LDP-C resource", checkResource(res, identifier, LDP.Container, time, dataset0));
-        assertEquals(2L, res.stream(LDP.PreferContainment).count(), "Check the containment triple count");
-        final Graph graph = rdf.createGraph();
-        res.stream(LDP.PreferContainment).map(Quad::asTriple).forEach(graph::add);
-        assertTrue(graph.contains(identifier, LDP.contains, child1), "Check that child1 is contained in the LDP-C");
-        assertTrue(graph.contains(identifier, LDP.contains, child2), "Check that child2 is contained in the LDP-C");
-        assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed triple count");
+
+            assertEquals(MISSING_RESOURCE, getResourceService().get(child1).toCompletableFuture().join(),
+                    "Check for no child1 resource");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1)
+                        .interactionModel(LDP.RDFSource)
+                        .container(identifier).build(), dataset1).toCompletableFuture().join(),
+                    "Check that the first child was successfully created in the LDP-C");
+
+
+            assertEquals(MISSING_RESOURCE, getResourceService().get(child2).toCompletableFuture().join(),
+                    "Check for no child2 resource");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2)
+                        .interactionModel(LDP.RDFSource)
+                        .container(identifier).build(), dataset2).toCompletableFuture().join(),
+                    "Check that the second child was successfully created in the LDP-C");
+
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check the LDP-C resource", checkResource(res, identifier, LDP.Container, time, dataset0));
+            assertEquals(2L, res.stream(LDP.PreferContainment).count(), "Check the containment triple count");
+            res.stream(LDP.PreferContainment).map(Quad::asTriple).forEach(graph::add);
+            assertTrue(graph.contains(identifier, LDP.contains, child1), "Check that child1 is contained in the LDP-C");
+            assertTrue(graph.contains(identifier, LDP.contains, child2), "Check that child2 is contained in the LDP-C");
+            assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed triple count");
+        }
     }
 
     /**
      * Test an LDP:BasicContainer.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test LDP-BC")
-    default void testLdpBC() {
+    default void testLdpBC() throws Exception {
         final Instant time = now();
         final RDF rdf = getInstance();
         final String base = TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier();
         final IRI identifier = rdf.createIRI(base);
-        final Dataset dataset0 = buildDataset(identifier, "Basic Container Test", SUBJECT0);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check for a pre-existing LDP-BC");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .interactionModel(LDP.BasicContainer).container(ROOT_CONTAINER).build(), dataset0)
-                .toCompletableFuture().join(), "Check that creating an LDP-BC succeeds");
-
         final IRI child1 = rdf.createIRI(base + "/child11");
-        final Dataset dataset1 = buildDataset(child1, "Contained Child 1", SUBJECT1);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(child1).toCompletableFuture().join(),
-                "Check for no child1 resource");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1).interactionModel(LDP.RDFSource)
-                .container(identifier).build(), dataset1).toCompletableFuture().join(), "Check that child1 is created");
-
         final IRI child2 = rdf.createIRI(base + "/child12");
-        final Dataset dataset2 = buildDataset(child2, "Contained Child2", SUBJECT2);
 
-        assertEquals(MISSING_RESOURCE, getResourceService().get(child2).toCompletableFuture().join(),
-                "Check for no child2 resource");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2).interactionModel(LDP.RDFSource)
-                    .container(identifier).build(), dataset2).toCompletableFuture().join(),
-                "Check that child2 is created");
+        try (final Dataset dataset0 = buildDataset(identifier, "Basic Container Test", SUBJECT0);
+             final Dataset dataset1 = buildDataset(child1, "Contained Child 1", SUBJECT1);
+             final Dataset dataset2 = buildDataset(child2, "Contained Child2", SUBJECT2);
+             final Graph graph = rdf.createGraph()) {
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check for a pre-existing LDP-BC");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .interactionModel(LDP.BasicContainer).container(ROOT_CONTAINER).build(), dataset0)
+                    .toCompletableFuture().join(), "Check that creating an LDP-BC succeeds");
 
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check the LDP-BC resource", checkResource(res, identifier, LDP.BasicContainer, time, dataset0));
-        assertEquals(2L, res.stream(LDP.PreferContainment).count(), "Check the containment triple count");
-        final Graph graph = rdf.createGraph();
-        res.stream(LDP.PreferContainment).map(Quad::asTriple).forEach(graph::add);
-        assertTrue(graph.contains(identifier, LDP.contains, child1), "Check that child1 is contained in the LDP-BC");
-        assertTrue(graph.contains(identifier, LDP.contains, child2), "Check that child2 is contained in the LDP-BC");
-        assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed triple count");
-        assertEquals(0L, res.stream(LDP.PreferMembership).count(), "Check for an absence of membership triples");
+
+            assertEquals(MISSING_RESOURCE, getResourceService().get(child1).toCompletableFuture().join(),
+                    "Check for no child1 resource");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1)
+                        .interactionModel(LDP.RDFSource).container(identifier).build(), dataset1)
+                    .toCompletableFuture().join(), "Check that child1 is created");
+
+
+            assertEquals(MISSING_RESOURCE, getResourceService().get(child2).toCompletableFuture().join(),
+                    "Check for no child2 resource");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2)
+                        .interactionModel(LDP.RDFSource).container(identifier).build(), dataset2)
+                    .toCompletableFuture().join(), "Check that child2 is created");
+
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check the LDP-BC resource", checkResource(res, identifier, LDP.BasicContainer, time, dataset0));
+            assertEquals(2L, res.stream(LDP.PreferContainment).count(), "Check the containment triple count");
+
+            res.stream(LDP.PreferContainment).map(Quad::asTriple).forEach(graph::add);
+            assertTrue(graph.contains(identifier, LDP.contains, child1),
+                    "Check that child1 is contained in the LDP-BC");
+            assertTrue(graph.contains(identifier, LDP.contains, child2),
+                    "Check that child2 is contained in the LDP-BC");
+            assertEquals(3L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed triple count");
+            assertEquals(0L, res.stream(LDP.PreferMembership).count(), "Check for an absence of membership triples");
+         }
     }
 
     /**
      * Test an LDP:DirectContainer.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test LDP-DC")
-    default void testLdpDC() {
+    default void testLdpDC() throws Exception {
         // Only test DC if the backend supports it
         assumeTrue(getResourceService().supportedInteractionModels().contains(LDP.DirectContainer));
 
@@ -357,56 +375,62 @@ public interface ResourceServiceTests {
         final String base = TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier();
         final IRI identifier = rdf.createIRI(base);
         final IRI member = rdf.createIRI(base + "/member");
-        final Dataset dataset0 = buildDataset(identifier, "Direct Container Test", SUBJECT0);
-        dataset0.add(Trellis.PreferUserManaged, identifier, LDP.membershipResource, member);
-        dataset0.add(Trellis.PreferUserManaged, identifier, LDP.isMemberOfRelation, DC.isPartOf);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check that the DC doesn't exist");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .membershipResource(member).memberOfRelation(DC.isPartOf)
-                    .interactionModel(LDP.DirectContainer).container(ROOT_CONTAINER).build(), dataset0)
-                .toCompletableFuture().join(), "Check that creating the LDP-DC succeeds");
-
         final IRI child1 = rdf.createIRI(base + "/child1");
-        final Dataset dataset1 = buildDataset(child1, "Child 1", SUBJECT1);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(child1).toCompletableFuture().join(),
-                "Check that no child resource exists");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1).interactionModel(LDP.RDFSource)
-                    .container(identifier).build(), dataset1).toCompletableFuture().join(),
-                "Check that the child resource is successfully created");
-
         final IRI child2 = rdf.createIRI(base + "/child2");
-        final Dataset dataset2 = buildDataset(child2, "Child 2", SUBJECT2);
 
-        assertEquals(MISSING_RESOURCE, getResourceService().get(child2).toCompletableFuture().join(),
-                "Check that no child2 resource exists");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2).interactionModel(LDP.RDFSource)
-                    .container(identifier).build(), dataset2).toCompletableFuture().join(),
-                "Check that the child2 resource is successfully created");
+        try (final Dataset dataset0 = buildDataset(identifier, "Direct Container Test", SUBJECT0);
+             final Dataset dataset1 = buildDataset(child1, "Child 1", SUBJECT1);
+             final Dataset dataset2 = buildDataset(child2, "Child 2", SUBJECT2);
+             final Graph graph = rdf.createGraph()) {
+            dataset0.add(Trellis.PreferUserManaged, identifier, LDP.membershipResource, member);
+            dataset0.add(Trellis.PreferUserManaged, identifier, LDP.isMemberOfRelation, DC.isPartOf);
 
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check the resource", checkResource(res, identifier, LDP.DirectContainer, time, dataset0));
-        assertEquals(of(member), res.getMembershipResource(), "Check for ldp:membershipResource");
-        assertEquals(of(DC.isPartOf), res.getMemberOfRelation(), "Check for ldp:isMemberOfRelation");
-        assertFalse(res.getMemberRelation().isPresent(), "Check for no ldp:hasMemberRelation");
-        assertFalse(res.getInsertedContentRelation().filter(isEqual(LDP.MemberSubject).negate()).isPresent(),
-                "Check for no ldp:InsertedContentRelation, excepting ldp:MemberSubject");
-        assertEquals(2L, res.stream(LDP.PreferContainment).count(), "Check the containment count");
-        final Graph graph = rdf.createGraph();
-        res.stream(LDP.PreferContainment).map(Quad::asTriple).forEach(graph::add);
-        assertTrue(graph.contains(identifier, LDP.contains, child1), "Check that child1 is contained in the LDP-DC");
-        assertTrue(graph.contains(identifier, LDP.contains, child2), "Check that child2 is contained in the LDP-DC");
-        assertEquals(5L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed triple count");
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check that the DC doesn't exist");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .membershipResource(member).memberOfRelation(DC.isPartOf)
+                        .interactionModel(LDP.DirectContainer).container(ROOT_CONTAINER).build(), dataset0)
+                    .toCompletableFuture().join(), "Check that creating the LDP-DC succeeds");
+
+
+            assertEquals(MISSING_RESOURCE, getResourceService().get(child1).toCompletableFuture().join(),
+                    "Check that no child resource exists");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1)
+                        .interactionModel(LDP.RDFSource).container(identifier).build(), dataset1)
+                    .toCompletableFuture().join(), "Check that the child resource is successfully created");
+
+
+            assertEquals(MISSING_RESOURCE, getResourceService().get(child2).toCompletableFuture().join(),
+                    "Check that no child2 resource exists");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2)
+                        .interactionModel(LDP.RDFSource).container(identifier).build(), dataset2)
+                    .toCompletableFuture().join(), "Check that the child2 resource is successfully created");
+
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check the resource", checkResource(res, identifier, LDP.DirectContainer, time, dataset0));
+            assertEquals(of(member), res.getMembershipResource(), "Check for ldp:membershipResource");
+            assertEquals(of(DC.isPartOf), res.getMemberOfRelation(), "Check for ldp:isMemberOfRelation");
+            assertFalse(res.getMemberRelation().isPresent(), "Check for no ldp:hasMemberRelation");
+            assertFalse(res.getInsertedContentRelation().filter(isEqual(LDP.MemberSubject).negate()).isPresent(),
+                    "Check for no ldp:InsertedContentRelation, excepting ldp:MemberSubject");
+            assertEquals(2L, res.stream(LDP.PreferContainment).count(), "Check the containment count");
+
+            res.stream(LDP.PreferContainment).map(Quad::asTriple).forEach(graph::add);
+            assertTrue(graph.contains(identifier, LDP.contains, child1),
+                    "Check that child1 is contained in the LDP-DC");
+            assertTrue(graph.contains(identifier, LDP.contains, child2),
+                    "Check that child2 is contained in the LDP-DC");
+            assertEquals(5L, res.stream(Trellis.PreferUserManaged).count(), "Check the user-managed triple count");
+        }
     }
 
     /**
      * Test an LDP:IndirectContainer.
+     * @throws Exception if the RDF resources did not exit cleanly
      */
     @Test
     @DisplayName("Test LDP-IC")
-    default void testLdpIC() {
+    default void testLdpIC() throws Exception {
         // Only execute this test if the backend supports it
         assumeTrue(getResourceService().supportedInteractionModels().contains(LDP.IndirectContainer));
 
@@ -415,48 +439,53 @@ public interface ResourceServiceTests {
         final String base = TRELLIS_DATA_PREFIX + getResourceService().generateIdentifier();
         final IRI identifier = rdf.createIRI(base);
         final IRI member = rdf.createIRI(base + "/member");
-        final Dataset dataset0 = buildDataset(identifier, "Indirect Container Test", SUBJECT0);
-        dataset0.add(Trellis.PreferUserManaged, identifier, LDP.membershipResource, member);
-        dataset0.add(Trellis.PreferUserManaged, identifier, LDP.hasMemberRelation, DC.relation);
-        dataset0.add(Trellis.PreferUserManaged, identifier, LDP.insertedContentRelation, FOAF.primaryTopic);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
-                "Check for a missing resource");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
-                    .membershipResource(member).memberRelation(DC.relation).insertedContentRelation(FOAF.primaryTopic)
-                    .interactionModel(LDP.IndirectContainer).container(ROOT_CONTAINER).build(), dataset0)
-                .toCompletableFuture().join(), "Check that creating a resource succeeds");
-
         final IRI child1 = rdf.createIRI(base + "/child1");
-        final Dataset dataset1 = buildDataset(child1, "Indirect Container Child 1", SUBJECT1);
-
-        assertEquals(MISSING_RESOURCE, getResourceService().get(child1).toCompletableFuture().join(),
-                "Check that the child resource doesn't exist");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1).interactionModel(LDP.RDFSource)
-                    .container(identifier).build(), dataset1).toCompletableFuture().join(),
-                "Check that creating a child resource succeeds");
-
         final IRI child2 = rdf.createIRI(base + "/child2");
-        final Dataset dataset2 = buildDataset(child2, "Indirect Container Child 2", SUBJECT2);
 
-        assertEquals(MISSING_RESOURCE, getResourceService().get(child2).toCompletableFuture().join(),
-                "Check that the child resource doesn't exist");
-        assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2).interactionModel(LDP.RDFSource)
-                    .container(identifier).build(), dataset2).toCompletableFuture().join(),
-                "Check that creating the child resource succeeds");
+        try (final Dataset dataset0 = buildDataset(identifier, "Indirect Container Test", SUBJECT0);
+             final Dataset dataset1 = buildDataset(child1, "Indirect Container Child 1", SUBJECT1);
+             final Dataset dataset2 = buildDataset(child2, "Indirect Container Child 2", SUBJECT2);
+             final Graph graph = rdf.createGraph()) {
+            dataset0.add(Trellis.PreferUserManaged, identifier, LDP.membershipResource, member);
+            dataset0.add(Trellis.PreferUserManaged, identifier, LDP.hasMemberRelation, DC.relation);
+            dataset0.add(Trellis.PreferUserManaged, identifier, LDP.insertedContentRelation, FOAF.primaryTopic);
 
-        final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
-        assertAll("Check the resource", checkResource(res, identifier, LDP.IndirectContainer, time, dataset0));
-        assertEquals(of(member), res.getMembershipResource(), "Check for ldp:membershipResource");
-        assertEquals(of(DC.relation), res.getMemberRelation(), "Check for ldp:hasMemberRelation");
-        assertEquals(of(FOAF.primaryTopic), res.getInsertedContentRelation(), "Check for ldp:insertedContentRelation");
-        assertFalse(res.getMemberOfRelation().isPresent(), "Check for no ldp:isMemberOfRelation");
-        assertEquals(2L, res.stream(LDP.PreferContainment).count(), "Check the containment triple count");
-        final Graph graph = rdf.createGraph();
-        res.stream(LDP.PreferContainment).map(Quad::asTriple).forEach(graph::add);
-        assertTrue(graph.contains(identifier, LDP.contains, child1), "Check that child1 is contained in the LDP-IC");
-        assertTrue(graph.contains(identifier, LDP.contains, child2), "Check that child2 is contained in the LDP-IC");
-        assertEquals(6L, res.stream(Trellis.PreferUserManaged).count(), "Check the total triple count");
+            assertEquals(MISSING_RESOURCE, getResourceService().get(identifier).toCompletableFuture().join(),
+                    "Check for a missing resource");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(identifier)
+                        .membershipResource(member).memberRelation(DC.relation)
+                        .insertedContentRelation(FOAF.primaryTopic)
+                        .interactionModel(LDP.IndirectContainer).container(ROOT_CONTAINER).build(), dataset0)
+                    .toCompletableFuture().join(), "Check that creating a resource succeeds");
+
+            assertEquals(MISSING_RESOURCE, getResourceService().get(child1).toCompletableFuture().join(),
+                    "Check that the child resource doesn't exist");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child1)
+                        .interactionModel(LDP.RDFSource).container(identifier).build(), dataset1)
+                    .toCompletableFuture().join(), "Check that creating a child resource succeeds");
+
+            assertEquals(MISSING_RESOURCE, getResourceService().get(child2).toCompletableFuture().join(),
+                    "Check that the child resource doesn't exist");
+            assertDoesNotThrow(() -> getResourceService().create(Metadata.builder(child2)
+                        .interactionModel(LDP.RDFSource).container(identifier).build(), dataset2)
+                    .toCompletableFuture().join(), "Check that creating the child resource succeeds");
+
+            final Resource res = getResourceService().get(identifier).toCompletableFuture().join();
+            assertAll("Check the resource", checkResource(res, identifier, LDP.IndirectContainer, time, dataset0));
+            assertEquals(of(member), res.getMembershipResource(), "Check for ldp:membershipResource");
+            assertEquals(of(DC.relation), res.getMemberRelation(), "Check for ldp:hasMemberRelation");
+            assertEquals(of(FOAF.primaryTopic), res.getInsertedContentRelation(),
+                    "Check for ldp:insertedContentRelation");
+            assertFalse(res.getMemberOfRelation().isPresent(), "Check for no ldp:isMemberOfRelation");
+            assertEquals(2L, res.stream(LDP.PreferContainment).count(), "Check the containment triple count");
+
+            res.stream(LDP.PreferContainment).map(Quad::asTriple).forEach(graph::add);
+            assertTrue(graph.contains(identifier, LDP.contains, child1),
+                    "Check that child1 is contained in the LDP-IC");
+            assertTrue(graph.contains(identifier, LDP.contains, child2),
+                    "Check that child2 is contained in the LDP-IC");
+            assertEquals(6L, res.stream(Trellis.PreferUserManaged).count(), "Check the total triple count");
+        }
     }
 
     /**


### PR DESCRIPTION
Most of the Graph and Dataset objects in the trellis-test codebase are
not closed. This updates those tests to close the resources.