### PR TITLE
Implement microprofile-based authentication module

### DIFF
--- a/auth/jwt/bnd.bnd
+++ b/auth/jwt/bnd.bnd
@@ -1,0 +1,13 @@
+Automatic-Module-Name:  ${project.ext.moduleName}
+Export-Package:         ${project.ext.moduleName}
+
+Bundle-Vendor:          ${project.vendor}
+Bundle-Version:         ${project.version}
+Bundle-License:         ${project.license}
+Bundle-DocURL:          ${project.docURL}
+Bundle-Name:            ${project.description}
+Bundle-SymbolicName:    ${project.group}.${project.name}
+Bundle-SCM:             url=https://github.com/trellis-ldp/trellis, \
+                        connection=scm:git:https://github.com/trellis-ldp/trellis.git, \
+                        developerConnection=scm:git:git@github.com:trellis-ldp/trellis.git
+

--- a/auth/jwt/build.gradle
+++ b/auth/jwt/build.gradle
@@ -1,0 +1,46 @@
+apply plugin: 'java-library'
+apply plugin: 'biz.aQute.bnd.builder'
+
+description = 'Trellis Microprofile JWT-Auth'
+
+ext {
+    moduleName = 'org.trellisldp.auth.jwt'
+}
+
+dependencies {
+    api "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion"
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
+    api "org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:$microprofileJwtVersion"
+
+    implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "io.smallrye:smallrye-jwt:$smallryeJwtVersion"
+    testImplementation "jakarta.json.bind:jakarta.json.bind-api:$jsonbApiVersion"
+    testImplementation "org.eclipse:yasson:$yassonVersion"
+    testImplementation "org.glassfish.jersey.core:jersey-server:$jerseyVersion"
+    testImplementation("org.jboss.weld:weld-junit5:$weldVersion") {
+        exclude group: "org.jboss.spec.javax.interceptor", module: "jboss-interceptors-api_1.2_spec"
+        exclude group: "org.jboss.spec.javax.el", module: "jboss-el-api_3.0_spec"
+    }
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+
+    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
+}
+
+if (project.sourceCompatibility.isJava11Compatible()) {
+    test {
+        inputs.property("moduleName", moduleName)
+        doFirst {
+            jvmArgs += [
+                '--add-opens', "$moduleName/$moduleName=weld.junit5",
+                '--add-opens', "$moduleName/$moduleName=weld.core.impl",
+            ]
+        }
+    }
+}

--- a/auth/jwt/src/main/java/module-info.java
+++ b/auth/jwt/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module org.trellisldp.auth.jwt {
+    exports org.trellisldp.auth.jwt;
+
+    requires jakarta.inject.api;
+    requires java.ws.rs;
+    requires java.annotation;
+    requires microprofile.config.api;
+    requires microprofile.jwt.auth.api;
+    requires org.slf4j;
+}

--- a/auth/jwt/src/main/java/org/trellisldp/auth/jwt/JwtAuthFilter.java
+++ b/auth/jwt/src/main/java/org/trellisldp/auth/jwt/JwtAuthFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.auth.jwt;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toSet;
+import static javax.ws.rs.Priorities.AUTHENTICATION;
+import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.slf4j.Logger;
+
+/** A JWT-based authentication filter. */
+@Provider
+@Priority(AUTHENTICATION + 10)
+public class JwtAuthFilter implements ContainerRequestFilter {
+
+    private static final Logger LOGGER = getLogger(JwtAuthFilter.class);
+
+    /** The configuration key controlling the list of of admin WebID values. */
+    public static final String CONFIG_AUTH_ADMIN_USERS = "trellis.auth.adminusers";
+
+    private final Set<String> admins;
+
+    @Inject
+    private JsonWebToken jwt;
+
+    /**
+     * Create an auth filter that augments Microprofile-JWT authentication with WebID support.
+     */
+    public JwtAuthFilter() {
+        this.admins = getConfiguredAdmins(getConfig().getOptionalValue(CONFIG_AUTH_ADMIN_USERS, String.class)
+                .orElse(""));
+    }
+
+    @Override
+    public void filter(final ContainerRequestContext ctx) throws IOException {
+        LOGGER.trace("JWT Auth Token: {}", jwt);
+        ctx.setSecurityContext(new WebIdSecurityContext(ctx.getSecurityContext(), jwt, admins));
+    }
+
+    static Set<String> getConfiguredAdmins(final String admins) {
+        return stream(admins.split(",")).map(String::trim).collect(toSet());
+    }
+}

--- a/auth/jwt/src/main/java/org/trellisldp/auth/jwt/WebIdPrincipal.java
+++ b/auth/jwt/src/main/java/org/trellisldp/auth/jwt/WebIdPrincipal.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.auth.jwt;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Set;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.slf4j.Logger;
+
+/** A WebID-based principal. */
+public class WebIdPrincipal implements JsonWebToken {
+
+    private static final Logger LOGGER = getLogger(WebIdPrincipal.class);
+
+    private final JsonWebToken jwt;
+    private final String webid;
+
+    /**
+     * Create a WebID-based principal from a JWT.
+     * @param jwt the JWT
+     */
+    public WebIdPrincipal(final JsonWebToken jwt) {
+        this.jwt = jwt;
+        this.webid = getWebId(jwt);
+        LOGGER.debug("Using webid: {}", webid);
+    }
+
+    @Override
+    public <T> T getClaim(final String claim) {
+        return jwt.getClaim(claim);
+    }
+
+    @Override
+    public Set<String> getClaimNames() {
+        return jwt.getClaimNames();
+    }
+
+    @Override
+    public String getName() {
+        return webid;
+    }
+
+    static String getWebId(final JsonWebToken jwt) {
+        if (jwt.containsClaim("webid")) {
+            return jwt.getClaim("webid");
+        }
+
+        final String subject = jwt.getSubject();
+        if (isUrl(subject)) {
+            return subject;
+        }
+
+        final String issuer = jwt.getIssuer();
+        if (isUrl(issuer)) {
+            return concat(issuer, subject);
+        }
+
+        return null;
+    }
+
+    static String concat(final String issuer, final String subject) {
+        if (subject != null) {
+            if (issuer.endsWith("/")) {
+                return issuer + subject;
+            }
+            return issuer + "/" + subject;
+        }
+
+        return null;
+    }
+
+    static boolean isUrl(final String url) {
+        return url != null && (url.startsWith("http://") || url.startsWith("https://"));
+    }
+}
+

--- a/auth/jwt/src/main/java/org/trellisldp/auth/jwt/WebIdSecurityContext.java
+++ b/auth/jwt/src/main/java/org/trellisldp/auth/jwt/WebIdSecurityContext.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.auth.jwt;
+
+import java.security.Principal;
+import java.util.Set;
+
+import javax.ws.rs.core.SecurityContext;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/** A WebId-enabled SecurityContext implementation. */
+public class WebIdSecurityContext implements SecurityContext {
+
+    /** The admin role. */
+    public static final String ADMIN_ROLE = "admin";
+
+    private final JsonWebToken principal;
+    private final SecurityContext delegate;
+    private final Set<String> admins;
+
+    /**
+     * Create a WebID-based security context.
+     * @param delegate the security context delegate
+     * @param principal the principal
+     * @param admins a whitelist of admin users
+     */
+    public WebIdSecurityContext(final SecurityContext delegate, final JsonWebToken principal,
+            final Set<String> admins) {
+        this.delegate = delegate;
+        this.principal = principal != null ? new WebIdPrincipal(principal) : principal;
+        this.admins = admins;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return delegate.isSecure();
+    }
+
+    @Override
+    public String getAuthenticationScheme() {
+        return delegate.getAuthenticationScheme();
+    }
+
+    @Override
+    public boolean isUserInRole(final String role) {
+        if (ADMIN_ROLE.equals(role)) {
+            return admins.contains(principal.getName());
+        }
+        return principal.getGroups().contains(role);
+    }
+}

--- a/auth/jwt/src/main/java/org/trellisldp/auth/jwt/package-info.java
+++ b/auth/jwt/src/main/java/org/trellisldp/auth/jwt/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Trellis Microprofile Auth filter
+ *
+ * <p>This package implements a microprofile-based OAuth filter for Trellis.
+ */
+package org.trellisldp.auth.jwt;

--- a/auth/jwt/src/main/resources/META-INF/beans.xml
+++ b/auth/jwt/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>

--- a/auth/jwt/src/test/java/org/trellisldp/auth/jwt/JwtAuthFilterTest.java
+++ b/auth/jwt/src/test/java/org/trellisldp/auth/jwt/JwtAuthFilterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.auth.jwt;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import io.smallrye.jwt.auth.cdi.PrincipalProducer;
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.SecurityContext;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.jose4j.jwt.JwtClaims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+/**
+ * @author acoburn
+ */
+@ExtendWith(WeldJunit5Extension.class)
+class JwtAuthFilterTest {
+
+    @WeldSetup
+    private WeldInitiator weld = WeldInitiator.from(JwtAuthFilter.class, PrincipalProducer.class)
+                    .activate(RequestScoped.class).build();
+
+    @Inject
+    private PrincipalProducer producer;
+
+    @Inject
+    private ContainerRequestFilter filter;
+
+    @Captor
+    private ArgumentCaptor<SecurityContext> securityArgument;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    void testJwtAuthFilter() {
+        final ContainerRequestContext mockContext = mock(ContainerRequestContext.class);
+        assertNotNull(filter);
+        assertNotNull(producer);
+
+        final String iss = "https://example.com/idp/";
+        final String sub = "acoburn";
+        final JwtClaims claims = new JwtClaims();
+        claims.setSubject(sub);
+        claims.setIssuer(iss);
+
+        producer.setJsonWebToken(new DefaultJWTCallerPrincipal(claims));
+        assertDoesNotThrow(() -> filter.filter(mockContext));
+        verify(mockContext).setSecurityContext(securityArgument.capture());
+        assertEquals(iss + sub, securityArgument.getValue().getUserPrincipal().getName());
+    }
+
+    @Test
+    void testJwtAuthWebidFilter() {
+        final ContainerRequestContext mockContext = mock(ContainerRequestContext.class);
+        assertNotNull(filter);
+        assertNotNull(producer);
+
+        final String webid = "https://people.apache.org/~acoburn/#i";
+        final String iss = "https://example.com/idp/";
+        final String sub = "acoburn";
+        final JwtClaims claims = new JwtClaims();
+        claims.setSubject(sub);
+        claims.setIssuer(iss);
+        claims.setClaim("webid", webid);
+
+        producer.setJsonWebToken(new DefaultJWTCallerPrincipal(claims));
+        assertDoesNotThrow(() -> filter.filter(mockContext));
+        verify(mockContext).setSecurityContext(securityArgument.capture());
+        assertEquals(webid, securityArgument.getValue().getUserPrincipal().getName());
+    }
+
+    @Test
+    void testJwtAuthNoTokenFilter() {
+        final ContainerRequestContext mockContext = mock(ContainerRequestContext.class);
+        assertNotNull(filter);
+        assertNotNull(producer);
+
+        assertDoesNotThrow(() -> filter.filter(mockContext));
+        verify(mockContext).setSecurityContext(securityArgument.capture());
+        assertNull(securityArgument.getValue().getUserPrincipal().getName());
+    }
+}

--- a/auth/jwt/src/test/java/org/trellisldp/auth/jwt/WebIdPrincipalTest.java
+++ b/auth/jwt/src/test/java/org/trellisldp/auth/jwt/WebIdPrincipalTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.auth.jwt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jose4j.jwt.JwtClaims;
+import org.junit.jupiter.api.Test;
+
+class WebIdPrincipalTest {
+
+    @Test
+    void testBasicPrincipal() {
+        final String iss = "https://example.com/idp/";
+        final String sub = "acoburn";
+        final JwtClaims claims = new JwtClaims();
+        claims.setSubject(sub);
+        claims.setIssuer(iss);
+        final JsonWebToken principal = new WebIdPrincipal(new DefaultJWTCallerPrincipal(claims));
+        assertTrue(principal.getClaimNames().contains("sub"));
+        assertEquals(iss + sub, principal.getName());
+        assertEquals(iss, principal.getIssuer());
+        assertEquals(iss, principal.getClaim("iss"));
+    }
+
+    @Test
+    void testIssNoSlashPrincipal() {
+        final String iss = "http://idp.example.com";
+        final String sub = "acoburn";
+        final JwtClaims claims = new JwtClaims();
+        claims.setSubject(sub);
+        claims.setIssuer(iss);
+        final JsonWebToken principal = new WebIdPrincipal(new DefaultJWTCallerPrincipal(claims));
+        assertTrue(principal.getClaimNames().contains("sub"));
+        assertEquals(iss + "/" + sub, principal.getName());
+        assertEquals(iss, principal.getIssuer());
+        assertEquals(iss, principal.getClaim("iss"));
+    }
+
+    @Test
+    void testWebIdPrincipal() {
+        final String iss = "https://example.com/idp/";
+        final String sub = "acoburn";
+        final String webid = "https://example.com/profile#me";
+        final JwtClaims claims = new JwtClaims();
+        claims.setSubject(sub);
+        claims.setIssuer(iss);
+        claims.setClaim("webid", webid);
+        final JsonWebToken principal = new WebIdPrincipal(new DefaultJWTCallerPrincipal(claims));
+        assertEquals(webid, principal.getName());
+        assertEquals(iss, principal.getIssuer());
+        assertEquals(iss, principal.getClaim("iss"));
+        assertEquals(sub, principal.getClaim("sub"));
+    }
+
+    @Test
+    void testWebIdSubPrincipal() {
+        final String iss = "https://example.com/idp/";
+        final String webid = "https://example.com/profile#me";
+        final JwtClaims claims = new JwtClaims();
+        claims.setSubject(webid);
+        claims.setIssuer(iss);
+        final JsonWebToken principal = new WebIdPrincipal(new DefaultJWTCallerPrincipal(claims));
+        assertEquals(webid, principal.getName());
+        assertEquals(iss, principal.getIssuer());
+        assertEquals(iss, principal.getClaim("iss"));
+    }
+
+    @Test
+    void testNoIssuerPrincipal() {
+        final String sub = "acoburn";
+        final JwtClaims claims = new JwtClaims();
+        claims.setSubject(sub);
+        final JsonWebToken principal = new WebIdPrincipal(new DefaultJWTCallerPrincipal(claims));
+        assertNull(principal.getName());
+    }
+
+    @Test
+    void testNoSubPrincipal() {
+        final String iss = "https://example.com/idp/";
+        final JwtClaims claims = new JwtClaims();
+        claims.setIssuer(iss);
+        final JsonWebToken principal = new WebIdPrincipal(new DefaultJWTCallerPrincipal(claims));
+        assertNull(principal.getName());
+    }
+}

--- a/auth/jwt/src/test/java/org/trellisldp/auth/jwt/WebIdSecurityContextTest.java
+++ b/auth/jwt/src/test/java/org/trellisldp/auth/jwt/WebIdSecurityContextTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.auth.jwt;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
+
+import javax.ws.rs.core.SecurityContext;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jose4j.jwt.JwtClaims;
+import org.junit.jupiter.api.Test;
+
+class WebIdSecurityContextTest {
+
+    @Test
+    void testNullPrincipal() {
+        final SecurityContext ctx = new WebIdSecurityContext(null, null, emptySet());
+        assertNull(ctx.getUserPrincipal());
+    }
+
+    @Test
+    void testMockedDelegate() {
+        final SecurityContext mockDelegate = mock(SecurityContext.class);
+        when(mockDelegate.isSecure()).thenReturn(true);
+        when(mockDelegate.getAuthenticationScheme()).thenReturn("Bearer");
+
+        final SecurityContext ctx = new WebIdSecurityContext(mockDelegate, null, emptySet());
+        assertTrue(ctx.isSecure());
+        assertEquals("Bearer", ctx.getAuthenticationScheme());
+    }
+
+    @Test
+    void testAdminRoles() {
+        final SecurityContext mockDelegate = mock(SecurityContext.class);
+        final String iss = "https://example.com/idp/";
+        final String sub = "acoburn";
+        final JwtClaims claims = new JwtClaims();
+        claims.setSubject(sub);
+        claims.setIssuer(iss);
+        final JsonWebToken principal = new DefaultJWTCallerPrincipal(claims);
+
+        final SecurityContext ctx = new WebIdSecurityContext(mockDelegate, principal, singleton(iss + sub));
+        assertTrue(ctx.isUserInRole(WebIdSecurityContext.ADMIN_ROLE));
+        assertFalse(ctx.isUserInRole("other-role"));
+    }
+
+}

--- a/auth/jwt/src/test/resources/logback.xml
+++ b/auth/jwt/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%p %d{HH:mm:ss.SSS} \(%c{0}\) %m%n</pattern>
+        </encoder>
+    </appender>
+
+  <logger name="org.trellisldp" additivity="false" level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <root additivity="false" level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ ext {
     microprofileConfigVersion = '1.3'
     microprofileHealthVersion = '2.1'
     microprofileMetricsVersion = '2.2'
+    microprofileJwtVersion = '1.1.1'
     microprofileOpenapiVersion = '1.1.2'
     microprofileReactiveMessagingVersion = '1.0'
 
@@ -73,6 +74,7 @@ ext {
     sleepycatVersion = '18.3.12'
     smallryeConfigVersion = '1.3.11'
     smallryeHealthVersion = '2.1.0'
+    smallryeJwtVersion = '2.0.10'
     smallryeReactiveVersion = '1.0.8'
     smallryeReactiveOperatorsVersion = '1.0.10'
     weldVersion = '2.0.1.Final'
@@ -86,6 +88,7 @@ ext {
     interceptorVersion = '1.2.5'
     jenaOsgiVersion = '3.13.1'
     jenaVersionRange = '[3.13,4)'
+    jsonApiVersion = '1.1.6'
     kafkaOsgiVersion = '2.2.0_1'
     karafVersion = '4.2.7'
     mustacheOsgiVersion = '0.9.6_1'

--- a/core/http/src/main/java/org/trellisldp/http/core/HttpSession.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpSession.java
@@ -99,7 +99,7 @@ public class HttpSession implements Session {
      * @return the session
      */
     public static Session from(final SecurityContext security) {
-        if (security != null && security.getUserPrincipal() != null) {
+        if (security != null && security.getUserPrincipal() != null && security.getUserPrincipal().getName() != null) {
             final IRI webid = rdf.createIRI(security.getUserPrincipal().getName());
             if (security.isUserInRole(ADMIN_ROLE)) {
                 return new HttpSession(Trellis.AdministratorAgent, webid);

--- a/core/http/src/test/java/org/trellisldp/http/core/HttpSessionTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/HttpSessionTest.java
@@ -80,4 +80,17 @@ class HttpSessionTest {
         assertEquals(rdf.createIRI(agent), session.getAgent(), "Incorrect agent in admin session");
         assertFalse(session.getDelegatedBy().isPresent(), "Incorrect delegate");
     }
+
+    @Test
+    void testNullPrincipalNameHttpSession() {
+        final SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        final Principal mockPrincipal = mock(Principal.class);
+
+        when(mockSecurityContext.getUserPrincipal()).thenReturn(mockPrincipal);
+        when(mockSecurityContext.isUserInRole(eq(HttpSession.ADMIN_ROLE))).thenReturn(false);
+
+        final Session session = HttpSession.from(mockSecurityContext);
+        assertEquals(Trellis.AnonymousAgent, session.getAgent(), "Incorrect agent");
+        assertFalse(session.getDelegatedBy().isPresent(), "Incorrect delegate");
+    }
 }

--- a/platform/bom/build.gradle
+++ b/platform/bom/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':trellis-reactive')
 
     implementation project(':trellis-auth-basic')
+    implementation project(':trellis-auth-jwt')
     implementation project(':trellis-auth-oauth')
 
     implementation project(':trellis-app')

--- a/platform/karaf/src/main/resources/features.xml
+++ b/platform/karaf/src/main/resources/features.xml
@@ -258,7 +258,6 @@
     <details>Installs the OAuth package</details>
 
     <feature prerequisite="true">wrap</feature>
-    <feature dependency="true">trellis-vocabulary</feature>
 
     <bundle dependency="true">wrap:mvn:io.jsonwebtoken/jjwt-api/${jjwtVersion}</bundle>
     <bundle dependency="true">wrap:mvn:io.jsonwebtoken/jjwt-impl/${jjwtVersion}</bundle>
@@ -269,24 +268,38 @@
     <bundle dependency="true">mvn:jakarta.interceptor/jakarta.interceptor-api/${interceptorVersion}</bundle>
     <bundle dependency="true">mvn:jakarta.ws.rs/jakarta.ws.rs-api/${jaxrsApiVersion}</bundle>
     <bundle dependency="true">mvn:jakarta.xml.bind/jakarta.xml.bind-api/${jaxbApiVersion}</bundle>
-    <bundle dependency="true">mvn:org.apache.commons/commons-rdf-api/${commonsRdfVersion}</bundle>
     <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
     <bundle dependency="true">mvn:org.eclipse.microprofile.config/microprofile-config-api/${microprofileConfigVersion}</bundle>
 
     <bundle>mvn:org.trellisldp/trellis-auth-oauth/${project.version}</bundle>
   </feature>
 
+  <feature name="trellis-auth-jwt" version="${project.version}">
+    <details>Installs the microprofile jwt auth package</details>
+
+    <!-- microprofile-auth-jwt depends on 1.x version of cdi -->
+    <bundle dependency="true">mvn:javax.enterprise/cdi-api/1.2</bundle>
+
+    <bundle dependency="true">mvn:jakarta.json.bind/jakarta.json.bind-api/${jsonbApiVersion}</bundle>
+    <bundle dependency="true">mvn:jakarta.json/jakarta.json-api/${jsonApiVersion}</bundle>
+    <bundle dependency="true">mvn:jakarta.ws.rs/jakarta.ws.rs-api/${jaxrsApiVersion}</bundle>
+    <bundle dependency="true">mvn:jakarta.xml.bind/jakarta.xml.bind-api/${jaxbApiVersion}</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
+    <bundle dependency="true">mvn:org.eclipse.microprofile.config/microprofile-config-api/${microprofileConfigVersion}</bundle>
+    <bundle dependency="true">mvn:org.eclipse.microprofile.jwt/microprofile-jwt-auth-api/${microprofileJwtVersion}</bundle>
+
+    <bundle>mvn:org.trellisldp/trellis-auth-jwt/${project.version}</bundle>
+  </feature>
+
+
   <feature name="trellis-auth-basic" version="${project.version}">
     <details>Installs the basic auth package</details>
-
-    <feature dependency="true">trellis-vocabulary</feature>
 
     <bundle dependency="true">mvn:jakarta.el/jakarta.el-api/${elVersion}</bundle>
     <bundle dependency="true">mvn:jakarta.enterprise/jakarta.enterprise.cdi-api/${cdiApiVersion}</bundle>
     <bundle dependency="true">mvn:jakarta.interceptor/jakarta.interceptor-api/${interceptorVersion}</bundle>
     <bundle dependency="true">mvn:jakarta.ws.rs/jakarta.ws.rs-api/${jaxrsApiVersion}</bundle>
     <bundle dependency="true">mvn:jakarta.xml.bind/jakarta.xml.bind-api/${jaxbApiVersion}</bundle>
-    <bundle dependency="true">mvn:org.apache.commons/commons-rdf-api/${commonsRdfVersion}</bundle>
     <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
     <bundle dependency="true">mvn:org.eclipse.microprofile.config/microprofile-config-api/${microprofileConfigVersion}</bundle>
 

--- a/platform/osgi/build.gradle
+++ b/platform/osgi/build.gradle
@@ -29,20 +29,11 @@ sonarqube {
 }
 
 dependencies {
-    implementation "org.apache.jena:jena-osgi:$jenaVersion"
-    implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
-    implementation project(':trellis-api')
-    implementation project(':trellis-http')
-    implementation project(':trellis-io-jena')
-    implementation project(':trellis-namespaces')
-    implementation project(':trellis-vocabulary')
-    implementation project(':trellis-triplestore')
-
-    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
-
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "org.apache.commons:commons-compress:$commonsCompressVersion"
     testImplementation "org.apache.karaf.features:standard:$karafVersion"
     testImplementation "org.apache.karaf.features:org.apache.karaf.features.core:$karafVersion"
+    testImplementation "org.apache.jena:jena-osgi:$jenaVersion"
     testImplementation "org.ops4j.pax.exam:pax-exam:$paxExamVersion"
     testImplementation "org.ops4j.pax.exam:pax-exam-junit4:$paxExamVersion"
     testImplementation "org.ops4j.pax.exam:pax-exam-container-karaf:$paxExamVersion"
@@ -50,6 +41,8 @@ dependencies {
     testImplementation "org.osgi:org.osgi.compendium:$osgiCompendiumVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.glassfish.hk2.external:javax.inject:$glassfishInjectVersion"
+
+    testImplementation project(':trellis-api')
     testImplementation project(':trellis-amqp')
     testImplementation project(':trellis-app')
     testImplementation project(':trellis-audit')
@@ -59,14 +52,19 @@ dependencies {
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-event-jsonb')
     testImplementation project(':trellis-file')
+    testImplementation project(':trellis-http')
+    testImplementation project(':trellis-io-jena')
     testImplementation project(':trellis-jms')
     testImplementation project(':trellis-kafka')
+    testImplementation project(':trellis-namespaces')
     testImplementation project(':trellis-triplestore')
     testImplementation project(':trellis-webac')
     testImplementation project(':trellis-karaf')
+    testImplementation project(':trellis-vocabulary')
 
     testImplementation group: 'org.apache.karaf.features', name: 'standard', version: karafVersion, classifier:'features', ext: 'xml'
 
+    testRuntimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
     testRuntimeClasspath "org.junit.vintage:junit-vintage-engine:${junitVersion}"
 
     karafDistro group: 'org.apache.karaf', name: 'apache-karaf', version: karafVersion, ext: 'zip'

--- a/platform/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
+++ b/platform/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
@@ -221,6 +221,16 @@ public class OSGiTest {
     }
 
     @Test
+    public void testJwtAuthAuthInstallation() throws Exception {
+        assertFalse("trellis-auth-jwt already installed!",
+                featuresService.isInstalled(featuresService.getFeature("trellis-auth-jwt")));
+        featuresService.installFeature("trellis-auth-jwt");
+        checkTrellisBundlesAreActive();
+        assertTrue("trellis-auth-jwt not installed!",
+                featuresService.isInstalled(featuresService.getFeature("trellis-auth-jwt")));
+    }
+
+    @Test
     public void testOAuthAuthInstallation() throws Exception {
         assertFalse("trellis-auth-oauth already installed!",
                 featuresService.isInstalled(featuresService.getFeature("trellis-auth-oauth")));

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -6,7 +6,7 @@ def installForQuarkus = [
     "trellis-api",
     "trellis-app",
     "trellis-audit",
-    "trellis-auth-oauth",
+    "trellis-auth-jwt",
     "trellis-cache",
     "trellis-cdi",
     "trellis-constraint-rules",
@@ -27,7 +27,7 @@ dependencies {
     implementation "org.trellisldp:trellis-api:${project.version}"
     implementation "org.trellisldp:trellis-app:${project.version}"
     implementation "org.trellisldp:trellis-audit:${project.version}"
-    implementation "org.trellisldp:trellis-auth-oauth:${project.version}"
+    implementation "org.trellisldp:trellis-auth-jwt:${project.version}"
     implementation "org.trellisldp:trellis-cache:${project.version}"
     implementation "org.trellisldp:trellis-cdi:${project.version}"
     implementation "org.trellisldp:trellis-constraint-rules:${project.version}"
@@ -45,6 +45,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-security'
     implementation 'io.quarkus:quarkus-smallrye-health'
+    implementation 'io.quarkus:quarkus-smallrye-jwt'
     implementation 'io.quarkus:quarkus-smallrye-metrics'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
@@ -57,7 +58,6 @@ dependencies {
     implementation "org.apache.jena:jena-arq:$jenaVersion"
     implementation "org.apache.jena:jena-rdfconnection:$jenaVersion"
     implementation "org.apache.jena:jena-tdb2:$jenaVersion"
-
 
     runtimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
     runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
@@ -72,6 +72,7 @@ test {
     systemProperty 'trellis.file.memento.basepath', "$buildDir/data/mementos"
     systemProperty 'trellis.triplestore.rdf.location', "$buildDir/data/rdf"
     systemProperty 'trellis.namespace.prefixes', 'dc11=http://purl.org/dc/elements/1.1/,,foo= , =bar,baz, = '
+    systemProperty 'mp.jwt.verify.publickey.location', 'https://www.trellisldp.org/tests/jwks.json'
 }
 
 sonarqube {

--- a/platform/quarkus/src/main/resources/application.properties
+++ b/platform/quarkus/src/main/resources/application.properties
@@ -58,3 +58,7 @@ quarkus.http.cors.access-control-max-age=24H
 # HTTP
 quarkus.http.port=8080
 
+# JWT
+mp.jwt.verify.issuer=
+mp.jwt.verify.publickey=
+mp.jwt.verify.publickey.location=

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,7 @@ include ':trellis-reactive'
 
 include ':trellis-auth-oauth'
 include ':trellis-auth-basic'
+include ':trellis-auth-jwt'
 
 include ':trellis-app'
 include ':trellis-audit'
@@ -64,6 +65,7 @@ project(':trellis-reactive').projectDir = "$rootDir/notifications/reactive" as F
 
 project(':trellis-auth-oauth').projectDir = "$rootDir/auth/oauth" as File
 project(':trellis-auth-basic').projectDir = "$rootDir/auth/basic" as File
+project(':trellis-auth-jwt').projectDir = "$rootDir/auth/jwt" as File
 
 project(':trellis-app').projectDir = "$rootDir/components/app" as File
 project(':trellis-app-triplestore').projectDir = "$rootDir/components/app-triplestore" as File


### PR DESCRIPTION
Resolves #508

This adds a microprofile-based authentication module. Effectively, it's a JAX-RS filter that takes the injected `JsonWebToken` and puts it into a `SecurityContext` that ensures that the `Principal` name is a WebID.

This module is, effectively, a microprofile version of `trellis-auth-oauth`