### PR TITLE
Upgrade to gradle6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'com.github.hierynomus.license' version "$licenseVersion"
     id 'com.github.kt3k.coveralls' version "$coverallsVersion"
     id 'com.github.spotbugs' version "$spotbugsVersion"
-    id 'com.gradle.build-scan' version "$scanVersion"
     id 'net.researchgate.release' version "$releasesVersion"
     id 'org.owasp.dependencycheck' version "$owaspVersion"
     id 'org.sonarqube' version "$sonarVersion"
@@ -369,6 +368,10 @@ subprojects { subproj ->
     signing {
         required { !version.endsWith("SNAPSHOT") && gradle.taskGraph.hasTask("publish") }
         sign publishing.publications
+    }
+
+    tasks.withType(Sign) {
+        onlyIf { !version.endsWith("SNAPSHOT") }
     }
 
     processResources {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform/bom/build.gradle
+++ b/platform/bom/build.gradle
@@ -52,6 +52,10 @@ publishing {
     }
 }
 
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
 java {
     // because this isn't built as a JPMS module
     if (project.hasProperty("jpms") && JavaVersion.current().isJava11Compatible()) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.gradle.enterprise" version "$scanVersion"
+}
+
 rootProject.name = 'trellis'
 
 include ':trellis-api'


### PR DESCRIPTION
Resolves #625 

This upgrades the Trellis build to gradle 6. With this commit, gradle 5 will no longer be supported.