### PR TITLE
Add Docker configuration for quarkus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,9 @@ jobs:
       env: JOB=docker
       before_script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       # Note: for maintenance branches, remove the dockerPushLatest task
-      script: if [[ $(./gradlew -q getVersion) == *SNAPSHOT* ]]; then ./gradlew dockerPush dockerPushDevelop; else ./gradlew dockerPush dockerPushLatest; fi
+      script:
+          - if [[ $(./gradlew -q getVersion) == *SNAPSHOT* ]]; then ./gradlew dockerPush dockerPushDevelop; else ./gradlew dockerPush dockerPushLatest; fi
+          - ./buildtools/src/main/resources/docker/publishToDockerHub.sh
 
     # deploy to AWS
     - name: "Publish JavaDocs"

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,6 @@ ext {
         'trellis-karaf',
         'trellis-openliberty',
         'trellis-osgi',
-        'trellis-quarkus',
         'trellis-server',
         'trellis-test'
     ]

--- a/buildtools/src/main/resources/docker/publishToDockerHub.sh
+++ b/buildtools/src/main/resources/docker/publishToDockerHub.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+IMAGE=trellisldp/trellis-triplestore
+
+VERSION=$(./gradlew -q getVersion)
+BRANCH=$(git branch 2>/dev/null | sed -n -e 's/^\* \(.*\)/\1/p')
+
+cd platform/quarkus
+../../gradlew assemble
+
+TAG=latest
+# Use the develop tag for snapshots
+if [[ $VERSION == *SNAPSHOT* ]]; then
+    TAG=develop
+fi
+
+# Don't use latest/develop tags for maintenance branches
+if [[ $BRANCH == *.x ]]; then
+    docker build -f src/main/docker/Dockerfile.jvm -t "$IMAGE:$VERSION" .
+else
+    docker build -f src/main/docker/Dockerfile.jvm -t "$IMAGE:$TAG" -t "$IMAGE:$VERSION" .
+fi
+
+docker push $IMAGE

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -14,7 +14,6 @@ def installForQuarkus = [
     "trellis-file",
     "trellis-http",
     "trellis-io-jena",
-    "trellis-namespaces",
     "trellis-rdfa",
     "trellis-reactive",
     "trellis-triplestore",
@@ -36,7 +35,6 @@ dependencies {
     implementation "org.trellisldp:trellis-file:${project.version}"
     implementation "org.trellisldp:trellis-http:${project.version}"
     implementation "org.trellisldp:trellis-io-jena:${project.version}"
-    implementation "org.trellisldp:trellis-namespaces:${project.version}"
     implementation "org.trellisldp:trellis-rdfa:${project.version}"
     implementation "org.trellisldp:trellis-reactive:${project.version}"
     implementation "org.trellisldp:trellis-triplestore:${project.version}"
@@ -48,10 +46,18 @@ dependencies {
     implementation 'io.quarkus:quarkus-security'
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-smallrye-metrics'
+    implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
 
     implementation "com.github.spullara.mustache.java:compiler:$mustacheVersion"
     implementation "com.google.guava:guava:$guavaVersion"
+    implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
+    implementation("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
+    implementation("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
+    implementation "org.apache.jena:jena-arq:$jenaVersion"
+    implementation "org.apache.jena:jena-rdfconnection:$jenaVersion"
+    implementation "org.apache.jena:jena-tdb2:$jenaVersion"
+
 
     runtime "jakarta.activation:jakarta.activation-api:$activationApiVersion"
     runtime "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
@@ -64,15 +70,15 @@ test {
     systemProperty 'com.arjuna.ats.arjuna.objectstore.objectStoreDir', "$buildDir/data/ObjectStore"
     systemProperty 'trellis.file.binary.basepath', "$buildDir/data/binaries"
     systemProperty 'trellis.file.memento.basepath', "$buildDir/data/mementos"
-    systemProperty 'trellis.namespaces.path', "$buildDir/resources/test/namespaces.json"
+    systemProperty 'trellis.triplestore.rdf.location', "$buildDir/data/rdf"
+    systemProperty 'trellis.namespace.prefixes', 'dc11=http://purl.org/dc/elements/1.1/,,foo= , =bar,baz, = '
 }
 
 sonarqube {
     skipProject = true
 }
 
-// This requires Graal-VM to be installed
-buildNative.enabled = project.hasProperty("hasGraalVm")
+buildNative.enabled = false
 
 rootProject.childProjects.each { n, p ->
     if (installForQuarkus.contains(p.name)) {

--- a/platform/quarkus/src/main/docker/Dockerfile.jvm
+++ b/platform/quarkus/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the docker image run:
+#
+# ./gradlew assemble
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t trellisldp/trellis-triplestore .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 trellisldp/trellis-triplestore
+#
+###
+FROM fabric8/java-alpine-openjdk8-jre
+LABEL maintainer="Aaron Coburn <acoburn@apache.org>"
+
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
+
+COPY build/lib/* /deployments/lib/
+COPY build/*-runner.jar /deployments/app.jar
+
+ENTRYPOINT [ "/deployments/run-java.sh" ]
+

--- a/platform/quarkus/src/main/java/org/trellisldp/quarkus/SimpleNamespaceService.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/quarkus/SimpleNamespaceService.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.quarkus;
+
+import static java.util.Arrays.stream;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toMap;
+import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.trellisldp.api.NamespaceService;
+import org.trellisldp.vocabulary.ACL;
+import org.trellisldp.vocabulary.AS;
+import org.trellisldp.vocabulary.DC;
+import org.trellisldp.vocabulary.FOAF;
+import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.RDF;
+import org.trellisldp.vocabulary.RDFS;
+import org.trellisldp.vocabulary.SKOS;
+import org.trellisldp.vocabulary.VCARD;
+import org.trellisldp.vocabulary.XSD;
+
+/**
+ * A simple, in-memory namespace service.
+ *
+ * <p>This service will load some standard namespaces/prefixes and read
+ * system properties into the namespace maping if they are defined like so:
+ * "trellis.ns-myprefix=http://example.com/namespace"
+ */
+@ApplicationScoped
+public class SimpleNamespaceService implements NamespaceService {
+
+    public static final String CONFIG_NAMESPACE_PREFIXES = "trellis.namespace.prefixes";
+
+    private final Map<String, String> namespaces = new HashMap<>();
+
+    /**
+     * Create a simple, in-memory namespace service.
+     */
+    public SimpleNamespaceService() {
+        namespaces.put("ldp", LDP.getNamespace());
+        namespaces.put("acl", ACL.getNamespace());
+        namespaces.put("as", AS.getNamespace());
+        namespaces.put("dc", DC.getNamespace());
+        namespaces.put("rdf", RDF.getNamespace());
+        namespaces.put("rdfs", RDFS.getNamespace());
+        namespaces.put("skos", SKOS.getNamespace());
+        namespaces.put("xsd", XSD.getNamespace());
+        namespaces.put("foaf", FOAF.getNamespace());
+        namespaces.put("vcard", VCARD.getNamespace());
+        getConfig().getOptionalValue(CONFIG_NAMESPACE_PREFIXES, String.class).map(SimpleNamespaceService::configToMap)
+            .ifPresent(data -> data.forEach(namespaces::put));
+    }
+
+    @Override
+    public Map<String, String> getNamespaces() {
+        return unmodifiableMap(namespaces);
+    }
+
+    @Override
+    public boolean setPrefix(final String prefix, final String namespace) {
+        return true;
+    }
+
+    static Map<String, String> configToMap(final String config) {
+        return stream(config.split(",")).map(item -> item.split("=")).filter(kv -> kv.length == 2)
+            .filter(kv -> !kv[0].trim().isEmpty() && !kv[1].trim().isEmpty())
+            .collect(toMap(kv -> kv[0].trim(), kv -> kv[1].trim()));
+    }
+}

--- a/platform/quarkus/src/main/resources/application.properties
+++ b/platform/quarkus/src/main/resources/application.properties
@@ -1,0 +1,60 @@
+# Trellis Triplestore
+trellis.triplestore.ldp.type=true
+trellis.triplestore.rdf.location=data/rdf
+
+# Trellis Auth
+trellis.auth.realm="trellis"
+trellis.auth.oauth.jwk=
+trellis.auth.adminusers=
+
+# Trellis JSON-LD
+trellis.io.jsonld.profiles=
+trellis.io.jsonld.domains=
+
+# Trellis RDFa
+trellis.rdfa.template=
+trellis.rdfa.css=
+trellis.rdfa.icon=
+trellis.rdfa.js=
+
+# Trellis WebAC
+trellis.webac.challenges=Bearer
+trellis.webac.realm=trellis
+
+# Trellis HTTP
+trellis.http.baseUrl=
+trellis.http.cache.maxage=
+trellis.http.cache.nocache=
+trellis.http.cache.revalidate=
+trellis.http.extension.graphs=
+trellis.http.memento.headerdates=true
+trellis.http.jsonld.profile=
+trellis.http.precondition.required=false
+trellis.http.patch.create=true
+trellis.http.put.uncontained=false
+trellis.http.weak.etag=false
+trellis.http.websubhub=
+
+# Trellis cache
+trellis.profile.cache.size=100
+trellis.profile.cache.expireHours=24
+trellis.authz.cache.size=1000
+trellis.authz.cache.expireSeconds=600
+
+# Trellis namespaces
+trellis.namespace.prefixes=
+
+# Trellis file
+trellis.file.binary.basepath=data/binaries
+trellis.file.memento.basepath=data/mementos
+
+# CORS
+quarkus.http.cors=true
+quarkus.http.cors.methods=GET,HEAD,OPTIONS,PUT,POST,PATCH,DELETE
+quarkus.http.cors.headers=Content-Type,Link,Accept,Accept-Datetime,Authorization,Prefer,Slug
+quarkus.http.cors.exposed-headers=Content-Type,Link,Memento-Datetime,Preference-Applied,Location,Accept-Patch,Accept-Post,Accept-Ranges,ETag,Vary
+quarkus.http.cors.access-control-max-age=24H
+
+# HTTP
+quarkus.http.port=8080
+

--- a/platform/quarkus/src/test/java/org/trellisldp/quarkus/ApplicationTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/quarkus/ApplicationTest.java
@@ -65,6 +65,6 @@ class ApplicationTest {
     @Test
     void rootResourceBody() {
         final String body = get("/").getBody().asString();
-        assertTrue(body.contains("<http://www.w3.org/ns/ldp#>"));
+        assertTrue(body.contains("ldp:BasicContainer"));
     }
 }

--- a/platform/quarkus/src/test/java/org/trellisldp/quarkus/SimpleNamespaceServiceTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/quarkus/SimpleNamespaceServiceTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.quarkus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.trellisldp.api.NamespaceService;
+
+public class SimpleNamespaceServiceTest {
+
+    @Test
+    public void testNamespace() {
+        final NamespaceService svc = new SimpleNamespaceService();
+        assertEquals(11, svc.getNamespaces().size());
+        assertTrue(svc.setPrefix("foo", "bar"));
+        assertEquals(11, svc.getNamespaces().size());
+    }
+
+    @Test
+    public void testEnvNamespace() {
+        final NamespaceService svc = new SimpleNamespaceService();
+        final String dc11 = "http://purl.org/dc/elements/1.1/";
+        assertEquals(dc11, svc.getNamespaces().get("dc11"));
+    }
+}


### PR DESCRIPTION
This adds a docker configuration for the quarkus-based image and pushes that image to docker hub on successful builds.

This also adds trellis-related configuration values to the `application.properties` file, making these values easier to override by users of the docker image.