### PR TITLE
Update gradle dependency scopes

### DIFF
--- a/auth/basic/build.gradle
+++ b/auth/basic/build.gradle
@@ -9,19 +9,19 @@ ext {
 }
 
 dependencies {
-    api("jakarta.annotation:jakarta.annotation-api:$annotationApiVersion")
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion")
+    api "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
 
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
-    testRuntime("jakarta.activation:jakarta.activation-api:$activationApiVersion")
+    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.glassfish.jersey.core:jersey-server:$jerseyVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }
 

--- a/auth/oauth/build.gradle
+++ b/auth/oauth/build.gradle
@@ -8,24 +8,24 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("jakarta.annotation:jakarta.annotation-api:$annotationApiVersion")
-    api("jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("commons-io:commons-io:$commonsIoVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
-    implementation("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
-    implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
-    implementation("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "commons-io:commons-io:$commonsIoVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    implementation "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
+    implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
+    implementation "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
 
-    testRuntime("jakarta.activation:jakarta.activation-api:$activationApiVersion")
+    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion")
-    testImplementation("org.glassfish.jersey.core:jersey-server:$jerseyVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
+    testImplementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -143,10 +143,10 @@ allprojects { subproj ->
     }
 
     dependencies {
-        testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")
-        testImplementation("org.apiguardian:apiguardian-api:${apiguardianVersion}")
-        testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
-        testRuntime("org.junit.platform:junit-platform-launcher:${junitLauncherVersion}")
+        testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
+        testImplementation "org.apiguardian:apiguardian-api:${apiguardianVersion}"
+        testRuntimeClasspath "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+        testRuntimeClasspath "org.junit.platform:junit-platform-launcher:${junitLauncherVersion}"
     }
 
     gradle.projectsEvaluated {

--- a/components/app-triplestore/build.gradle
+++ b/components/app-triplestore/build.gradle
@@ -11,62 +11,62 @@ configurations.all {
 }
 
 dependencies {
-    compile("com.github.jsonld-java:jsonld-java:$jsonldVersion") {
+    implementation("com.github.jsonld-java:jsonld-java:$jsonldVersion") {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient-osgi'
         exclude group: 'org.apache.httpcomponents', module: 'httpcore-osgi'
     }
-    compile("commons-codec:commons-codec:$commonsCodecVersion")
-    compile("jakarta.activation:jakarta.activation-api:$activationApiVersion")
-    compile("jakarta.jms:jakarta.jms-api:$jmsApiVersion")
-    compile("org.apache.activemq:activemq-client:$activeMqVersion")
-    compile("org.apache.jena:jena-arq:$jenaVersion")
-    compile("org.apache.jena:jena-rdfconnection:$jenaVersion")
-    compile("org.apache.jena:jena-tdb2:$jenaVersion")
-    compile("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    compile("org.slf4j:slf4j-api:$slf4jVersion")
-    compile("jakarta.validation:jakarta.validation-api:$validationApiVersion")
-    compile("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
-    compile("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
-    compile("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
+    implementation "commons-codec:commons-codec:$commonsCodecVersion"
+    implementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    implementation "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    implementation "jakarta.jms:jakarta.jms-api:$jmsApiVersion"
+    implementation "jakarta.validation:jakarta.validation-api:$validationApiVersion"
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    implementation "org.apache.activemq:activemq-client:$activeMqVersion"
+    implementation "org.apache.jena:jena-arq:$jenaVersion"
+    implementation "org.apache.jena:jena-rdfconnection:$jenaVersion"
+    implementation "org.apache.jena:jena-tdb2:$jenaVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
+    implementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
 
-    compile project(':trellis-constraint-rules')
-    compile project(':trellis-io-jena')
-    compile project(':trellis-api')
-    compile project(':trellis-http')
-    compile project(':trellis-app')
-    compile project(':trellis-cache')
-    compile project(':trellis-dropwizard')
-    compile project(':trellis-vocabulary')
-    compile project(':trellis-file')
-    compile project(':trellis-namespaces')
-    compile project(':trellis-audit')
-    compile project(':trellis-event-jackson')
-    compile project(':trellis-webac')
-    compile project(':trellis-triplestore')
-    compile project(':trellis-jms')
-    compile project(':trellis-rdfa')
-    compile project(':trellis-kafka')
-    compile project(':trellis-auth-oauth')
-    compile project(':trellis-auth-basic')
+    implementation project(':trellis-constraint-rules')
+    implementation project(':trellis-io-jena')
+    implementation project(':trellis-api')
+    implementation project(':trellis-http')
+    implementation project(':trellis-app')
+    implementation project(':trellis-cache')
+    implementation project(':trellis-dropwizard')
+    implementation project(':trellis-vocabulary')
+    implementation project(':trellis-file')
+    implementation project(':trellis-namespaces')
+    implementation project(':trellis-audit')
+    implementation project(':trellis-event-jackson')
+    implementation project(':trellis-webac')
+    implementation project(':trellis-triplestore')
+    implementation project(':trellis-jms')
+    implementation project(':trellis-rdfa')
+    implementation project(':trellis-kafka')
+    implementation project(':trellis-auth-oauth')
+    implementation project(':trellis-auth-basic')
 
-    compile("io.dropwizard:dropwizard-core:$dropwizardVersion")
-    compile("io.dropwizard:dropwizard-metrics:$dropwizardVersion")
-    compile("io.dropwizard:dropwizard-http2:$dropwizardVersion")
+    implementation "io.dropwizard:dropwizard-core:$dropwizardVersion"
+    implementation "io.dropwizard:dropwizard-metrics:$dropwizardVersion"
+    implementation "io.dropwizard:dropwizard-http2:$dropwizardVersion"
 
-    testCompile("org.awaitility:awaitility:$awaitilityVersion") {
+    testImplementation("org.awaitility:awaitility:$awaitilityVersion") {
         exclude group: "org.hamcrest", module: 'hamcrest-core'
         exclude group: 'org.hamcrest', module: 'hamcrest-library'
     }
-    testCompile("org.hamcrest:hamcrest:$hamcrestVersion")
-    testCompile("ch.qos.logback:logback-classic:$logbackVersion")
-    testCompile("org.mockito:mockito-core:$mockitoVersion")
-    testCompile project(':trellis-test')
-    testCompile("io.dropwizard:dropwizard-client:$dropwizardVersion")
-    testCompile("io.dropwizard:dropwizard-testing:$dropwizardVersion")
-    testCompile("org.apache.activemq:activemq-broker:$activeMqVersion")
+    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation project(':trellis-test')
+    testImplementation "io.dropwizard:dropwizard-client:$dropwizardVersion"
+    testImplementation "io.dropwizard:dropwizard-testing:$dropwizardVersion"
+    testImplementation "org.apache.activemq:activemq-broker:$activeMqVersion"
 }
 
 jar {

--- a/components/app/build.gradle
+++ b/components/app/build.gradle
@@ -10,17 +10,17 @@ ext {
 }
 
 dependencies {
-    api("jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion")
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion"
     api project(':trellis-api')
     api project(':trellis-http')
     api project(':trellis-vocabulary')
 
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testRuntime("jakarta.activation:jakarta.activation-api:$activationApiVersion")
+    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
     testImplementation("org.jboss.weld:weld-junit5:$weldVersion") {
         exclude group: "org.jboss.spec.javax.interceptor", module: "jboss-interceptors-api_1.2_spec"
         exclude group: "org.jboss.spec.javax.el", module: "jboss-el-api_3.0_spec"

--- a/components/audit/build.gradle
+++ b/components/audit/build.gradle
@@ -13,6 +13,6 @@ dependencies {
 
     implementation project(':trellis-vocabulary')
 
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
 }

--- a/components/cache/build.gradle
+++ b/components/cache/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     api project(':trellis-api')
     api "com.google.guava:guava:$guavaVersion"
 
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }
 

--- a/components/cdi/build.gradle
+++ b/components/cdi/build.gradle
@@ -9,15 +9,15 @@ ext {
 }
 
 dependencies {
-    api("jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion")
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion"
     api project(':trellis-api')
     api project(':trellis-app')
 
-    testRuntime("jakarta.activation:jakarta.activation-api:$activationApiVersion")
+    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
     testImplementation("org.jboss.weld:weld-junit5:$weldVersion") {
         exclude group: "org.jboss.spec.javax.interceptor", module: "jboss-interceptors-api_1.2_spec"
         exclude group: "org.jboss.spec.javax.el", module: "jboss-el-api_3.0_spec"

--- a/components/constraint-rules/build.gradle
+++ b/components/constraint-rules/build.gradle
@@ -17,7 +17,7 @@ dependencies {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    testImplementation("org.apache.jena:jena-arq:$jenaVersion")
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "org.apache.jena:jena-arq:$jenaVersion"
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }

--- a/components/dropwizard/build.gradle
+++ b/components/dropwizard/build.gradle
@@ -7,46 +7,46 @@ ext {
 }
 
 dependencies {
-    api("io.dropwizard:dropwizard-core:$dropwizardVersion")
+    api "io.dropwizard:dropwizard-core:$dropwizardVersion"
     api project(':trellis-api')
     api project(':trellis-http')
     api project(':trellis-cache')
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("jakarta.validation:jakarta.validation-api:$validationApiVersion")
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "jakarta.validation:jakarta.validation-api:$validationApiVersion"
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation project(':trellis-vocabulary')
     implementation project(':trellis-audit')
     implementation project(':trellis-webac')
     implementation project(':trellis-auth-basic')
     implementation project(':trellis-auth-oauth')
 
-    testRuntime("jakarta.activation:jakarta.activation-api:$activationApiVersion")
+    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.hamcrest:hamcrest:$hamcrestVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
     testImplementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    testImplementation("org.apache.jena:jena-arq:$jenaVersion")
-    testImplementation("org.apache.jena:jena-rdfconnection:$jenaVersion")
+    testImplementation "org.apache.jena:jena-arq:$jenaVersion"
+    testImplementation "org.apache.jena:jena-rdfconnection:$jenaVersion"
     testImplementation("org.awaitility:awaitility:$awaitilityVersion") {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
         exclude group: 'org.hamcrest', module: 'hamcrest-library'
     }
-    testImplementation("org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-triplestore')
     testImplementation project(':trellis-constraint-rules')
     testImplementation project(':trellis-io-jena')
     testImplementation project(':trellis-file')
     testImplementation project(':trellis-rdfa')
     testImplementation project(':trellis-app')
-    testImplementation("io.dropwizard:dropwizard-client:$dropwizardVersion")
+    testImplementation "io.dropwizard:dropwizard-client:$dropwizardVersion"
     testImplementation("io.dropwizard:dropwizard-testing:$dropwizardVersion") {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }

--- a/components/file/build.gradle
+++ b/components/file/build.gradle
@@ -9,23 +9,23 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
     api project(':trellis-api')
 
-    implementation("commons-codec:commons-codec:$commonsCodecVersion")
-    implementation("commons-io:commons-io:$commonsIoVersion")
+    implementation "commons-codec:commons-codec:$commonsCodecVersion"
+    implementation "commons-io:commons-io:$commonsIoVersion"
     implementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    implementation("org.apache.jena:jena-arq:$jenaVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "org.apache.jena:jena-arq:$jenaVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation project(':trellis-vocabulary')
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("jakarta.annotation:jakarta.annotation-api:$annotationApiVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
 }
 

--- a/components/io-jena/build.gradle
+++ b/components/io-jena/build.gradle
@@ -9,21 +9,21 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
     api("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    api("org.apache.jena:jena-arq:$jenaVersion")
+    api "org.apache.jena:jena-arq:$jenaVersion"
     api project(':trellis-api')
 
-    implementation("commons-io:commons-io:$commonsIoVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "commons-io:commons-io:$commonsIoVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation project(':trellis-vocabulary')
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
 }
 

--- a/components/namespaces/build.gradle
+++ b/components/namespaces/build.gradle
@@ -9,16 +9,16 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
     api project(':trellis-api')
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-vocabulary')
 }

--- a/components/rdfa/build.gradle
+++ b/components/rdfa/build.gradle
@@ -9,21 +9,21 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
     api project(':trellis-api')
 
-    implementation("com.github.spullara.mustache.java:compiler:$mustacheVersion")
-    implementation("org.apache.jena:jena-arq:$jenaVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
+    implementation "com.github.spullara.mustache.java:compiler:$mustacheVersion"
+    implementation "org.apache.jena:jena-arq:$jenaVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
     implementation project(':trellis-vocabulary')
 
     testImplementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    testImplementation("org.apache.jena:jena-arq:$jenaVersion")
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "org.apache.jena:jena-arq:$jenaVersion"
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }
 

--- a/components/test/build.gradle
+++ b/components/test/build.gradle
@@ -11,34 +11,34 @@ sonarqube {
 }
 
 dependencies {
-    implementation("commons-codec:commons-codec:$commonsCodecVersion")
-    implementation("commons-io:commons-io:$commonsIoVersion")
-    implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
-    implementation("jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion")
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
-    implementation("org.apache.commons:commons-text:$commonsTextVersion")
+    implementation "commons-codec:commons-codec:$commonsCodecVersion"
+    implementation "commons-io:commons-io:$commonsIoVersion"
+    implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
+    implementation "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    implementation "org.apache.commons:commons-text:$commonsTextVersion"
     implementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: "org.apache.jena", module: "jena-osgi"
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    implementation("org.apache.jena:jena-arq:$jenaVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
+    implementation "org.apache.jena:jena-arq:$jenaVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
     implementation("org.awaitility:awaitility:$awaitilityVersion") {
         exclude group: 'org.hamcrest', module: 'hamcrest-library'
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-    implementation("org.hamcrest:hamcrest:$hamcrestVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
-    implementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    implementation "org.hamcrest:hamcrest:$hamcrestVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     implementation project(':trellis-api')
     implementation project(':trellis-http')
     implementation project(':trellis-io-jena')
     implementation project(':trellis-vocabulary')
 
-    runtime("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    runtimeClasspath "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }
 
 jar {

--- a/components/triplestore/build.gradle
+++ b/components/triplestore/build.gradle
@@ -9,31 +9,31 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("jakarta.annotation:jakarta.annotation-api:$annotationApiVersion")
-    api("org.apache.jena:jena-rdfconnection:$jenaVersion")
-    api("org.apache.jena:jena-arq:$jenaVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    api "org.apache.jena:jena-rdfconnection:$jenaVersion"
+    api "org.apache.jena:jena-arq:$jenaVersion"
     api("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    api("org.eclipse.microprofile.health:microprofile-health-api:$microprofileHealthVersion")
+    api "org.eclipse.microprofile.health:microprofile-health-api:$microprofileHealthVersion"
     api project(':trellis-api')
 
-    implementation("org.apache.jena:jena-tdb2:$jenaVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "org.apache.jena:jena-tdb2:$jenaVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation project(':trellis-vocabulary')
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("io.smallrye:smallrye-health:$smallryeHealthVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "io.smallrye:smallrye-health:$smallryeHealthVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-audit')
     testImplementation project(':trellis-test')
     testImplementation("org.awaitility:awaitility:$awaitilityVersion") {
         exclude group: "org.hamcrest", module: 'hamcrest-core'
         exclude group: 'org.hamcrest', module: 'hamcrest-library'
     }
-    testImplementation("org.hamcrest:hamcrest:$hamcrestVersion")
+    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/components/webac/build.gradle
+++ b/components/webac/build.gradle
@@ -9,27 +9,27 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("jakarta.enterprise:jakarta.enterprise.cdi-api:${cdiApiVersion}")
-    api("jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion")
-    api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:${cdiApiVersion}"
+    api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
+    api "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
     api project(':trellis-api')
     api project(':trellis-http')
 
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
     implementation project(':trellis-vocabulary')
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
     testImplementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    testImplementation("org.apache.jena:jena-arq:$jenaVersion")
-    testImplementation("org.glassfish.jersey.core:jersey-server:$jerseyVersion")
-    testImplementation("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "org.apache.jena:jena-arq:$jenaVersion"
+    testImplementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
+    testImplementation "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-triplestore')
 }

--- a/components/webdav/build.gradle
+++ b/components/webdav/build.gradle
@@ -9,37 +9,37 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("jakarta.enterprise:jakarta.enterprise.cdi-api:${cdiApiVersion}")
-    api("jakarta.annotation:jakarta.annotation-api:$annotationApiVersion")
-    api("jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion")
-    api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
-    api("org.eclipse.microprofile.metrics:microprofile-metrics-api:$microprofileMetricsVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:${cdiApiVersion}"
+    api "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
+    api "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
+    api "org.eclipse.microprofile.metrics:microprofile-metrics-api:$microprofileMetricsVersion"
     api project(':trellis-api')
 
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
-    implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
-    implementation("org.apache.jena:jena-arq:$jenaVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
+    implementation "org.apache.jena:jena-arq:$jenaVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation project(':trellis-http')
     implementation project(':trellis-vocabulary')
 
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
-    testImplementation("org.glassfish.jersey.core:jersey-server:$jerseyVersion")
-    testImplementation("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion")
-    testImplementation("org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion")
-    testImplementation("org.glassfish.jersey.connectors:jersey-apache-connector:$jerseyVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
+    testImplementation "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion"
+    testImplementation "org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion"
+    testImplementation "org.glassfish.jersey.connectors:jersey-apache-connector:$jerseyVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-audit')
     testImplementation project(':trellis-constraint-rules')
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-io-jena')
 
-    testRuntimeClasspath("jakarta.activation:jakarta.activation-api:$activationApiVersion")
-    testRuntimeClasspath("ch.qos.logback:logback-classic:$logbackVersion")
-    testRuntimeClasspath("org.glassfish.jaxb:jaxb-runtime:$glassfishJaxbVersion")
+    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
+    testRuntimeClasspath "org.glassfish.jaxb:jaxb-runtime:$glassfishJaxbVersion"
 }
 
 if (project.sourceCompatibility.isJava11Compatible()) {

--- a/core/api/build.gradle
+++ b/core/api/build.gradle
@@ -9,19 +9,19 @@ ext {
 }
 
 dependencies {
-    api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
-    api("jakarta.enterprise:jakarta.enterprise.cdi-api:${cdiApiVersion}")
+    api "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion"
 
-    testImplementation("commons-io:commons-io:$commonsIoVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "commons-io:commons-io:$commonsIoVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    testImplementation("org.apache.jena:jena-arq:$jenaVersion")
-    testImplementation("org.apache.commons:commons-text:$commonsTextVersion")
+    testImplementation "org.apache.jena:jena-arq:$jenaVersion"
+    testImplementation "org.apache.commons:commons-text:$commonsTextVersion"
     testImplementation project(':trellis-vocabulary')
 
-    testRuntimeClasspath("ch.qos.logback:logback-classic:$logbackVersion")
+    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
 }
 

--- a/core/http/build.gradle
+++ b/core/http/build.gradle
@@ -10,39 +10,39 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("jakarta.enterprise:jakarta.enterprise.cdi-api:${cdiApiVersion}")
-    api("jakarta.annotation:jakarta.annotation-api:$annotationApiVersion")
-    api("jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion")
-    api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
-    api("org.eclipse.microprofile.metrics:microprofile-metrics-api:$microprofileMetricsVersion")
-    api("org.eclipse.microprofile.openapi:microprofile-openapi-api:$microprofileOpenapiVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion"
+    api "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
+    api "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
+    api "org.eclipse.microprofile.metrics:microprofile-metrics-api:$microprofileMetricsVersion"
+    api "org.eclipse.microprofile.openapi:microprofile-openapi-api:$microprofileOpenapiVersion"
     api project(':trellis-api')
 
-    implementation("commons-codec:commons-codec:$commonsCodecVersion")
-    implementation("commons-io:commons-io:$commonsIoVersion")
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
-    implementation("org.apache.commons:commons-lang3:$commonsLangVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "commons-codec:commons-codec:$commonsCodecVersion"
+    implementation "commons-io:commons-io:$commonsIoVersion"
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation project(':trellis-vocabulary')
 
-    testImplementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.glassfish.jersey.core:jersey-server:$jerseyVersion")
-    testImplementation("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion")
-    testImplementation("org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion")
-    testImplementation("org.glassfish.jersey.connectors:jersey-apache-connector:$jerseyVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
+    testImplementation "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion"
+    testImplementation "org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion"
+    testImplementation "org.glassfish.jersey.connectors:jersey-apache-connector:$jerseyVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-audit')
     testImplementation project(':trellis-constraint-rules')
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-io-jena')
 
-    testRuntimeClasspath("jakarta.activation:jakarta.activation-api:$activationApiVersion")
-    testRuntimeClasspath("ch.qos.logback:logback-classic:$logbackVersion")
+    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
 if (project.sourceCompatibility.isJava11Compatible()) {

--- a/core/vocabulary/build.gradle
+++ b/core/vocabulary/build.gradle
@@ -9,14 +9,14 @@ ext {
 }
 
 dependencies {
-    api("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
+    api "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
 
     testImplementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
-    testImplementation("org.apache.jena:jena-arq:$jenaVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "org.apache.jena:jena-arq:$jenaVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
-    testRuntimeClasspath("ch.qos.logback:logback-classic:$logbackVersion")
+    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
 }

--- a/notifications/amqp/build.gradle
+++ b/notifications/amqp/build.gradle
@@ -13,18 +13,18 @@ ext {
 }
 
 dependencies {
-    api("com.rabbitmq:amqp-client:$rabbitMqVersion")
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
+    api "com.rabbitmq:amqp-client:$rabbitMqVersion"
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
     api project(':trellis-api')
 
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("com.sleepycat:je:$sleepycatVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "com.sleepycat:je:$sleepycatVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-vocabulary')
 

--- a/notifications/event-jackson/build.gradle
+++ b/notifications/event-jackson/build.gradle
@@ -11,12 +11,12 @@ ext {
 dependencies {
     api project(':trellis-api')
 
-    implementation("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
-    implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     implementation project(':trellis-vocabulary')
 
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
 }

--- a/notifications/jms/build.gradle
+++ b/notifications/jms/build.gradle
@@ -13,18 +13,18 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("jakarta.jms:jakarta.jms-api:$jmsApiVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "jakarta.jms:jakarta.jms-api:$jmsApiVersion"
     api project(':trellis-api')
 
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testImplementation("org.apache.activemq:activemq-client:$activeMqVersion")
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "org.apache.activemq:activemq-client:$activeMqVersion"
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-vocabulary')
 
@@ -34,7 +34,7 @@ dependencies {
     }
 
     if (!project.sourceCompatibility.isJava11Compatible()) {
-        testImplementation("org.apache.activemq:activemq-broker:$activeMqVersion")
+        testImplementation "org.apache.activemq:activemq-broker:$activeMqVersion"
     }
 }
 

--- a/notifications/kafka/build.gradle
+++ b/notifications/kafka/build.gradle
@@ -9,17 +9,17 @@ ext {
 }
 
 dependencies {
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("org.apache.kafka:kafka-clients:$kafkaVersion")
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "org.apache.kafka:kafka-clients:$kafkaVersion"
     api project(':trellis-api')
 
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-vocabulary')
 }

--- a/notifications/reactive/build.gradle
+++ b/notifications/reactive/build.gradle
@@ -9,28 +9,28 @@ ext {
 }
 
 dependencies {
-    api("io.reactivex.rxjava2:rxjava:$rxjavaVersion")
-    api("jakarta.inject:jakarta.inject-api:$injectApiVersion")
-    api("org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:$microprofileReactiveMessagingVersion")
+    api "io.reactivex.rxjava2:rxjava:$rxjavaVersion"
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-api:$microprofileReactiveMessagingVersion"
     api project(':trellis-api')
 
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
-    testImplementation("io.smallrye:smallrye-config:$smallryeConfigVersion")
-    testImplementation("io.smallrye.reactive:smallrye-reactive-streams-operators:$smallryeReactiveOperatorsVersion")
-    testImplementation("io.smallrye.reactive:smallrye-reactive-messaging-provider:$smallryeReactiveVersion")
-    testImplementation("org.apache.commons:commons-rdf-simple:$commonsRdfVersion")
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "io.smallrye.reactive:smallrye-reactive-streams-operators:$smallryeReactiveOperatorsVersion"
+    testImplementation "io.smallrye.reactive:smallrye-reactive-messaging-provider:$smallryeReactiveVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
     testImplementation("org.awaitility:awaitility:$awaitilityVersion") {
         exclude group: "org.hamcrest", module: 'hamcrest-core'
         exclude group: 'org.hamcrest', module: 'hamcrest-library'
     }
-    testImplementation("org.hamcrest:hamcrest:$hamcrestVersion")
+    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
     testImplementation("org.jboss.weld:weld-junit5:$weldVersion") {
         exclude group: "org.jboss.spec.javax.interceptor", module: "jboss-interceptors-api_1.2_spec"
         exclude group: "org.jboss.spec.javax.el", module: "jboss-el-api_3.0_spec"
     }
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-vocabulary')
 }

--- a/platform/openliberty/build.gradle
+++ b/platform/openliberty/build.gradle
@@ -18,9 +18,9 @@ ext {
 }
 
 dependencies {
-    implementation("jakarta.enterprise:jakarta.enterprise.cdi-api:${cdiApiVersion}")
-    implementation("jakarta.annotation:jakarta.annotation-api:$annotationApiVersion")
-    implementation("jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion")
+    implementation "jakarta.enterprise:jakarta.enterprise.cdi-api:${cdiApiVersion}"
+    implementation "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    implementation "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
 
     implementation project(':trellis-api')
     implementation project(':trellis-app')
@@ -43,22 +43,22 @@ dependencies {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient-osgi'
         exclude group: 'org.apache.httpcomponents', module: 'httpcore-osgi'
     }
-    implementation("commons-codec:commons-codec:$commonsCodecVersion")
-    implementation("org.apache.jena:jena-arq:$jenaVersion")
-    implementation("org.apache.jena:jena-rdfconnection:$jenaVersion")
-    implementation("org.apache.jena:jena-tdb2:$jenaVersion")
-    implementation("org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
-    implementation("org.apache.commons:commons-rdf-api:$commonsRdfVersion")
+    implementation "commons-codec:commons-codec:$commonsCodecVersion"
+    implementation "org.apache.jena:jena-arq:$jenaVersion"
+    implementation "org.apache.jena:jena-rdfconnection:$jenaVersion"
+    implementation "org.apache.jena:jena-tdb2:$jenaVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
     implementation("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {
         exclude group: 'org.apache.jena', module: 'jena-osgi'
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
 
-    runtime("ch.qos.logback:logback-classic:$logbackVersion")
-    runtime("jakarta.activation:jakarta.activation-api:$activationApiVersion")
-    runtime("jakarta.validation:jakarta.validation-api:$validationApiVersion")
-    runtime("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
+    runtimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
+    runtimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    runtimeClasspath "jakarta.validation:jakarta.validation-api:$validationApiVersion"
+    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
     testImplementation project(':trellis-test')
 

--- a/platform/osgi/build.gradle
+++ b/platform/osgi/build.gradle
@@ -29,40 +29,41 @@ sonarqube {
 }
 
 dependencies {
-    compile("org.apache.jena:jena-osgi:$jenaVersion")
-    compile("org.apache.commons:commons-compress:$commonsCompressVersion")
-    compile("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
-    compile project(':trellis-api')
-    compile project(':trellis-http')
-    compile project(':trellis-io-jena')
-    compile project(':trellis-namespaces')
-    compile project(':trellis-vocabulary')
-    compile project(':trellis-triplestore')
+    implementation "org.apache.jena:jena-osgi:$jenaVersion"
+    implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
+    implementation project(':trellis-api')
+    implementation project(':trellis-http')
+    implementation project(':trellis-io-jena')
+    implementation project(':trellis-namespaces')
+    implementation project(':trellis-vocabulary')
+    implementation project(':trellis-triplestore')
 
-    testCompile("ch.qos.logback:logback-classic:$logbackVersion")
-    testCompile("org.apache.karaf.features:standard:$karafVersion")
-    testCompile("org.apache.karaf.features:org.apache.karaf.features.core:$karafVersion")
-    testCompile("org.ops4j.pax.exam:pax-exam:$paxExamVersion")
-    testCompile("org.ops4j.pax.exam:pax-exam-junit4:$paxExamVersion")
-    testCompile("org.ops4j.pax.exam:pax-exam-container-karaf:$paxExamVersion")
-    testCompile("org.osgi:org.osgi.core:$osgiVersion")
-    testCompile("org.osgi:org.osgi.compendium:$osgiCompendiumVersion")
-    testCompile("org.mockito:mockito-core:$mockitoVersion")
-    testCompile("org.glassfish.hk2.external:javax.inject:$glassfishInjectVersion")
-    testCompile project(':trellis-amqp')
-    testCompile project(':trellis-audit')
-    testCompile project(':trellis-constraint-rules')
-    testCompile project(':trellis-event-jackson')
-    testCompile project(':trellis-file')
-    testCompile project(':trellis-jms')
-    testCompile project(':trellis-kafka')
-    testCompile project(':trellis-triplestore')
-    testCompile project(':trellis-webac')
-    testCompile project(':trellis-karaf')
+    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
-    testCompile group: 'org.apache.karaf.features', name: 'standard', version: karafVersion, classifier:'features', ext: 'xml'
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "org.apache.karaf.features:standard:$karafVersion"
+    testImplementation "org.apache.karaf.features:org.apache.karaf.features.core:$karafVersion"
+    testImplementation "org.ops4j.pax.exam:pax-exam:$paxExamVersion"
+    testImplementation "org.ops4j.pax.exam:pax-exam-junit4:$paxExamVersion"
+    testImplementation "org.ops4j.pax.exam:pax-exam-container-karaf:$paxExamVersion"
+    testImplementation "org.osgi:org.osgi.core:$osgiVersion"
+    testImplementation "org.osgi:org.osgi.compendium:$osgiCompendiumVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.glassfish.hk2.external:javax.inject:$glassfishInjectVersion"
+    testImplementation project(':trellis-amqp')
+    testImplementation project(':trellis-audit')
+    testImplementation project(':trellis-constraint-rules')
+    testImplementation project(':trellis-event-jackson')
+    testImplementation project(':trellis-file')
+    testImplementation project(':trellis-jms')
+    testImplementation project(':trellis-kafka')
+    testImplementation project(':trellis-triplestore')
+    testImplementation project(':trellis-webac')
+    testImplementation project(':trellis-karaf')
 
-    testRuntime("org.junit.vintage:junit-vintage-engine:${junitVersion}")
+    testImplementation group: 'org.apache.karaf.features', name: 'standard', version: karafVersion, classifier:'features', ext: 'xml'
+
+    testRuntimeClasspath "org.junit.vintage:junit-vintage-engine:${junitVersion}"
 
     karafDistro group: 'org.apache.karaf', name: 'apache-karaf', version: karafVersion, ext: 'zip'
 }
@@ -85,7 +86,7 @@ task generateDependsFile {
         properties.setProperty( "${project.group}/${project.name}/version", "${project.version}" )
 
         // then for all our deps
-        project.configurations.testRuntime.resolvedConfiguration.resolvedArtifacts.each {
+        project.configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.each {
             final String keyBase = it.moduleVersion.id.group + '/' + it.moduleVersion.id.name
             properties.setProperty( "${keyBase}/scope", "compile" )
             properties.setProperty( "${keyBase}/type", it.extension )

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -51,16 +51,16 @@ dependencies {
 
     implementation "com.github.spullara.mustache.java:compiler:$mustacheVersion"
     implementation "com.google.guava:guava:$guavaVersion"
-    implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
-    implementation("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
-    implementation("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
+    implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
+    implementation "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
+    implementation "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
     implementation "org.apache.jena:jena-arq:$jenaVersion"
     implementation "org.apache.jena:jena-rdfconnection:$jenaVersion"
     implementation "org.apache.jena:jena-tdb2:$jenaVersion"
 
 
-    runtime "jakarta.activation:jakarta.activation-api:$activationApiVersion"
-    runtime "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    runtimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
     testImplementation "io.quarkus:quarkus-junit5"
     testImplementation "io.rest-assured:rest-assured"

--- a/platform/server/build.gradle
+++ b/platform/server/build.gradle
@@ -11,18 +11,18 @@ application {
 }
 
 dependencies {
-    compile project(':trellis-app-triplestore')
+    implementation project(':trellis-app-triplestore')
 
-    runtime("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
+    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
     if (project.sourceCompatibility.isJava11Compatible()) {
-        runtime("io.dropwizard:dropwizard-core:$dropwizardVersion")
-        runtime("io.dropwizard:dropwizard-metrics:$dropwizardVersion")
-        runtime("io.dropwizard:dropwizard-http2:$dropwizardVersion")
+        runtimeClasspath "io.dropwizard:dropwizard-core:$dropwizardVersion"
+        runtimeClasspath "io.dropwizard:dropwizard-metrics:$dropwizardVersion"
+        runtimeClasspath "io.dropwizard:dropwizard-http2:$dropwizardVersion"
 
-        runtime("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
-        runtime("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
-        runtime("io.jsonwebtoken:jjwt-api:$jjwtVersion")
+        runtimeClasspath "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
+        runtimeClasspath "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
+        runtimeClasspath "io.jsonwebtoken:jjwt-api:$jjwtVersion"
     }
 }
 


### PR DESCRIPTION
There are a lot of line changes here but not much going on.

The use of `compile` and `testCompile` scopes are deprecated and have been changed to `implementation` and `testImplementation`

Similarly, `runtime` and `testRuntime` => `runtimeClasspath` and `testRuntimeClasspath`

Those changes will be needed once we move to Gradle 6.

Furthermore, the declaration of these dependences has been normalized (removing unneeded parens)