### PR TITLE
Support scope attribute in WWW-Authenticate header

### DIFF
--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/AbstractTrellisApplication.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/AbstractTrellisApplication.java
@@ -136,7 +136,7 @@ public abstract class AbstractTrellisApplication<T extends TrellisConfiguration>
             of(config.getAuth().getBasic()).filter(BasicAuthConfiguration::getEnabled).map(x -> "Basic")
                 .ifPresent(challenges::add);
             environment.jersey().register(new WebAcFilter(webac, challenges, config.getAuth().getRealm(),
-                        config.getBaseUrl()));
+                        config.getAuth().getScope(), config.getBaseUrl()));
         });
 
         // WebSub

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/AuthConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/AuthConfiguration.java
@@ -32,6 +32,9 @@ public class AuthConfiguration {
     private String realm = "trellis";
 
     @NotNull
+    private String scope = "";
+
+    @NotNull
     private List<String> adminUsers = new ArrayList<>();
 
     /**
@@ -122,5 +125,23 @@ public class AuthConfiguration {
     @JsonProperty
     public void setRealm(final String realm) {
         this.realm = realm;
+    }
+
+    /**
+     * Set the security scope.
+     * @param scope the security scope
+     */
+    @JsonProperty
+    public void setScope(final String scope) {
+        this.scope = scope;
+    }
+
+    /**
+     * Get the security scope.
+     * @return the scope
+     */
+    @JsonProperty
+    public String getScope() {
+        return scope;
     }
 }

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/config/TrellisConfigurationTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/config/TrellisConfigurationTest.java
@@ -118,9 +118,12 @@ class TrellisConfigurationTest {
         assertTrue(config.getAuth().getBasic().getEnabled(), "basic auth not enabled!");
         assertEquals("users.auth", config.getAuth().getBasic().getUsersFile(), "Incorrect basic users file!");
         assertEquals("trellis", config.getAuth().getRealm(), "Incorrect auth realm!");
+        assertEquals("openid", config.getAuth().getScope(), "Incorrect auth scope!");
 
         config.getAuth().setRealm("foobar");
+        config.getAuth().setScope("baz");
         assertEquals("foobar", config.getAuth().getRealm(), "Incorrect auth/basic/realm value!");
+        assertEquals("baz", config.getAuth().getScope(), "Incorrect auth scope!");
         assertTrue(config.getAuth().getJwt().getEnabled(), "auth/jwt not enabled!");
         assertEquals("Mz4DGzFLQysSGC98ESAnSafMLbxa71ls/zzUFOdCIJw9L0J8Q0Gt7+yCM+Ag73Tm5OTwpBemFOqPFiZ5BeBo4Q==",
                 config.getAuth().getJwt().getKey(), "Incorrect auth/jwt/key");

--- a/components/dropwizard/src/test/resources/config1.yml
+++ b/components/dropwizard/src/test/resources/config1.yml
@@ -14,6 +14,7 @@ baseUrl: http://localhost:8080/
 hubUrl: http://hub.example.com/
 
 auth:
+    scope: "openid"
     adminUsers:
         - zoyd
         - wheeler

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
@@ -301,14 +301,14 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("POST");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm",
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "my-scope",
                 "http://example.com/");
 
         final List<Object> challenges = assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
                 "No auth exception thrown with no access modes!").getChallenges();
 
-        assertTrue(challenges.contains("Foo realm=\"my-realm\""), "Foo not among challenges!");
-        assertTrue(challenges.contains("Bar realm=\"my-realm\""), "Bar not among challenges!");
+        assertTrue(challenges.contains("Foo realm=\"my-realm\" scope=\"my-scope\""), "Foo not among challenges!");
+        assertTrue(challenges.contains("Bar realm=\"my-realm\" scope=\"my-scope\""), "Bar not among challenges!");
     }
 
     @Test
@@ -318,7 +318,7 @@ class WebAcFilterTest {
         when(mockResponseContext.getHeaders()).thenReturn(headers);
         when(mockUriInfo.getAbsolutePathBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", null);
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "", null);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);
@@ -338,7 +338,7 @@ class WebAcFilterTest {
         when(mockResponseContext.getHeaders()).thenReturn(headers);
         when(mockUriInfo.getAbsolutePathBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", null);
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "", null);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);
@@ -351,7 +351,7 @@ class WebAcFilterTest {
         when(mockResponseContext.getStatusInfo()).thenReturn(OK);
         when(mockResponseContext.getHeaders()).thenReturn(headers);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm",
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "",
                 "http://example.com/");
 
         assertTrue(headers.isEmpty());
@@ -375,7 +375,7 @@ class WebAcFilterTest {
         when(mockUriInfo.getQueryParameters()).thenReturn(params);
         when(mockUriInfo.getAbsolutePathBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", null);
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "", null);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);
@@ -388,7 +388,7 @@ class WebAcFilterTest {
         when(mockResponseContext.getStatusInfo()).thenReturn(FORBIDDEN);
         when(mockResponseContext.getHeaders()).thenReturn(headers);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", null);
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "", null);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);


### PR DESCRIPTION
Resolves #575

Adding this support is driven by configuration and is entirely optional