### PR TITLE
Add support for resource creation via PATCH

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
@@ -70,6 +70,9 @@ public final class HttpConstants {
     /** Configuration key defining whether to require precondition headers for PUT operations. */
     public static final String CONFIG_HTTP_PRECONDITION_REQUIRED = "trellis.http.precondition.required";
 
+    /** Configuration key defining whether PATCH requests can create resources. */
+    public static final String CONFIG_HTTP_PATCH_CREATE = "trellis.http.patch.create";
+
     /** Configuration key defining whether PUT-on-create generates contained or uncontained resources. */
     public static final String CONFIG_HTTP_PUT_UNCONTAINED = "trellis.http.put.uncontained";
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -142,8 +142,15 @@ public class DeleteHandler extends MutatingLdpHandler {
         // is generated.
 
         // Collect the audit data
-        getAuditUpdateData().forEachOrdered(immutable::add);
-        return handleResourceReplacement(mutable, immutable);
+        getAuditQuadData().forEachOrdered(immutable::add);
+
+        final Metadata.Builder metadata = metadataBuilder(getResource().getIdentifier(),
+                getResource().getInteractionModel(), mutable);
+        getResource().getContainer().ifPresent(metadata::container);
+        getResource().getBinaryMetadata().ifPresent(metadata::binary);
+        metadata.revision(getResource().getRevision());
+
+        return handleResourceReplacement(metadata.build(), mutable, immutable);
     }
 
     private CompletionStage<Void> handleResourceDeletion(final Dataset immutable) {

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -56,7 +56,6 @@ import static org.trellisldp.http.impl.HttpUtils.getSyntax;
 import static org.trellisldp.http.impl.HttpUtils.ldpResourceTypes;
 import static org.trellisldp.http.impl.HttpUtils.triplePreferences;
 import static org.trellisldp.http.impl.HttpUtils.unskolemizeTriples;
-import static org.trellisldp.vocabulary.Trellis.PreferAccessControl;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -145,11 +144,9 @@ public class GetHandler extends BaseLdpHandler {
                 .map(b -> b.getMimeType().orElse(APPLICATION_OCTET_STREAM)).orElse(null));
 
         final IRI ext = getExtensionGraphName();
-        if (ext != null) {
-            final boolean noAcl = PreferAccessControl.equals(ext) && !resource.hasAcl();
-            if (noAcl && !resource.stream(ext).findAny().isPresent()) {
-                throw new NotFoundException();
-            }
+        if (ext != null && !resource.stream(ext).findAny().isPresent()) {
+            LOGGER.trace("No stream for extention: {}", ext);
+            throw new NotFoundException();
         }
 
         setResource(resource);
@@ -370,7 +367,7 @@ public class GetHandler extends BaseLdpHandler {
 
     private void addLdpHeaders(final ResponseBuilder builder, final IRI model) {
         ldpResourceTypes(model).forEach(type -> {
-            builder.link(type.getIRIString(), "type");
+            builder.link(type.getIRIString(), Link.TYPE);
             // Mementos don't accept POST or PATCH
             if (LDP.Container.equals(type) && !isMemento) {
                 final List<RDFSyntax> rdfSyntaxes = getServices().getIOService().supportedWriteSyntaxes();

--- a/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
@@ -28,6 +28,8 @@ import static org.apache.commons.lang3.StringUtils.strip;
 import static org.apache.commons.rdf.api.RDFSyntax.RDFA;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
+import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 import static org.trellisldp.api.TrellisUtils.getInstance;
 import static org.trellisldp.http.core.HttpConstants.DEFAULT_REPRESENTATION;
 import static org.trellisldp.http.core.HttpConstants.PRECONDITION_REQUIRED;
@@ -62,6 +64,7 @@ import org.apache.commons.rdf.api.RDFSyntax;
 import org.apache.commons.rdf.api.Triple;
 import org.slf4j.Logger;
 import org.trellisldp.api.IOService;
+import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.http.core.Prefer;
@@ -95,10 +98,10 @@ public final class HttpUtils {
     public static Stream<IRI> ldpResourceTypes(final IRI ixnModel) {
         final Stream.Builder<IRI> supertypes = Stream.builder();
         if (ixnModel != null) {
-            LOGGER.debug("Finding types that subsume {}", ixnModel.getIRIString());
+            LOGGER.trace("Finding types that subsume {}", ixnModel.getIRIString());
             supertypes.accept(ixnModel);
             final IRI superClass = LDP.getSuperclassOf(ixnModel);
-            LOGGER.debug("... including {}", superClass);
+            LOGGER.trace("... including {}", superClass);
             ldpResourceTypes(superClass).forEach(supertypes);
         }
         return supertypes.build();
@@ -368,6 +371,15 @@ public final class HttpUtils {
         if (required && ifMatch == null && ifUnmodifiedSince == null) {
             throw new ClientErrorException(status(PRECONDITION_REQUIRED).build());
         }
+    }
+
+    /**
+     * Check whether a resource exists.
+     * @param resource the resource
+     * @return true if the resource isn't missing or deleted; false otherwise
+     */
+    public static boolean exists(final Resource resource) {
+        return !DELETED_RESOURCE.equals(resource) && !MISSING_RESOURCE.equals(resource);
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/impl/OptionsHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/OptionsHandler.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
 import org.apache.commons.rdf.api.IRI;
@@ -108,7 +109,7 @@ public class OptionsHandler extends BaseLdpHandler {
         LOGGER.debug("OPTIONS request for {}", getIdentifier());
 
         ldpResourceTypes(getResource().getInteractionModel())
-            .forEach(type -> builder.link(type.getIRIString(), "type"));
+            .forEach(type -> builder.link(type.getIRIString(), Link.TYPE));
 
         if (hasDescription()) {
             builder.link(getDescription(), "describedby");

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -749,7 +749,8 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     void testGetBinaryAcl() {
-        when(mockBinaryResource.hasAcl()).thenReturn(true);
+        when(mockBinaryResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
+                    rdf.createQuad(PreferAccessControl, binaryIdentifier, ACL.mode, ACL.Read)));
         try (final Response res = target(BINARY_PATH).queryParam(EXT, ACL_PARAM).request().get()) {
             assertEquals(SC_OK, res.getStatus(), ERR_RESPONSE_CODE);
             assertFalse(getLinks(res).stream().anyMatch(l -> l.getRel().equals(DESCRIBES)),
@@ -792,7 +793,8 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     void testGetAclJsonCompact() throws IOException {
-        when(mockResource.hasAcl()).thenReturn(true);
+        when(mockResource.stream(eq(PreferAccessControl))).thenAnswer(inv -> Stream.of(
+                    rdf.createQuad(PreferAccessControl, binaryIdentifier, ACL.mode, ACL.Read)));
         try (final Response res = target(RESOURCE_PATH).queryParam(EXT, ACL_PARAM).request()
                 .accept(COMPACT_JSONLD).get()) {
             assertEquals(SC_OK, res.getStatus(), ERR_RESPONSE_CODE);
@@ -2131,7 +2133,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     void testPatchMissing() {
         try (final Response res = target(NON_EXISTENT_PATH).request()
                 .method(PATCH, entity(INSERT_TITLE, APPLICATION_SPARQL_UPDATE))) {
-            assertEquals(SC_NOT_FOUND, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(SC_CREATED, res.getStatus(), ERR_RESPONSE_CODE);
         }
     }
 
@@ -2139,7 +2141,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     void testPatchGone() {
         try (final Response res = target(DELETED_PATH).request()
                 .method(PATCH, entity(INSERT_TITLE, APPLICATION_SPARQL_UPDATE))) {
-            assertEquals(SC_GONE, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(SC_CREATED, res.getStatus(), ERR_RESPONSE_CODE);
         }
     }
 
@@ -2229,7 +2231,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         when(mockMementoService.get(eq(identifier), eq(MAX))).thenAnswer(inv -> completedFuture(MISSING_RESOURCE));
         try (final Response res = target(RESOURCE_PATH + TEST_PATH).request()
                 .method(PATCH, entity(INSERT_TITLE, APPLICATION_SPARQL_UPDATE))) {
-            assertEquals(SC_NOT_FOUND, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(SC_CREATED, res.getStatus(), ERR_RESPONSE_CODE);
             assertNull(res.getHeaderString(MEMENTO_DATETIME), ERR_MEMENTO_DATETIME);
         }
     }

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -93,6 +93,7 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     static final String NEW_RESOURCE = RESOURCE_PATH + "/newresource";
     static final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + RESOURCE_PATH);
     static final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
+    static final IRI binaryIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + BINARY_PATH);
     static final IRI binaryInternalIdentifier = rdf.createIRI("file:///some/file");
     static final IRI newresourceIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + NEW_RESOURCE);
     static final IRI childIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + CHILD_PATH);
@@ -106,7 +107,6 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
     private static final IRI userDeletedIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + USER_DELETED_PATH);
     private static final Set<IRI> allInteractionModels = new HashSet<>(asList(LDP.Resource, LDP.RDFSource,
             LDP.NonRDFSource, LDP.Container, LDP.BasicContainer, LDP.DirectContainer, LDP.IndirectContainer));
-    private static final IRI binaryIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + BINARY_PATH);
     private static final IRI nonexistentIdentifier = rdf.createIRI(TRELLIS_DATA_PREFIX + NON_EXISTENT_PATH);
     private static final String BASE_URL = "http://example.org/";
     private static final BinaryMetadata testBinary = BinaryMetadata.builder(binaryInternalIdentifier)

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -44,6 +44,7 @@ import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
 import static org.apache.commons.rdf.api.RDFSyntax.RDFA;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.trellisldp.api.Syntax.LD_PATCH;
 import static org.trellisldp.http.core.HttpConstants.ACCEPT_DATETIME;
@@ -80,9 +81,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.http.core.Prefer;
+import org.trellisldp.vocabulary.ACL;
 import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.OA;
 import org.trellisldp.vocabulary.SKOS;
+import org.trellisldp.vocabulary.Trellis;
 
 /**
  * @author acoburn
@@ -389,7 +392,8 @@ class GetHandlerTest extends BaseTestHandler {
     @Test
     void testGetAcl() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
-        when(mockResource.hasAcl()).thenReturn(true);
+        when(mockResource.stream(eq(Trellis.PreferAccessControl))).thenAnswer(inv -> Stream.of(
+                    rdf.createQuad(Trellis.PreferAccessControl, identifier, ACL.mode, ACL.Read)));
         when(mockTrellisRequest.getExt()).thenReturn("acl");
 
         final GetConfiguration config = new GetConfiguration(false, true, true, null, baseUrl);


### PR DESCRIPTION
Resolves #564

This feature is enabled by default, but it can be disabled by setting the `trellis.http.patch.create` property to `false`.