### PR TITLE
Add LDP type triples by default

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/AuditTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuditTests.java
@@ -13,6 +13,7 @@
  */
 package org.trellisldp.test;
 
+import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Stream.of;
 import static javax.ws.rs.client.Entity.entity;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
@@ -36,6 +37,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
 import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.Triple;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -125,7 +127,8 @@ public interface AuditTests extends CommonTests {
     default void testNoAuditTriples() throws Exception {
         try (final Response res = target(getResourceLocation()).request().get();
              final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
-            assertEquals(2L, g.size(), "Check that the graph has 2 triples");
+            assertEquals(2L, g.stream().map(Triple::getPredicate).filter(isEqual(type).negate()).count(),
+                    "Check that the graph has 2 triples");
         }
     }
 
@@ -139,7 +142,8 @@ public interface AuditTests extends CommonTests {
         try (final Response res = target(getResourceLocation()).request().header("Prefer",
                     "return=representation; omit=\"" + Trellis.PreferAudit.getIRIString() + "\"").get();
              final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
-            assertEquals(2L, g.size(), "Check that the graph has only 2 triples");
+            assertEquals(2L, g.stream().map(Triple::getPredicate).filter(isEqual(type).negate()).count(),
+                    "Check that the graph has only 2 triples");
         }
     }
 
@@ -171,7 +175,8 @@ public interface AuditTests extends CommonTests {
                         rdf.createIRI("https://people.apache.org/~acoburn/#i")), "Verify agent 3");
             assertEquals(2L, g.stream(null, type, AS.Update).count(), "Count the number of update events");
             assertEquals(1L, g.stream(null, type, AS.Create).count(), "Count the number of create events");
-            assertEquals(17L, g.size(), "Get the total graph size");
+            assertEquals(11L, g.stream().map(Triple::getPredicate).filter(isEqual(type).negate()).count(),
+                        "Get the total graph size, absent any type triples");
         }
     }
 }

--- a/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
@@ -14,6 +14,7 @@
 package org.trellisldp.test;
 
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.Response.Status.Family.REDIRECTION;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
@@ -38,6 +39,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.Triple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -178,7 +180,8 @@ public interface MementoResourceTests extends MementoCommonTests {
                         "Check for a skos:prefLabel property");
                 assertTrue(g.contains(subject, DC.subject, rdf.createIRI("http://example.org/subject/1")),
                         "Check for a dc:subject property");
-                assertEquals(3L, g.size(), "Check for three triples");
+                assertEquals(2L, g.stream().map(Triple::getPredicate).filter(isEqual(type).negate()).count(),
+                        "Check for two non-type triples");
             });
 
             assertTrue(dataset.getGraph(urls.get(1)).isPresent(), "Check that the last graph is present");
@@ -192,7 +195,8 @@ public interface MementoResourceTests extends MementoCommonTests {
                         "Check for a dc:title property");
                 assertTrue(g.contains(subject, DC.alternative, rdf.createLiteral("Alternative Title")),
                         "Check for a dc:alternative property");
-                assertEquals(5L, g.size(), "Check for five triples");
+                assertEquals(4L, g.stream().map(Triple::getPredicate).filter(isEqual(type).negate()).count(),
+                        "Check for four non-type triples");
             });
         }
     }

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -133,7 +133,7 @@ public class TriplestoreResourceService implements ResourceService {
     @Inject
     public TriplestoreResourceService(final RDFConnection rdfConnection, final IdentifierService identifierService) {
         this.includeLdpType = getConfig().getOptionalValue(CONFIG_TRIPLESTORE_LDP_TYPE, Boolean.class)
-            .orElse(Boolean.FALSE);
+            .orElse(Boolean.TRUE);
         this.rdfConnection = requireNonNull(rdfConnection, "RDFConnection may not be null!");
         this.supplier = requireNonNull(identifierService, "IdentifierService may not be null!").getSupplier();
         this.supportedIxnModels = unmodifiableSet(new HashSet<>(asList(LDP.Resource, LDP.RDFSource, LDP.NonRDFSource,

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -151,7 +151,8 @@ class TriplestoreResourceServiceTest {
         final Dataset data = rdf.createDataset();
         svc.get(root).thenAccept(res ->
                 res.stream().filter(q -> !q.getGraphName().filter(Trellis.PreferServerManaged::equals).isPresent())
-                            .forEach(data::add)).toCompletableFuture().join();
+                        .filter(q -> !q.getPredicate().equals(RDF.type) && !q.getObject().equals(LDP.BasicContainer))
+                        .forEach(data::add)).toCompletableFuture().join();
         data.add(Trellis.PreferUserManaged, root, RDFS.label, rdf.createLiteral("Resource Label"));
         data.add(Trellis.PreferUserManaged, root, RDFS.seeAlso, rdf.createIRI("http://example.com"));
         data.add(Trellis.PreferUserManaged, root, LDP.inbox, rdf.createIRI("http://ldn.example.com/"));
@@ -1363,9 +1364,10 @@ class TriplestoreResourceServiceTest {
 
     private static Stream<Executable> checkResourceStream(final Resource res, final long userManaged,
             final long accessControl, final long audit, final long membership, final long containment) {
-        final long total = userManaged + accessControl + audit + membership + containment;
+        final long ldpTriples = 1;
+        final long total = userManaged + accessControl + audit + membership + containment + ldpTriples;
         return Stream.of(
-                () -> assertEquals(userManaged, res.stream(Trellis.PreferUserManaged).count(),
+                () -> assertEquals(userManaged + ldpTriples, res.stream(Trellis.PreferUserManaged).count(),
                                    "Incorrect user triple count!"),
                 () -> assertEquals(accessControl, res.stream(Trellis.PreferAccessControl).count(),
                                    "Incorrect ACL triple count!"),


### PR DESCRIPTION
Resolves #595

Most of this PR adjusts the test suite to also handle implementations that may choose not to add the LDP type triple(s).