### PR TITLE
Use trailing slashes for containers

### DIFF
--- a/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/TrellisApplicationTest.java
+++ b/components/app-triplestore/src/test/java/org/trellisldp/app/triplestore/TrellisApplicationTest.java
@@ -194,6 +194,12 @@ class TrellisApplicationTest implements MessageListener {
     @Nested
     @DisplayName("Trellis Event Tests")
     class EventTests extends AbstractApplicationEventTests {
+
+        @BeforeEach
+        public void before() {
+            TrellisApplicationTest.this.MESSAGES.clear();
+        }
+
         @Override
         public Client getClient() {
             return TrellisApplicationTest.this.CLIENT;

--- a/components/test/src/main/java/org/trellisldp/test/LdpBasicContainerTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpBasicContainerTests.java
@@ -175,7 +175,7 @@ public interface LdpBasicContainerTests extends CommonTests {
     default void testPatchNewRDF() throws Exception {
         final RDF rdf = getInstance();
         // PATCH an LDP-RS
-        final String location = getContainerLocation() + "/" + generateRandomValue("PATCH");
+        final String location = getContainerLocation() + generateRandomValue("PATCH");
         assumeTrue(getConfig().getOptionalValue(CONFIG_HTTP_PATCH_CREATE, Boolean.class)
             .orElse(Boolean.TRUE));
         try (final Response res = target(location).request()
@@ -242,14 +242,14 @@ public interface LdpBasicContainerTests extends CommonTests {
     default void testCreateContainerViaPut() throws Exception {
         final RDF rdf = getInstance();
         final String containerContent = getResourceAsString(BASIC_CONTAINER);
-        final String child4 = getContainerLocation() + "/child4";
         final boolean createUncontained = getConfig().getOptionalValue(CONFIG_HTTP_PUT_UNCONTAINED, Boolean.class)
             .orElse(Boolean.FALSE);
 
         // First fetch the container headers to get the initial ETag
         final EntityTag initialETag = getETag(getContainerLocation());
+        final String child4 = getContainerLocation() + "child4/";
 
-        try (final Response res = target(child4).request()
+        try (final Response res = target(getContainerLocation() + "child4").request()
                 .header(LINK, fromUri(LDP.BasicContainer.getIRIString()).rel(TYPE).build())
                 .put(entity(containerContent, TEXT_TURTLE))) {
             assertAll("Check PUTting an LDP-BC", checkRdfResponse(res, LDP.BasicContainer, null));
@@ -284,17 +284,17 @@ public interface LdpBasicContainerTests extends CommonTests {
     default void testCreateContainerWithSlug() throws Exception {
         final RDF rdf = getInstance();
         final String containerContent = getResourceAsString(BASIC_CONTAINER);
-        final String child5 = getContainerLocation() + "/child5";
 
         // First fetch the container headers to get the initial ETag
         final EntityTag initialETag = getETag(getContainerLocation());
+        final String child5;
 
         // POST an LDP-BC
         try (final Response res = target(getContainerLocation()).request().header("Slug", "child5")
                 .header(LINK, fromUri(LDP.BasicContainer.getIRIString()).rel(TYPE).build())
                 .post(entity(containerContent, TEXT_TURTLE))) {
             assertAll("Check POSTing an LDP-BC", checkRdfResponse(res, LDP.BasicContainer, null));
-            assertEquals(child5, res.getLocation().toString(), "Check the resource location");
+            child5 = res.getLocation().toString();
         }
 
         await().until(() -> !initialETag.equals(getETag(getContainerLocation())));

--- a/components/test/src/main/java/org/trellisldp/test/LdpDirectContainerTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpDirectContainerTests.java
@@ -58,8 +58,8 @@ import org.trellisldp.vocabulary.Trellis;
 @DisplayName("Direct Container Tests")
 public interface LdpDirectContainerTests extends CommonTests {
 
-    String MEMBER_RESOURCE1 = "/members1";
-    String MEMBER_RESOURCE2 = "/members2";
+    String MEMBER_RESOURCE1 = "members1";
+    String MEMBER_RESOURCE2 = "members2/";
     String MEMBER_RESOURCE_HASH = "#members";
     String BASIC_CONTAINER = "/basicContainer.ttl";
     String DIRECT_CONTAINER = "/directContainer.ttl";

--- a/components/test/src/main/java/org/trellisldp/test/LdpIndirectContainerTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpIndirectContainerTests.java
@@ -59,7 +59,7 @@ import org.trellisldp.vocabulary.Trellis;
 public interface LdpIndirectContainerTests extends CommonTests {
 
     String BASIC_CONTAINER = "/basicContainer.ttl";
-    String MEMBER_RESOURCE2 = "/members2";
+    String MEMBER_RESOURCE2 = "members2";
     String MEMBER_RESOURCE_HASH = "#members";
     String SIMPLE_RESOURCE = "/simpleResource.ttl";
     String DIRECT_CONTAINER = "/directContainer.ttl";
@@ -123,7 +123,7 @@ public interface LdpIndirectContainerTests extends CommonTests {
             setContainerLocation(res.getLocation().toString());
         }
 
-        setMemberLocation(getContainerLocation() + "/member");
+        setMemberLocation(getContainerLocation() + "member");
 
         final String content = getResourceAsString(INDIRECT_CONTAINER)
             + membershipResource(getMemberLocation());

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -30,11 +30,11 @@ import static org.apache.jena.tdb2.DatabaseMgr.connectDatasetGraph;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
+import static org.trellisldp.api.TrellisUtils.normalizeIdentifier;
 import static org.trellisldp.triplestore.TriplestoreUtils.OBJECT;
 import static org.trellisldp.triplestore.TriplestoreUtils.PREDICATE;
 import static org.trellisldp.triplestore.TriplestoreUtils.SUBJECT;
 import static org.trellisldp.triplestore.TriplestoreUtils.asJenaDataset;
-import static org.trellisldp.triplestore.TriplestoreUtils.getBaseIRI;
 import static org.trellisldp.triplestore.TriplestoreUtils.getInstance;
 import static org.trellisldp.triplestore.TriplestoreUtils.getObject;
 import static org.trellisldp.vocabulary.Trellis.DeletedResource;
@@ -175,7 +175,7 @@ public class TriplestoreResourceService implements ResourceService {
 
         // Relocate some user-managed triples into the server-managed graph
         metadata.getMembershipResource().ifPresent(member -> {
-            dataset.add(PreferServerManaged, metadata.getIdentifier(), LDP.member, getBaseIRI(member));
+            dataset.add(PreferServerManaged, metadata.getIdentifier(), LDP.member, normalizeIdentifier(member));
             dataset.add(PreferServerManaged, metadata.getIdentifier(), LDP.membershipResource, member);
         });
 

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreUtils.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreUtils.java
@@ -42,6 +42,7 @@ final class TriplestoreUtils {
     public static final Var SUBJECT = Var.alloc("subject");
     public static final Var PREDICATE = Var.alloc("predicate");
     public static final Var OBJECT = Var.alloc("object");
+    public static final Var TYPE = Var.alloc("type");
 
     public static JenaRDF getInstance() {
         return rdf;
@@ -59,12 +60,8 @@ final class TriplestoreUtils {
         return rdf.asRDFTerm(qs.get("object").asNode());
     }
 
-    public static RDFTerm getBaseIRI(final RDFTerm object) {
-        if (object instanceof IRI) {
-            final String iri = ((IRI) object).getIRIString().split("#")[0];
-            return rdf.createIRI(iri);
-        }
-        return object;
+    public static IRI getType(final QuerySolution qs) {
+        return (IRI) rdf.asRDFTerm(qs.get("type").asNode());
     }
 
     public static Optional<Triple> nodesToTriple(final RDFNode s, final RDFNode p, final RDFNode o) {

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
@@ -192,7 +192,10 @@ class TriplestoreResourceTest {
     void testResourceWithChildren() {
         final JenaDataset dataset = buildLdpDataset(LDP.Container);
         dataset.add(Trellis.PreferServerManaged, identifier, DC.isPartOf, root);
-        getChildIRIs().forEach(c -> dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier));
+        getChildIRIs().forEach(c -> {
+            dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier);
+            dataset.add(Trellis.PreferServerManaged, c, RDF.type, LDP.RDFSource);
+        });
 
         final TriplestoreResource res = new TriplestoreResource(connect(wrap(dataset.asJenaDatasetGraph())),
                 identifier, false);
@@ -229,7 +232,10 @@ class TriplestoreResourceTest {
         dataset.add(Trellis.PreferServerManaged, identifier, LDP.insertedContentRelation, LDP.MemberSubject);
         dataset.add(Trellis.PreferServerManaged, identifier, DC.modified, rdf.createLiteral(time, XSD.dateTime));
         dataset.add(Trellis.PreferServerManaged, member, DC.isPartOf, root);
-        getChildIRIs().forEach(c -> dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier));
+        getChildIRIs().forEach(c -> {
+            dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier);
+            dataset.add(Trellis.PreferServerManaged, c, RDF.type, LDP.RDFSource);
+        });
 
         final RDFConnection rdfConnection = connect(wrap(dataset.asJenaDatasetGraph()));
         final TriplestoreResource res = new TriplestoreResource(rdfConnection, identifier, true);
@@ -264,6 +270,7 @@ class TriplestoreResourceTest {
         dataset.add(member, member, DC.alternative, rdf.createLiteral("A membership resource"));
         getChildIRIs().forEach(c -> {
             dataset.add(Trellis.PreferServerManaged, c, DC.isPartOf, identifier);
+            dataset.add(Trellis.PreferServerManaged, c, RDF.type, LDP.RDFSource);
             dataset.add(c, c, DC.subject, rdf.createIRI("http://example.org/" + randomUUID()));
         });
 

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreUtilsTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreUtilsTest.java
@@ -74,19 +74,6 @@ class TriplestoreUtilsTest {
     }
 
     @Test
-    void testBaseIRItruncate() {
-        final IRI iri = jenaRdf.createIRI("http://example.com/resource#i");
-        assertEquals(jenaRdf.createIRI("http://example.com/resource"), TriplestoreUtils.getBaseIRI(iri),
-                "Check that fragment URLs are removed");
-    }
-
-    @Test
-    void testBaseIRInoTruncate() {
-        final IRI iri = jenaRdf.createIRI("http://example.com/resource");
-        assertEquals(iri, TriplestoreUtils.getBaseIRI(iri), "Check that fragment URLs are removed");
-    }
-
-    @Test
     void testNodeConversion() {
         final Resource s = createResource("http://example.com/Resource");
         final Property p = createProperty("http://example.com/prop");
@@ -99,11 +86,5 @@ class TriplestoreUtilsTest {
         assertFalse(TriplestoreUtils.nodesToTriple(s, null, o).isPresent(), "null node results in a valid triple!");
         assertFalse(TriplestoreUtils.nodesToTriple(null, p, o).isPresent(), "null node results in a valid triple!");
         assertTrue(TriplestoreUtils.nodesToTriple(s, p, o).isPresent(), "Nodes not converted to triple!");
-    }
-
-    @Test
-    void testBaseIRIliteral() {
-        final Literal l = jenaRdf.createLiteral("a literal");
-        assertEquals(l, TriplestoreUtils.getBaseIRI(l), "Incorrect literal value!");
     }
 }

--- a/components/webac/src/main/java/org/trellisldp/webac/WebAcFilter.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebAcFilter.java
@@ -175,10 +175,11 @@ public class WebAcFilter implements ContainerRequestFilter, ContainerResponseFil
     @Override
     public void filter(final ContainerRequestContext ctx) {
         final String path = ctx.getUriInfo().getPath();
+        final String normalized = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
         final Session s = HttpSession.from(ctx.getSecurityContext());
         final String method = ctx.getMethod();
 
-        final Set<IRI> modes = accessService.getAccessModes(rdf.createIRI(TRELLIS_DATA_PREFIX + path), s);
+        final Set<IRI> modes = accessService.getAccessModes(rdf.createIRI(TRELLIS_DATA_PREFIX + normalized), s);
         if (ctx.getUriInfo().getQueryParameters().getOrDefault(HttpConstants.EXT, emptyList())
                 .contains(HttpConstants.ACL) || reqAudit(ctx)) {
             verifyCanControl(modes, s, path);

--- a/components/webac/src/test/java/org/trellisldp/webac/AuthorizationTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/AuthorizationTest.java
@@ -94,4 +94,15 @@ class AuthorizationTest {
         assertEquals(1, auth.getDefault().size(), "Incorrect number of default values!");
         assertTrue(auth.getDefault().contains(rdf.createIRI("trellis:data/container")), "missing default value!");
     }
+
+    @Test
+    void testNormalizeIdentifier() {
+        final IRI iri = rdf.createIRI("trellis:data/resource");
+        final IRI iriSlash = rdf.createIRI("trellis:data/resource/");
+        final IRI root = rdf.createIRI("trellis:data/");
+        assertEquals(iri, Authorization.normalizeIdentifier(rdf.createTriple(subject, ACL.accessTo, iri)));
+        assertEquals(iri, Authorization.normalizeIdentifier(rdf.createTriple(subject, ACL.accessTo, iriSlash)));
+        assertEquals(root, Authorization.normalizeIdentifier(rdf.createTriple(subject, ACL.accessTo, root)));
+        assertNull(Authorization.normalizeIdentifier(rdf.createTriple(subject, ACL.accessTo, rdf.createBlankNode())));
+    }
 }

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
@@ -140,6 +140,26 @@ class WebAcFilterTest {
     }
 
     @Test
+    void testFilterReadSlashPath() {
+        final Set<IRI> modes = new HashSet<>();
+        when(mockContext.getMethod()).thenReturn("GET");
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
+        when(mockUriInfo.getPath()).thenReturn("container/");
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        modes.add(ACL.Read);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
+
+        modes.clear();
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
+                "No expception thrown when not authorized!");
+
+        when(mockContext.getSecurityContext()).thenReturn(mockSecurityContext);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
+    }
+
+    @Test
     void testFilterCustomRead() {
         final Set<IRI> modes = new HashSet<>();
         when(mockContext.getMethod()).thenReturn("READ");

--- a/components/webdav/src/test/java/org/trellisldp/webdav/AbstractWebDAVTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/AbstractWebDAVTest.java
@@ -180,7 +180,7 @@ abstract class AbstractWebDAVTest extends JerseyTest {
         final Response res = target(CHILD_PATH).request().method("MKCOL");
 
         assertEquals(SC_CREATED, res.getStatus(), "Unexpected response code!");
-        assertEquals(getBaseUri() + CHILD_PATH, res.getLocation().toString(), "Incorrect Location header!");
+        assertEquals(getBaseUri() + CHILD_PATH + "/", res.getLocation().toString(), "Incorrect Location header!");
     }
 
     @Test

--- a/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
+++ b/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
@@ -98,6 +98,25 @@ public final class TrellisUtils {
     }
 
     /**
+     * For any identifier, normalize its form to remove any hashURIs or trailing slashes.
+     * @param identifier the identifier
+     * @return a normalized identifier
+     */
+    public static IRI normalizeIdentifier(final IRI identifier) {
+        final String iri = identifier.getIRIString();
+        if (iri.contains("#")) {
+            final String normalized = iri.split("#")[0];
+            if (normalized.endsWith("/")) {
+                return rdf.createIRI(normalized.substring(0, normalized.length() - 1));
+            }
+            return rdf.createIRI(normalized);
+        } else if (iri.endsWith("/") && !TRELLIS_DATA_PREFIX.equals(iri)) {
+            return rdf.createIRI(iri.substring(0, iri.length() - 1));
+        }
+        return identifier;
+    }
+
+    /**
      * Collect a stream of Triples into a Graph.
      *
      * @return a graph

--- a/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
@@ -17,6 +17,7 @@ import static java.util.Optional.of;
 import static java.util.stream.Stream.generate;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.condition.JRE.JAVA_8;
+import static org.trellisldp.api.TrellisUtils.TRELLIS_DATA_PREFIX;
 import static org.trellisldp.api.TrellisUtils.getInstance;
 import static org.trellisldp.api.TrellisUtils.toDataset;
 import static org.trellisldp.api.TrellisUtils.toGraph;
@@ -69,15 +70,31 @@ class TrellisUtilsTest {
         }
     }
 
+    @Test
+    void testNormalizeIdentifier() {
+        final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
+        final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
+        final IRI resourceSlash = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource/");
+        final IRI child = rdf.createIRI("trellis:data/resource/child");
+        final IRI childHash = rdf.createIRI("trellis:data/resource/child#hash");
+        final IRI childSlashHash = rdf.createIRI("trellis:data/resource/child/#hash");
+        assertEquals(root, TrellisUtils.normalizeIdentifier(root));
+        assertEquals(resource, TrellisUtils.normalizeIdentifier(resource));
+        assertEquals(resource, TrellisUtils.normalizeIdentifier(resourceSlash));
+        assertEquals(child, TrellisUtils.normalizeIdentifier(child));
+        assertEquals(child, TrellisUtils.normalizeIdentifier(childHash));
+        assertEquals(child, TrellisUtils.normalizeIdentifier(childSlashHash));
+    }
+
     private IRI getIRI() {
         return rdf.createIRI("ex:" + generator.generate(5));
     }
 
     @Test
     void testGetContainer() {
-        final IRI root = rdf.createIRI("trellis:data/");
-        final IRI resource = rdf.createIRI("trellis:data/resource");
-        final IRI child = rdf.createIRI("trellis:data/resource/child");
+        final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
+        final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
+        final IRI child = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource/child");
         assertEquals(of(root), TrellisUtils.getContainer(resource), "Resource parent isn't the root resource!");
         assertEquals(of(resource), TrellisUtils.getContainer(child), "Child resource doesn't point to parent!");
         assertFalse(TrellisUtils.getContainer(root).isPresent(), "Root resource has a parent!");

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
@@ -24,9 +24,7 @@ import static javax.ws.rs.Priorities.AUTHORIZATION;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
-import static javax.ws.rs.core.Response.seeOther;
 import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.UriBuilder.fromUri;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 import static org.trellisldp.http.core.HttpConstants.*;
 import static org.trellisldp.http.core.TrellisExtensions.buildExtensionMapFromConfig;
@@ -77,7 +75,6 @@ public class TrellisHttpFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(final ContainerRequestContext ctx) {
-        checkTrailingSlash(ctx);
         // Validate headers
         validateAcceptDatetime(ctx);
         validateRange(ctx);
@@ -93,15 +90,6 @@ public class TrellisHttpFilter implements ContainerRequestFilter {
                         singletonList(extensions.get(ext).getIRIString()),
                         asList(PreferUserManaged.getIRIString(), PreferContainment.getIRIString(),
                             PreferMembership.getIRIString()), null, null).toString());
-        }
-    }
-
-    private void checkTrailingSlash(final ContainerRequestContext ctx) {
-        final String slash = "/";
-        // Check for a trailing slash. If so, redirect
-        final String path = ctx.getUriInfo().getPath();
-        if (path.endsWith(slash) && !path.equals(slash)) {
-            ctx.abortWith(seeOther(fromUri(path.substring(0, path.length() - 1)).build()).build());
         }
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -457,9 +457,15 @@ public class TrellisHttpResource {
 
     private Response handleException(final Throwable err) {
         final Throwable cause = err.getCause();
-        if (cause instanceof ClientErrorException) LOGGER.debug("Client error: ", err);
-        else if (cause instanceof RedirectionException) LOGGER.debug("Redirection: ", err);
-        else LOGGER.error("Error:", err);
+        if (cause instanceof ClientErrorException) {
+            LOGGER.debug("Client error: {}", err.getMessage());
+            LOGGER.trace("Client error: ", err);
+        } else if (cause instanceof RedirectionException) {
+            LOGGER.debug("Redirection: {}", err.getMessage());
+            LOGGER.trace("Redirection: ", err);
+        } else {
+            LOGGER.error("Error:", err);
+        }
         return cause instanceof WebApplicationException
                         ? ((WebApplicationException) cause).getResponse()
                         : new WebApplicationException(err).getResponse();

--- a/core/http/src/main/java/org/trellisldp/http/core/TrellisRequest.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/TrellisRequest.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.UriInfo;
  */
 public class TrellisRequest {
 
+    private final boolean trailingSlash;
     private final String path;
     private final String baseUrl;
     private final String method;
@@ -73,6 +74,7 @@ public class TrellisRequest {
         this.parameters = uriInfo.getQueryParameters();
         this.baseUrl = uriInfo.getBaseUri().toString();
         this.path = uriInfo.getPathParameters().getFirst("path");
+        this.trailingSlash = uriInfo.getPath().endsWith("/");
 
         // Extract request method
         this.method = request.getMethod();
@@ -146,10 +148,26 @@ public class TrellisRequest {
     /**
      * Get the path.
      *
-     * @return the path
+     * <p>This method returns a normalized resource path for use with internal
+     * identifiers. That means that any trailing slash will not be present. Please
+     * see the {@link #hasTrailingSlash} method to check for a trailing slash.
+     *
+     * @return the normalized path
      */
     public String getPath() {
+        if (path.endsWith("/")) {
+            return path.substring(0, path.length() - 1);
+        }
         return path;
+    }
+
+    /**
+     * Test whether the path has a trailing slash.
+     *
+     * @return true if the request path ends in a slash
+     */
+    public boolean hasTrailingSlash() {
+        return trailingSlash;
     }
 
     /**

--- a/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
@@ -23,6 +23,7 @@ import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static javax.ws.rs.core.Response.notModified;
 import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.UriBuilder.fromUri;
 import static org.apache.commons.lang3.StringUtils.strip;
 import static org.apache.commons.rdf.api.RDFSyntax.RDFA;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
@@ -60,6 +61,7 @@ import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
 import org.trellisldp.api.RuntimeTrellisException;
 import org.trellisldp.http.core.Prefer;
+import org.trellisldp.http.core.TrellisRequest;
 import org.trellisldp.vocabulary.LDP;
 import org.trellisldp.vocabulary.Trellis;
 
@@ -97,6 +99,19 @@ public final class HttpUtils {
             ldpResourceTypes(superClass).forEach(supertypes);
         }
         return supertypes.build();
+    }
+
+    /**
+     * Test matching an identifier, irrespective of trailing slash.
+     * @param subject the subject of a triple
+     * @param identifier the identifier
+     * @return a triple predicate
+     */
+    public static boolean matchIdentifier(final BlankNodeOrIRI subject, final IRI identifier) {
+        if (subject.equals(identifier)) {
+            return true;
+        }
+        return subject instanceof IRI && ((IRI) subject).getIRIString().equals(identifier.getIRIString() + "/");
     }
 
     /**
@@ -369,6 +384,16 @@ public final class HttpUtils {
         } catch (final Exception ex) {
             throw new RuntimeTrellisException("Error closing dataset", ex);
         }
+    }
+
+    /**
+     * Build a canonical url for a resource.
+     * @param req the trellis request
+     * @param baseUrl the base url
+     * @return an absolute URL
+     */
+    public static String buildResourceUrl(final TrellisRequest req, final String baseUrl) {
+        return fromUri(baseUrl).path(req.getPath() + (req.hasTrailingSlash() ? "/" : "")).build().toString();
     }
 
     private HttpUtils() {

--- a/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
@@ -103,7 +103,7 @@ public final class MementoResource {
             final String baseUrl) {
 
         final List<MediaType> acceptableTypes = req.getAcceptableMediaTypes();
-        final String identifier = fromUri(baseUrl).path(req.getPath()).build().toString();
+        final String identifier = HttpUtils.buildResourceUrl(req, baseUrl);
         final List<Link> allLinks = getMementoLinks(identifier, mementos).collect(toList());
 
         final ResponseBuilder builder = ok().link(identifier, ORIGINAL + " " + TIMEGATE);
@@ -136,7 +136,7 @@ public final class MementoResource {
      */
     public ResponseBuilder getTimeGateBuilder(final SortedSet<Instant> mementos, final TrellisRequest req,
             final String baseUrl) {
-        final String identifier = fromUri(baseUrl).path(req.getPath()).build().toString();
+        final String identifier = HttpUtils.buildResourceUrl(req, baseUrl);
         return status(FOUND)
             .location(fromUri(identifier + VERSION_PARAM + req.getDatetime().getInstant().getEpochSecond()).build())
             .link(identifier, ORIGINAL + " " + TIMEGATE)

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -183,7 +183,9 @@ public class PatchHandler extends MutatingLdpHandler {
 
     @Override
     protected String getIdentifier() {
-        return super.getIdentifier() + (getExtensionGraphName() != null ? "?ext=" + getRequest().getExt() : "");
+        final boolean isContainer = getResource() != null && HttpUtils.isContainer(getResource().getInteractionModel());
+        return super.getIdentifier() + (isContainer ? "/" : "")
+            + (getExtensionGraphName() != null ? "?ext=" + getRequest().getExt() : "");
     }
 
     private List<Triple> updateGraph(final RDFSyntax syntax, final IRI graphName) {
@@ -198,8 +200,7 @@ public class PatchHandler extends MutatingLdpHandler {
                 }
             }
 
-            getServices().getIOService().update(graph, updateBody, syntax, getBaseUrl() + getRequest().getPath() +
-                (getExtensionGraphName() != null ? "?ext=" + getRequest().getExt() : ""));
+            getServices().getIOService().update(graph, updateBody, syntax, getIdentifier());
             triples = graph.stream().filter(triple -> !RDF.type.equals(triple.getPredicate())
                 || !triple.getObject().ntriplesString().startsWith("<" + LDP.getNamespace())).collect(toList());
         } catch (final Exception ex) {

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -95,7 +95,6 @@ public class PostHandler extends MutatingLdpHandler {
         super(req, trellis, extensions, baseUrl, entity);
 
         final String separator = req.getPath().isEmpty() ? "" : "/";
-
         this.idPath = separator + id;
         this.contentType = req.getContentType();
         this.parentIdentifier = parentIdentifier;
@@ -209,6 +208,7 @@ public class PostHandler extends MutatingLdpHandler {
 
         getAuditQuadData().forEachOrdered(immutable::add);
 
+        LOGGER.info("Creating resource");
         return persistPromise.thenCompose(future -> handleResourceCreation(metadata.build(), mutable, immutable))
             .thenCompose(future -> emitEvent(internalId, AS.Create, ldpType))
             .thenApply(future -> {
@@ -219,7 +219,7 @@ public class PostHandler extends MutatingLdpHandler {
 
     @Override
     protected String getIdentifier() {
-        return super.getIdentifier() + idPath;
+        return super.getIdentifier() + idPath + (HttpUtils.isContainer(ldpType) ? "/" : "");
     }
 
     @Override

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -163,7 +163,7 @@ public class PutHandler extends MutatingLdpHandler {
 
         final Dataset mutable = rdf.createDataset();
         final Dataset immutable = rdf.createDataset();
-        LOGGER.debug("Persisting {} with mutable data:\n{}\n and immutable data:\n{}", getIdentifier(), mutable,
+        LOGGER.trace("Persisting {} with mutable data:\n{}\n and immutable data:\n{}", getIdentifier(), mutable,
                         immutable);
         return handleResourceUpdate(mutable, immutable, builder, ldpType)
             .whenComplete((a, b) -> closeDataset(mutable))
@@ -177,7 +177,8 @@ public class PutHandler extends MutatingLdpHandler {
 
     @Override
     protected String getIdentifier() {
-        return super.getIdentifier() + (getExtensionGraphName() != null ? "?ext=" + getRequest().getExt() : "");
+        return super.getIdentifier() + (HttpUtils.isContainer(getLdpType()) ? "/" : "")
+            + (getExtensionGraphName() != null ? "?ext=" + getRequest().getExt() : "");
     }
 
     private static RDFSyntax getRdfSyntax(final String contentType, final List<RDFSyntax> syntaxes) {
@@ -263,7 +264,7 @@ public class PutHandler extends MutatingLdpHandler {
                 LOGGER.trace("Adding link for type {}", type);
                 builder.link(type, Link.TYPE);
             });
-        LOGGER.debug("Persisting mutable data for {} with data: {}", internalId, mutable);
+        LOGGER.trace("Persisting mutable data for {} with data: {}", internalId, mutable);
 
         return persistPromise.thenCompose(future -> createOrReplace(metadata.build(), mutable, immutable))
             .thenCompose(future -> handleUpdateEvent(ldpType))

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -102,6 +102,7 @@ class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
                 singletonMap(ACL, PreferAccessControl), null);
 
         when(mockUriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>(singletonMap("path", "resource")));
+        when(mockUriInfo.getPath()).thenReturn("resource");
         when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://my.example.com/"));
         when(mockUriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
         when(mockHttpHeaders.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());

--- a/core/http/src/test/java/org/trellisldp/http/impl/HttpUtilsTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/HttpUtilsTest.java
@@ -232,6 +232,18 @@ class HttpUtilsTest {
     }
 
     @Test
+    void testMatchIdentifier() {
+        final IRI root = rdf.createIRI(TRELLIS_DATA_PREFIX);
+        final IRI resource = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource");
+        final IRI resourceSlash = rdf.createIRI(TRELLIS_DATA_PREFIX + "resource/");
+        assertTrue(HttpUtils.matchIdentifier(root, root));
+        assertTrue(HttpUtils.matchIdentifier(resourceSlash, resource));
+        assertFalse(HttpUtils.matchIdentifier(resource, resourceSlash));
+        assertFalse(HttpUtils.matchIdentifier(root, resource));
+        assertFalse(HttpUtils.matchIdentifier(rdf.createBlankNode(), root));
+    }
+
+    @Test
     void testProfile() {
         final List<MediaType> types = asList(APPLICATION_JSON_TYPE, TEXT_XML_TYPE,
                 new MediaType("application", "ld+json", singletonMap("profile", compacted.getIRIString())));

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -62,13 +62,26 @@ class PostHandlerTest extends BaseTestHandler {
 
     @Test
     void testPostLdprs() throws IOException {
-        when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel(TYPE).build());
+        when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.RDFSource.getIRIString()).rel(TYPE).build());
 
         final PostHandler handler = buildPostHandler(RESOURCE_EMPTY, NEW_RESOURCE, null);
         try (final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
                 .toCompletableFuture().join().build()) {
             assertEquals(CREATED, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertEquals(create(baseUrl + NEW_RESOURCE), res.getLocation(), ERR_LOCATION);
+            assertAll(CHECK_LINK_TYPES, checkLdpType(res, LDP.RDFSource));
+        }
+    }
+
+    @Test
+    void testPostLdpc() throws IOException {
+        when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Container.getIRIString()).rel(TYPE).build());
+
+        final PostHandler handler = buildPostHandler(RESOURCE_EMPTY, NEW_RESOURCE, null);
+        try (final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
+                .toCompletableFuture().join().build()) {
+            assertEquals(CREATED, res.getStatusInfo(), ERR_RESPONSE_CODE);
+            assertEquals(create(baseUrl + NEW_RESOURCE + "/"), res.getLocation(), ERR_LOCATION);
             assertAll(CHECK_LINK_TYPES, checkLdpType(res, LDP.Container));
         }
     }

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -126,7 +126,7 @@ class PutHandlerTest extends BaseTestHandler {
             assertAll(CHECK_LINK_TYPES, checkLdpType(res, LDP.Container));
 
             verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class));
-            verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + RESOURCE_NAME));
+            verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + RESOURCE_NAME + "/"));
         }
     }
 
@@ -143,7 +143,7 @@ class PutHandlerTest extends BaseTestHandler {
             assertAll(CHECK_LINK_TYPES, checkLdpType(res, LDP.Container));
 
             verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class));
-            verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + RESOURCE_NAME));
+            verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + RESOURCE_NAME + "/"));
         }
     }
 
@@ -159,7 +159,7 @@ class PutHandlerTest extends BaseTestHandler {
             assertEquals(CREATED, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertAll(CHECK_LINK_TYPES, checkLdpType(res, LDP.Container));
 
-            verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + RESOURCE_NAME));
+            verify(mockIoService).read(any(InputStream.class), eq(TURTLE), eq(baseUrl + RESOURCE_NAME + "/"));
             verify(mockBinaryService, never()).setContent(any(BinaryMetadata.class), any(InputStream.class));
         }
     }

--- a/core/http/src/test/resources/logback-test.xml
+++ b/core/http/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-  <logger name="org.trellisldp" additivity="false" level="INFO">
+  <logger name="org.trellisldp" additivity="false" level="DEBUG">
     <appender-ref ref="STDOUT"/>
   </logger>
   <root additivity="false" level="WARN">


### PR DESCRIPTION
Resolves #565

Effectively, what's going on here is this:

* Internally, all resource identifiers contain no trailing slash in the path portion
* The HTTP layer maps any response headers for containers to URLs that end in slashes
* Any GET requests for non-container URLs that end in a slash or container URLs that don't end in a slash are redirected to the appropriate URL location
* PUT/PATCH/POST/DELETE respond to either form of any URL
* The resource service implementation, when it streams containment and member triples needs to know whether the associated URL refers to a container or not, and adjusts accordingly
* The various integration tests have been updated to support the new behavior

I don't plan to merge this until an equivalent PR is prepared for `trellis-extensions`