### PR TITLE
Adjust runtime dependency scope

### DIFF
--- a/auth/basic/build.gradle
+++ b/auth/basic/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
-    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
     testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"

--- a/auth/jwt/build.gradle
+++ b/auth/jwt/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     }
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
-    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
-    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
+    testRuntimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
 if (project.sourceCompatibility.isJava11Compatible()) {

--- a/auth/oauth/build.gradle
+++ b/auth/oauth/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
     implementation "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
 
-    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
     testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,8 @@ allprojects { subproj ->
     dependencies {
         testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
         testImplementation "org.apiguardian:apiguardian-api:${apiguardianVersion}"
-        testRuntimeClasspath "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
-        testRuntimeClasspath "org.junit.platform:junit-platform-launcher:${junitLauncherVersion}"
+        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+        testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junitLauncherVersion}"
     }
 
     dependencyCheck {

--- a/components/app/build.gradle
+++ b/components/app/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
     testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"

--- a/components/cdi/build.gradle
+++ b/components/cdi/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     api project(':trellis-api')
     api project(':trellis-app')
 
-    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
     testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"

--- a/components/dropwizard/build.gradle
+++ b/components/dropwizard/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation project(':trellis-auth-basic')
     implementation project(':trellis-auth-oauth')
 
-    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
     testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"

--- a/components/webdav/build.gradle
+++ b/components/webdav/build.gradle
@@ -37,9 +37,9 @@ dependencies {
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-io-jena')
 
-    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
-    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
-    testRuntimeClasspath "org.glassfish.jaxb:jaxb-runtime:$glassfishJaxbVersion"
+    testRuntimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
+    testRuntimeOnly "org.glassfish.jaxb:jaxb-runtime:$glassfishJaxbVersion"
 }
 
 if (project.sourceCompatibility.isJava11Compatible()) {

--- a/core/api/build.gradle
+++ b/core/api/build.gradle
@@ -22,6 +22,6 @@ dependencies {
     testImplementation "org.apache.commons:commons-text:$commonsTextVersion"
     testImplementation project(':trellis-vocabulary')
 
-    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
+    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }
 

--- a/core/http/build.gradle
+++ b/core/http/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     testImplementation project(':trellis-event-jackson')
     testImplementation project(':trellis-io-jena')
 
-    testRuntimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
-    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
+    testRuntimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
 if (project.sourceCompatibility.isJava11Compatible()) {

--- a/core/vocabulary/build.gradle
+++ b/core/vocabulary/build.gradle
@@ -18,5 +18,5 @@ dependencies {
     testImplementation "org.apache.jena:jena-arq:$jenaVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
-    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
+    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }

--- a/platform/openliberty/build.gradle
+++ b/platform/openliberty/build.gradle
@@ -55,10 +55,10 @@ dependencies {
         exclude group: 'org.apache.servicemix.bundles', module: 'org.apache.servicemix.bundles.xerces'
     }
 
-    runtimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
-    runtimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
-    runtimeClasspath "jakarta.validation:jakarta.validation-api:$validationApiVersion"
-    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
+    runtimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    runtimeOnly "jakarta.validation:jakarta.validation-api:$validationApiVersion"
+    runtimeOnly "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
     testImplementation project(':trellis-test')
 

--- a/platform/osgi/build.gradle
+++ b/platform/osgi/build.gradle
@@ -87,7 +87,7 @@ task generateDependsFile {
         properties.setProperty( "${project.group}/${project.name}/version", "${project.version}" )
 
         // then for all our deps
-        project.configurations.testRuntimeOnly.resolvedConfiguration.resolvedArtifacts.each {
+        project.configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.each {
             final String keyBase = it.moduleVersion.id.group + '/' + it.moduleVersion.id.name
             properties.setProperty( "${keyBase}/scope", "compile" )
             properties.setProperty( "${keyBase}/type", it.extension )

--- a/platform/osgi/build.gradle
+++ b/platform/osgi/build.gradle
@@ -63,8 +63,8 @@ dependencies {
 
     testImplementation group: 'org.apache.karaf.features', name: 'standard', version: karafVersion, classifier:'features', ext: 'xml'
 
-    testRuntimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
-    testRuntimeClasspath "org.junit.vintage:junit-vintage-engine:${junitVersion}"
+    testRuntimeOnly "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVersion}"
 
     karafDistro group: 'org.apache.karaf', name: 'apache-karaf', version: karafVersion, ext: 'zip'
 }
@@ -87,7 +87,7 @@ task generateDependsFile {
         properties.setProperty( "${project.group}/${project.name}/version", "${project.version}" )
 
         // then for all our deps
-        project.configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.each {
+        project.configurations.testRuntimeOnly.resolvedConfiguration.resolvedArtifacts.each {
             final String keyBase = it.moduleVersion.id.group + '/' + it.moduleVersion.id.name
             properties.setProperty( "${keyBase}/scope", "compile" )
             properties.setProperty( "${keyBase}/type", it.extension )

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -59,8 +59,8 @@ dependencies {
     implementation "org.apache.jena:jena-rdfconnection:$jenaVersion"
     implementation "org.apache.jena:jena-tdb2:$jenaVersion"
 
-    runtimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
-    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    runtimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    runtimeOnly "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
     testImplementation "io.quarkus:quarkus-junit5"
     testImplementation "io.rest-assured:rest-assured"

--- a/platform/server/build.gradle
+++ b/platform/server/build.gradle
@@ -13,16 +13,16 @@ application {
 dependencies {
     implementation project(':trellis-dropwizard-triplestore')
 
-    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    runtimeOnly "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
 
     if (project.sourceCompatibility.isJava11Compatible()) {
-        runtimeClasspath "io.dropwizard:dropwizard-core:$dropwizardVersion"
-        runtimeClasspath "io.dropwizard:dropwizard-metrics:$dropwizardVersion"
-        runtimeClasspath "io.dropwizard:dropwizard-http2:$dropwizardVersion"
+        runtimeOnly "io.dropwizard:dropwizard-core:$dropwizardVersion"
+        runtimeOnly "io.dropwizard:dropwizard-metrics:$dropwizardVersion"
+        runtimeOnly "io.dropwizard:dropwizard-http2:$dropwizardVersion"
 
-        runtimeClasspath "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
-        runtimeClasspath "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
-        runtimeClasspath "io.jsonwebtoken:jjwt-api:$jjwtVersion"
+        runtimeOnly "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
+        runtimeOnly "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
+        runtimeOnly "io.jsonwebtoken:jjwt-api:$jjwtVersion"
     }
 }
 


### PR DESCRIPTION
According to the [gradle documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph), we should be using `runtimeOnly` instead of `runtimeClasspath` when defining dependency scopes.