### PR TITLE
Address PMD warnings in test code for core components

### DIFF
--- a/core/api/src/test/java/org/trellisldp/api/DefaultIdentifierServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/DefaultIdentifierServiceTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
  */
 class DefaultIdentifierServiceTest {
 
+    private static final String WRONG_PREFIX = "Generated id has wrong prefix!";
+
     @Test
     void testSupplier() {
         final String prefix = "trellis:data/";
@@ -31,8 +33,8 @@ class DefaultIdentifierServiceTest {
         final String id1 = supplier.get();
         final String id2 = supplier.get();
 
-        assertTrue(id1.startsWith(prefix), "Generated id has wrong prefix!");
-        assertTrue(id2.startsWith(prefix), "Generated id has wrong prefix!");
+        assertTrue(id1.startsWith(prefix), WRONG_PREFIX);
+        assertTrue(id2.startsWith(prefix), WRONG_PREFIX);
         assertNotEquals(id1, id2, "Generated ids shouldn't match!");
     }
 
@@ -46,9 +48,9 @@ class DefaultIdentifierServiceTest {
         final String id1 = gen1.get();
         final String id2 = gen2.get();
 
-        assertTrue(id1.startsWith(prefix1), "Generated id has wrong prefix!");
+        assertTrue(id1.startsWith(prefix1), WRONG_PREFIX);
         assertNotEquals(prefix1, id1, "Generated id shouldn't equal prefix!");
-        assertTrue(id2.startsWith(prefix2), "Generated id has wrong prefix!");
+        assertTrue(id2.startsWith(prefix2), WRONG_PREFIX);
         assertNotEquals(prefix2, id2, "Generated id shouldn't equal prefix!");
     }
 

--- a/core/api/src/test/java/org/trellisldp/api/NoopEventSerializationServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopEventSerializationServiceTest.java
@@ -38,7 +38,6 @@ class NoopEventSerializationServiceTest {
         when(event.getTypes()).thenReturn(emptyList());
         when(event.getIdentifier()).thenReturn(rdf.createIRI(identifier));
         final EventSerializationService svc = new NoopEventSerializationService();
-        System.out.println(svc.serialize(event));
         assertEquals("{\n  \"@context\": \"https://www.w3.org/ns/activitystreams\",\n" +
                 "  \"id\": \"" + identifier + "\"\n}", svc.serialize(event));
     }

--- a/core/api/src/test/java/org/trellisldp/api/NoopResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopResourceServiceTest.java
@@ -37,10 +37,11 @@ class NoopResourceServiceTest {
     }
 
     @Test
-    void testReplaceResource() {
+    void testReplaceResource() throws Exception {
         final Metadata metadata = Metadata.builder(identifier).interactionModel(LDP.RDFSource).build();
-        final Dataset dataset = rdf.createDataset();
-        assertDoesNotThrow(() -> testService.replace(metadata, dataset).toCompletableFuture().join());
+        try (final Dataset dataset = rdf.createDataset()) {
+            assertDoesNotThrow(() -> testService.replace(metadata, dataset).toCompletableFuture().join());
+        }
     }
 
     @Test
@@ -50,9 +51,10 @@ class NoopResourceServiceTest {
     }
 
     @Test
-    void testAddResource() {
-        final Dataset dataset = rdf.createDataset();
-        assertDoesNotThrow(() -> testService.add(identifier, dataset).toCompletableFuture().join());
+    void testAddResource() throws Exception {
+        try (final Dataset dataset = rdf.createDataset()) {
+            assertDoesNotThrow(() -> testService.add(identifier, dataset).toCompletableFuture().join());
+        }
     }
 
     @Test

--- a/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -81,15 +81,16 @@ class ResourceServiceTest {
     }
 
     @Test
-    void testDefaultCreate() {
+    void testDefaultCreate() throws Exception {
         final IRI root = rdf.createIRI("trellis:data/");
-        final Dataset dataset = rdf.createDataset();
         final Metadata metadata = Metadata.builder(existing).container(root).interactionModel(LDP.RDFSource).build();
 
-        when(mockResourceService.replace(eq(metadata), eq(dataset))).thenReturn(completedFuture(null));
+        try (final Dataset dataset = rdf.createDataset()) {
+            when(mockResourceService.replace(eq(metadata), eq(dataset))).thenReturn(completedFuture(null));
 
-        assertDoesNotThrow(() -> mockResourceService.create(metadata, dataset).toCompletableFuture().join());
-        verify(mockResourceService).replace(eq(metadata), eq(dataset));
+            assertDoesNotThrow(() -> mockResourceService.create(metadata, dataset).toCompletableFuture().join());
+            verify(mockResourceService).replace(eq(metadata), eq(dataset));
+        }
     }
 
     @Test

--- a/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
@@ -45,28 +45,28 @@ class TrellisUtilsTest {
     }
 
     @Test
-    void testCollectGraph() {
-        final Graph graph = generate(() -> rdf.createTriple(getIRI(), getIRI(), getIRI()))
-            .parallel().limit(size).collect(toGraph());
-
-        assertTrue(size >= graph.size(), "Generated graph has too many triples!");
+    void testCollectGraph() throws Exception {
+        try (final Graph graph = generate(() -> rdf.createTriple(getIRI(), getIRI(), getIRI()))
+                .parallel().limit(size).collect(toGraph())) {
+            assertTrue(size >= graph.size(), "Generated graph has too many triples!");
+        }
     }
 
     @Test
-    void testCollectDataset() {
-        final Dataset dataset = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
-            .parallel().limit(size).collect(toDataset());
-
-        assertTrue(size >= dataset.size(), "Generated dataset has too many triples!");
+    void testCollectDataset() throws Exception {
+        try (final Dataset dataset = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
+                .parallel().limit(size).collect(toDataset())) {
+            assertTrue(size >= dataset.size(), "Generated dataset has too many triples!");
+        }
     }
 
     @Test
-    void testDatasetCollectorFinisher() {
-        final Dataset dataset = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
-            .parallel().limit(size).collect(toDataset());
-
-        final TrellisUtils.DatasetCollector collector = toDataset();
-        assertEquals(dataset, collector.finisher().apply(dataset), "Dataset finisher returns the wrong object!");
+    void testDatasetCollectorFinisher() throws Exception {
+        try (final Dataset dataset = generate(() -> rdf.createQuad(getIRI(), getIRI(), getIRI(), getIRI()))
+                .parallel().limit(size).collect(toDataset())) {
+            final TrellisUtils.DatasetCollector collector = toDataset();
+            assertEquals(dataset, collector.finisher().apply(dataset), "Dataset finisher returns the wrong object!");
+        }
     }
 
     private IRI getIRI() {

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
@@ -35,7 +35,6 @@ class TrellisHttpResourceAdminTest extends AbstractTrellisHttpResourceTest {
         initMocks(this);
 
         final String baseUri = getBaseUri().toString();
-        final String origin = baseUri.substring(0, baseUri.length() - 1);
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler, baseUri));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
@@ -39,9 +39,6 @@ class TrellisHttpResourceBaseUrlTest extends AbstractTrellisHttpResourceTest {
         // Junit runner doesn't seem to work very well with JerseyTest
         initMocks(this);
 
-        final String baseUri = getBaseUri().toString();
-        final String origin = baseUri.substring(0, baseUri.length() - 1);
-
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler, URL));
         config.register(new TestAuthenticationFilter("testUser", "group"));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
@@ -36,7 +36,6 @@ class TrellisHttpResourceNoAgentTest extends AbstractTrellisHttpResourceTest {
         initMocks(this);
 
         final String baseUri = getBaseUri().toString();
-        final String origin = baseUri.substring(0, baseUri.length() - 1);
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler, baseUri));

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -81,11 +81,7 @@ class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
 
         initMocks(this);
 
-        final String baseUri = getBaseUri().toString();
-        final String origin = baseUri.substring(0, baseUri.length() - 1);
-
         final ResourceConfig config = new ResourceConfig();
-
         config.register(new TrellisHttpResource(mockBundler, null));
         config.register(new CacheControlFilter());
         config.register(new WebSubHeaderFilter(HUB));
@@ -111,10 +107,11 @@ class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
         matcher.getResourceHeaders(mockResponse, mockRequest, mockUriInfo, mockHttpHeaders);
         verify(mockResponse).resume(captor.capture());
 
-        final Response res = captor.getValue();
-        assertTrue(getLinks(res).stream().anyMatch(l ->
-                    l.getRel().equals("self") && l.getUri().toString().startsWith("http://my.example.com/")),
-                "Missing rel=self header with correct prefix!");
+        try (final Response res = captor.getValue()) {
+            assertTrue(getLinks(res).stream().anyMatch(l ->
+                        l.getRel().equals("self") && l.getUri().toString().startsWith("http://my.example.com/")),
+                    "Missing rel=self header with correct prefix!");
+        }
     }
 
     @Test

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUserTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUserTest.java
@@ -30,9 +30,6 @@ class TrellisHttpResourceUserTest extends AbstractTrellisHttpResourceTest {
         // Junit runner doesn't seem to work very well with JerseyTest
         initMocks(this);
 
-        final String baseUri = getBaseUri().toString();
-        final String origin = baseUri.substring(0, baseUri.length() - 1);
-
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler));
         config.register(new TestAuthenticationFilter("testUser", "group"));

--- a/core/http/src/test/java/org/trellisldp/http/core/PreferTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/PreferTest.java
@@ -15,6 +15,7 @@ package org.trellisldp.http.core;
 
 import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.trellisldp.http.core.Prefer.*;
 
 import java.util.stream.Stream;
 
@@ -25,6 +26,14 @@ import org.junit.jupiter.api.function.Executable;
  * @author acoburn
  */
 class PreferTest {
+
+    private static final String CHECK_ASYNC = "Check respond async";
+    private static final String CHECK_HANDLING = "Check handling";
+    private static final String CHECK_NO_OMIT = "Check for no omits";
+    private static final String CHECK_NO_INCLUDE = "Check for no includes";
+    private static final String CHECK_PREF_TYPE = "Check preference type";
+    private static final String CHECK_SIMPLE_PARSING = "Check simple Prefer parsing";
+    private static final String URL = "http://example.org/test";
 
     @Test
     void testPreferNullValues() {
@@ -39,35 +48,35 @@ class PreferTest {
     @Test
     void testPrefer1() {
         final Prefer prefer = Prefer.valueOf("return=representation; include=\"http://example.org/test\"");
-        assertAll("Check simple Prefer parsing", checkPreferInclude(prefer, "http://example.org/test"));
+        assertAll(CHECK_SIMPLE_PARSING, checkPreferInclude(prefer, URL));
     }
 
     @Test
     void testPrefer1b() {
-        final Prefer prefer = Prefer.ofInclude("http://example.org/test");
-        assertAll("Check simple Prefer parsing", checkPreferInclude(prefer, "http://example.org/test"));
+        final Prefer prefer = Prefer.ofInclude(URL);
+        assertAll(CHECK_SIMPLE_PARSING, checkPreferInclude(prefer, URL));
     }
 
     @Test
     void testPrefer1c() {
         final Prefer prefer = Prefer.valueOf("return=representation; include=http://example.org/test");
-        assertAll("Check simple Prefer parsing", checkPreferInclude(prefer, "http://example.org/test"));
+        assertAll(CHECK_SIMPLE_PARSING, checkPreferInclude(prefer, URL));
     }
 
     @Test
     void testPrefer2() {
         final Prefer prefer = Prefer.valueOf("return  =  representation;   include =  \"http://example.org/test\"");
-        assertAll("Check simple Prefer parsing", checkPreferInclude(prefer, "http://example.org/test"));
+        assertAll(CHECK_SIMPLE_PARSING, checkPreferInclude(prefer, URL));
     }
 
     @Test
     void testPrefer3() {
         final Prefer prefer = Prefer.valueOf("return=minimal");
-        assertEquals(of("minimal"), prefer.getPreference(), "Check preference value");
+        assertEquals(of(PREFER_MINIMAL), prefer.getPreference(), CHECK_PREF_TYPE);
         assertTrue(prefer.getInclude().isEmpty(), "Check that there are no includes");
         assertTrue(prefer.getOmit().isEmpty(), "Check omits count is zero");
-        assertFalse(prefer.getHandling().isPresent(), "Check handling");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
@@ -75,109 +84,109 @@ class PreferTest {
         final Prefer prefer = Prefer.valueOf("return=other");
         assertTrue(prefer.getInclude().isEmpty(), "Check includes is empty");
         assertTrue(prefer.getOmit().isEmpty(), "Check omits is empty");
-        assertFalse(prefer.getPreference().isPresent(), "Check preference type");
-        assertFalse(prefer.getHandling().isPresent(), "Check handling type");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertFalse(prefer.getPreference().isPresent(), CHECK_PREF_TYPE);
+        assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
     void testPrefer5() {
         final Prefer prefer = Prefer.valueOf("return=representation; omit=\"http://example.org/test\"");
-        assertEquals(of("representation"), prefer.getPreference(), "Check preference value");
-        assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
+        assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
+        assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertFalse(prefer.getOmit().isEmpty(), "Check for omits");
-        assertTrue(prefer.getOmit().contains("http://example.org/test"), "Check omit value");
-        assertFalse(prefer.getHandling().isPresent(), "Check handling");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertTrue(prefer.getOmit().contains(URL), "Check omit value");
+        assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
     void testPrefer5b() {
-        final Prefer prefer = Prefer.ofOmit("http://example.org/test");
-        assertEquals(of("representation"), prefer.getPreference(), "Check preference value");
-        assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
+        final Prefer prefer = Prefer.ofOmit(URL);
+        assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
+        assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
         assertFalse(prefer.getOmit().isEmpty(), "Check for omit values");
-        assertTrue(prefer.getOmit().contains("http://example.org/test"), "Check omit value");
-        assertFalse(prefer.getHandling().isPresent(), "Check handling");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertTrue(prefer.getOmit().contains(URL), "Check omit value");
+        assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
     void testPrefer6() {
         final Prefer prefer = Prefer.valueOf("handling=lenient; return=minimal");
-        assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
-        assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
-        assertEquals(of("minimal"), prefer.getPreference(), "Check preference value");
-        assertEquals(of("lenient"), prefer.getHandling(), "Check handling value");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
+        assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
+        assertEquals(of(PREFER_MINIMAL), prefer.getPreference(), CHECK_PREF_TYPE);
+        assertEquals(of(PREFER_LENIENT), prefer.getHandling(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
     void testPrefer7() {
         final Prefer prefer = Prefer.valueOf("respond-async; random-param");
-        assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
-        assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
-        assertFalse(prefer.getPreference().isPresent(), "Check preference type");
-        assertFalse(prefer.getHandling().isPresent(), "Check handling value");
-        assertTrue(prefer.getRespondAsync(), "Check respond async");
+        assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
+        assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
+        assertFalse(prefer.getPreference().isPresent(), CHECK_PREF_TYPE);
+        assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING);
+        assertTrue(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
     void testPrefer8() {
         final Prefer prefer = Prefer.valueOf("handling=strict; return=minimal");
-        assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
-        assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
-        assertEquals(of("minimal"), prefer.getPreference(), "Check preference value");
-        assertEquals(of("strict"), prefer.getHandling(), "Check handling value");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
+        assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
+        assertEquals(of(PREFER_MINIMAL), prefer.getPreference(), CHECK_PREF_TYPE);
+        assertEquals(of(PREFER_STRICT), prefer.getHandling(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
     void testPrefer9() {
         final Prefer prefer = Prefer.valueOf("handling=blah; return=minimal");
-        assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
-        assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
-        assertEquals(of("minimal"), prefer.getPreference(), "Check preference type");
-        assertFalse(prefer.getHandling().isPresent(), "Check handling");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
+        assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
+        assertEquals(of(PREFER_MINIMAL), prefer.getPreference(), CHECK_PREF_TYPE);
+        assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
     void testStaticInclude() {
         final Prefer prefer = Prefer.ofInclude();
-        assertEquals(of("representation"), prefer.getPreference(), "Check preference type");
-        assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
-        assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
+        assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
+        assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
+        assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
     }
 
     @Test
     void testStaticOmit() {
         final Prefer prefer = Prefer.ofOmit();
-        assertEquals(of("representation"), prefer.getPreference(), "Check preference type");
-        assertTrue(prefer.getInclude().isEmpty(), "Check for no includes");
-        assertTrue(prefer.getOmit().isEmpty(), "Check for no omits");
+        assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
+        assertTrue(prefer.getInclude().isEmpty(), CHECK_NO_INCLUDE);
+        assertTrue(prefer.getOmit().isEmpty(), CHECK_NO_OMIT);
     }
 
     @Test
     void testPreferBadQuotes() {
         final Prefer prefer = Prefer.valueOf("return=representation; include=\"http://example.org/test");
-        assertEquals(of("representation"), prefer.getPreference(), "Check preference type");
+        assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
         assertEquals(1L, prefer.getInclude().size(), "Check includes count");
         assertTrue(prefer.getInclude().contains("\"http://example.org/test"));
         assertTrue(prefer.getOmit().isEmpty(), "Check omits count is zero");
-        assertFalse(prefer.getHandling().isPresent(), "Check handling");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
     void testPreferBadQuotes2() {
         final Prefer prefer = Prefer.valueOf("return=representation; include=\"");
-        assertEquals(of("representation"), prefer.getPreference(), "Check preference type");
+        assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE);
         assertEquals(1L, prefer.getInclude().size(), "Check for includes size");
         assertTrue(prefer.getInclude().contains("\""), "Check for weird quote in includes");
         assertTrue(prefer.getOmit().isEmpty(), "Check omits count is zero");
-        assertFalse(prefer.getHandling().isPresent(), "Check handling");
-        assertFalse(prefer.getRespondAsync(), "Check respond async");
+        assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING);
+        assertFalse(prefer.getRespondAsync(), CHECK_ASYNC);
     }
 
     @Test
@@ -187,11 +196,11 @@ class PreferTest {
 
     private Stream<Executable> checkPreferInclude(final Prefer prefer, final String url) {
         return Stream.of(
-                () -> assertEquals(of("representation"), prefer.getPreference(), "Check preference"),
+                () -> assertEquals(of(PREFER_REPRESENTATION), prefer.getPreference(), CHECK_PREF_TYPE),
                 () -> assertEquals(1L, prefer.getInclude().size(), "Check includes count"),
                 () -> assertTrue(prefer.getInclude().contains(url), "Check includes value"),
                 () -> assertTrue(prefer.getOmit().isEmpty(), "Check omits count"),
-                () -> assertFalse(prefer.getHandling().isPresent(), "Check handling"),
-                () -> assertFalse(prefer.getRespondAsync(), "Check respond async"));
+                () -> assertFalse(prefer.getHandling().isPresent(), CHECK_HANDLING),
+                () -> assertFalse(prefer.getRespondAsync(), CHECK_ASYNC));
     }
 }

--- a/core/http/src/test/java/org/trellisldp/http/core/SlugTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/SlugTest.java
@@ -22,10 +22,14 @@ import org.junit.jupiter.api.Test;
  */
 class SlugTest {
 
+    private static final String SLUG_VALUE = "slugValue";
+    private static final String SLUG_UNDERSCORE_VALUE = "slug_value";
+    private static final String CHECK_SLUG_VALUE = "Check slug value";
+
     @Test
     void testSlug() {
-        final Slug slug = Slug.valueOf("slugValue");
-        assertEquals("slugValue", slug.getValue(), "Check slug value");
+        final Slug slug = Slug.valueOf(SLUG_VALUE);
+        assertEquals(SLUG_VALUE, slug.getValue(), CHECK_SLUG_VALUE);
     }
 
     @Test
@@ -37,31 +41,31 @@ class SlugTest {
     @Test
     void testSpaceNormalization() {
         final Slug slug = Slug.valueOf("slug  value");
-        assertEquals("slug_value", slug.getValue(), "Check slug value");
+        assertEquals(SLUG_UNDERSCORE_VALUE, slug.getValue(), CHECK_SLUG_VALUE);
     }
 
     @Test
     void testSlashNormalization() {
         final Slug slug = Slug.valueOf("slug/value");
-        assertEquals("slug_value", slug.getValue(), "Check slug value");
+        assertEquals(SLUG_UNDERSCORE_VALUE, slug.getValue(), CHECK_SLUG_VALUE);
     }
 
     @Test
     void testSpaceSlashNormalization() {
         final Slug slug = Slug.valueOf("slug\t/ value");
-        assertEquals("slug_value", slug.getValue(), "Check slug value");
+        assertEquals(SLUG_UNDERSCORE_VALUE, slug.getValue(), CHECK_SLUG_VALUE);
     }
 
     @Test
     void testHashUri() {
         final Slug slug = Slug.valueOf("slugValue#foo");
-        assertEquals("slugValue", slug.getValue(), "Check slug value");
+        assertEquals(SLUG_VALUE, slug.getValue(), CHECK_SLUG_VALUE);
     }
 
     @Test
     void testQueryParam() {
         final Slug slug = Slug.valueOf("slugValue?bar=baz");
-        assertEquals("slugValue", slug.getValue(), "Check slug value");
+        assertEquals(SLUG_VALUE, slug.getValue(), CHECK_SLUG_VALUE);
     }
 
     @Test

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -97,12 +97,19 @@ import org.trellisldp.vocabulary.LDP;
 /**
  * Base class for the HTTP handler tests.
  */
-abstract class BaseTestHandler {
+class BaseTestHandler {
+
+    static final String ERR_RESPONSE_CODE = "Incorrect response code!";
+    static final String CHECK_LINK_TYPES = "Check LDP type link headers";
+    static final String RESOURCE_SIMPLE = "/simpleData.txt";
+    static final String RESOURCE_TURTLE = "/simpleTriple.ttl";
+    static final String RESOURCE_EMPTY = "/emptyData.txt";
+    static final String RESOURCE_NAME = "resource";
 
     static final String baseUrl = "http://example.org/";
     static final RDF rdf = getInstance();
     static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
-    static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
+    static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_NAME);
     static final Instant time = ofEpochSecond(1496262729);
 
     private static final Set<IRI> allInteractionModels = new HashSet<>(asList(LDP.Resource, LDP.RDFSource,

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -45,9 +45,10 @@ class DeleteHandlerTest extends BaseTestHandler {
     @Test
     void testDelete() {
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, null);
-        final Response res = handler.deleteResource(handler.initialize(mockParent, mockResource))
-            .toCompletableFuture().join().build();
-        assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect delete response!");
+        try (final Response res = handler.deleteResource(handler.initialize(mockParent, mockResource))
+                .toCompletableFuture().join().build()) {
+            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
+        }
     }
 
     @Test
@@ -78,12 +79,13 @@ class DeleteHandlerTest extends BaseTestHandler {
     void testDeletePersistenceSupport() {
         when(mockResourceService.supportedInteractionModels()).thenReturn(emptySet());
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, baseUrl);
-        final Response res = assertThrows(WebApplicationException.class, () ->
-                handler.initialize(mockParent, mockResource)).getResponse();
-        assertTrue(res.getLinks().stream().anyMatch(link ->
-            link.getUri().toString().equals(UnsupportedInteractionModel.getIRIString()) &&
-            link.getRel().equals(LDP.constrainedBy.getIRIString())), "Missing Link headers");
-        assertEquals(TEXT_PLAIN_TYPE, res.getMediaType(), "Incorrect media type");
+        try (final Response res = assertThrows(WebApplicationException.class, () ->
+                handler.initialize(mockParent, mockResource)).getResponse()) {
+            assertTrue(res.getLinks().stream().anyMatch(link ->
+                link.getUri().toString().equals(UnsupportedInteractionModel.getIRIString()) &&
+                link.getRel().equals(LDP.constrainedBy.getIRIString())), "Missing Link headers");
+            assertEquals(TEXT_PLAIN_TYPE, res.getMediaType(), "Incorrect media type");
+        }
     }
 
     @Test

--- a/core/http/src/test/java/org/trellisldp/http/impl/MementoResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/MementoResourceTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.Test;
 
 class MementoResourceTest {
 
+    private static final String URL = "http://example.com/resource";
+
     @Test
     void testFilteredMementoLink() {
         final Link link = fromUri("http://example.com/resource/memento/1").rel(MEMENTO)
@@ -59,7 +61,7 @@ class MementoResourceTest {
 
     @Test
     void testFilteredOtherLink() {
-        final Link link = fromUri("http://example.com/resource").rel(TYPE)
+        final Link link = fromUri(URL).rel(TYPE)
             .param(FROM, ofInstant(now().minusSeconds(1000), UTC).format(RFC_1123_DATE_TIME))
             .param(UNTIL, ofInstant(now(), UTC).format(RFC_1123_DATE_TIME)).build();
         assertTrue(MementoResource.filterLinkParams(link, false).getParams().containsKey(FROM));
@@ -78,27 +80,24 @@ class MementoResourceTest {
 
     @Test
     void testMementoHeadersSingle() {
-        final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
         mementos.add(time);
 
-        final List<Link> links = MementoResource.getMementoHeaders(identifier, mementos, time).collect(toList());
+        final List<Link> links = MementoResource.getMementoHeaders(URL, mementos, time).collect(toList());
         assertEquals(2L, links.size());
         checkMementoHeaders(links, 0L, 0L, 1L);
     }
 
     @Test
     void testMementoHeadersMultipleFirst() {
-        final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
         mementos.add(time);
         mementos.add(time.plusSeconds(1L));
         mementos.add(time.plusSeconds(2L));
 
-        final List<Link> links = MementoResource.getMementoHeaders(identifier, mementos, time)
-            .collect(toList());
+        final List<Link> links = MementoResource.getMementoHeaders(URL, mementos, time).collect(toList());
         assertEquals(4L, links.size());
         checkMementoHeaders(links, 0L, 1L, 3L);
     }
@@ -106,14 +105,13 @@ class MementoResourceTest {
 
     @Test
     void testMementoHeadersMultipleMiddle() {
-        final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
         mementos.add(time);
         mementos.add(time.plusSeconds(1L));
         mementos.add(time.plusSeconds(2L));
 
-        final List<Link> links = MementoResource.getMementoHeaders(identifier, mementos, time.plusSeconds(1L))
+        final List<Link> links = MementoResource.getMementoHeaders(URL, mementos, time.plusSeconds(1L))
             .collect(toList());
         assertEquals(3L, links.size());
         checkMementoHeaders(links, 1L, 1L, 2L);
@@ -121,14 +119,13 @@ class MementoResourceTest {
 
     @Test
     void testMementoHeadersMultipleLast() {
-        final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
         mementos.add(time);
         mementos.add(time.plusSeconds(1L));
         mementos.add(time.plusSeconds(2L));
 
-        final List<Link> links = MementoResource.getMementoHeaders(identifier, mementos, time.plusSeconds(2L))
+        final List<Link> links = MementoResource.getMementoHeaders(URL, mementos, time.plusSeconds(2L))
             .collect(toList());
         assertEquals(4L, links.size());
         checkMementoHeaders(links, 1L, 0L, 3L);
@@ -136,14 +133,13 @@ class MementoResourceTest {
 
     @Test
     void testMementoHeadersMultipleBeyond() {
-        final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
         mementos.add(time);
         mementos.add(time.plusSeconds(1L));
         mementos.add(time.plusSeconds(2L));
 
-        final List<Link> links = MementoResource.getMementoHeaders(identifier, mementos, time.plusSeconds(3L))
+        final List<Link> links = MementoResource.getMementoHeaders(URL, mementos, time.plusSeconds(3L))
             .collect(toList());
         assertEquals(3L, links.size());
         checkMementoHeaders(links, 0L, 0L, 2L);
@@ -151,14 +147,13 @@ class MementoResourceTest {
 
     @Test
     void testMementoHeadersMultiplePrecede() {
-        final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
         mementos.add(time);
         mementos.add(time.plusSeconds(1L));
         mementos.add(time.plusSeconds(2L));
 
-        final List<Link> links = MementoResource.getMementoHeaders(identifier, mementos, time.minusSeconds(1L))
+        final List<Link> links = MementoResource.getMementoHeaders(URL, mementos, time.minusSeconds(1L))
             .collect(toList());
         assertEquals(3L, links.size());
         checkMementoHeaders(links, 0L, 0L, 2L);
@@ -166,19 +161,17 @@ class MementoResourceTest {
 
     @Test
     void testMementoLinksEmpty() {
-        final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
-        final List<Link> links = MementoResource.getMementoLinks(identifier, mementos).collect(toList());
+        final List<Link> links = MementoResource.getMementoLinks(URL, mementos).collect(toList());
         assertTrue(links.isEmpty());
     }
 
     @Test
     void testMementoLinksSingle() {
-        final String identifier = "http://example.com/resource";
         final SortedSet<Instant> mementos = new TreeSet<>();
         final Instant time = now();
         mementos.add(time);
-        final List<Link> links = MementoResource.getMementoLinks(identifier, mementos).collect(toList());
+        final List<Link> links = MementoResource.getMementoLinks(URL, mementos).collect(toList());
         assertEquals(3L, links.size());
         checkMementoHeaders(links, 0L, 0L, 1L);
         assertEquals(1L, links.stream().filter(l -> l.getRels().contains("timegate")).count());

--- a/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
@@ -44,17 +44,20 @@ import org.trellisldp.vocabulary.LDP;
  */
 class OptionsHandlerTest extends BaseTestHandler {
 
+    private static final String ERR_ACCEPT_PATCH = "Incorrect Accept-Patch header!";
+    private static final String CHECK_ALLOW = "Check Allow headers";
+
     @Test
     void testOptionsLdprs() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, null);
-        final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build();
-
-        assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
-        assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
-        assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header!");
-        assertAll("Check Allow headers", checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
+        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
+            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header!");
+            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
+        }
     }
 
     @Test
@@ -63,17 +66,17 @@ class OptionsHandlerTest extends BaseTestHandler {
         when(mockIoService.supportedWriteSyntaxes()).thenReturn(asList(TURTLE, JSONLD, NTRIPLES));
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, baseUrl);
-        final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build();
+        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
+            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
 
-        assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
-        assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
-
-        final String acceptPost = res.getHeaderString(ACCEPT_POST);
-        assertNotNull(acceptPost, "Missing Accept-Post header!");
-        assertTrue(acceptPost.contains(APPLICATION_LD_JSON), "JSON-LD missing from acceptable POST formats!");
-        assertTrue(acceptPost.contains(APPLICATION_N_TRIPLES), "N-Triples missing from acceptable POST formats!");
-        assertTrue(acceptPost.contains(TEXT_TURTLE.split(";")[0]), "Turtle missing from acceptable POST formats!");
-        assertAll("Check Allow headers", checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH, POST)));
+            final String acceptPost = res.getHeaderString(ACCEPT_POST);
+            assertNotNull(acceptPost, "Missing Accept-Post header!");
+            assertTrue(acceptPost.contains(APPLICATION_LD_JSON), "JSON-LD missing from acceptable POST formats!");
+            assertTrue(acceptPost.contains(APPLICATION_N_TRIPLES), "N-Triples missing from acceptable POST formats!");
+            assertTrue(acceptPost.contains(TEXT_TURTLE.split(";")[0]), "Turtle missing from acceptable POST formats!");
+            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH, POST)));
+        }
     }
 
     @Test
@@ -81,11 +84,11 @@ class OptionsHandlerTest extends BaseTestHandler {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, null);
-        final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build();
-
-        assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
-        assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
-        assertAll("Check Allow headers", checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
+        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
+            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
+        }
     }
 
     @Test
@@ -93,22 +96,22 @@ class OptionsHandlerTest extends BaseTestHandler {
         when(mockTrellisRequest.getExt()).thenReturn("acl");
 
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, false, baseUrl);
-        final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build();
-
-        assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
-        assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), "Incorrect Accept-Patch header!");
-        assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header!");
-        assertAll("Check Allow headers", checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
+        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
+            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header!");
+            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
+        }
     }
 
     @Test
     void testOptionsMemento() {
         final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, true, null);
-        final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build();
-
-        assertEquals(NO_CONTENT, res.getStatusInfo(), "Incorrect response code!");
-        assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header on Memento!");
-        assertNull(res.getHeaderString(ACCEPT_PATCH), "Unexpected Accept-Patch header on Memento!");
-        assertAll("Check Allow headers", checkAllowHeader(res, asList(GET, HEAD, OPTIONS)));
+        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
+            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
+            assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header on Memento!");
+            assertNull(res.getHeaderString(ACCEPT_PATCH), "Unexpected Accept-Patch header on Memento!");
+            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS)));
+        }
     }
 }

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/AbstractVocabularyTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/AbstractVocabularyTest.java
@@ -90,7 +90,7 @@ abstract class AbstractVocabularyTest {
 
         final Set<String> subjects = fields().map(namespace()::concat).collect(toSet());
 
-        assertTrue(subjects.size() > 0, "Unable to extract field definitions!");
+        assertFalse(subjects.isEmpty(), "Unable to extract field definitions!");
 
         graph.find(ANY, ANY, ANY).mapWith(Triple::getSubject).filterKeep(Node::isURI).mapWith(Node::getURI)
                 .filterKeep(Objects::nonNull)


### PR DESCRIPTION
There are a lot of line changes here, but it's all just reformatting test code to address PMD warnings. Primarily it consists of closing `AutoClosable` resources and factoring repeated strings into variables.

This is also just for the code in `./core`. Other components will be addressed separately. 