### PR TITLE
Add support for relative IRIs

### DIFF
--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/TrellisConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/TrellisConfiguration.java
@@ -52,6 +52,8 @@ public class TrellisConfiguration extends Configuration {
     @NotNull
     private NotificationsConfiguration notifications = new NotificationsConfiguration();
 
+    private boolean useRelativeIris;
+
     private String hubUrl;
 
     private String baseUrl;
@@ -221,6 +223,24 @@ public class TrellisConfiguration extends Configuration {
     @JsonProperty
     public JsonLdConfiguration getJsonld() {
         return jsonld;
+    }
+
+    /**
+     * Set the configuration for relative IRIs.
+     * @param useRelativeIris whether to use relative IRIs
+     */
+    @JsonProperty
+    public void setUseRelativeIris(final boolean useRelativeIris) {
+        this.useRelativeIris = useRelativeIris;
+    }
+
+    /**
+     * Get the configuration for relative IRIs.
+     * @return true if using relative IRIs; false otherwise
+     */
+    @JsonProperty
+    public boolean getUseRelativeIris() {
+        return useRelativeIris;
     }
 
     /**

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleServiceBundler.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleServiceBundler.java
@@ -49,7 +49,7 @@ public class SimpleServiceBundler extends BaseServiceBundler {
         timemapGenerator = new DefaultTimemapGenerator();
         constraintServices = new DefaultConstraintServices(singletonList(new LdpConstraintService()));
         ioService = new JenaIOService(new NoopNamespaceService(), null, new NoopProfileCache(),
-                emptySet(), emptySet());
+                emptySet(), emptySet(), false);
         binaryService = new FileBinaryService(new DefaultIdentifierService(),
                 resourceFilePath("data") + "/binaries", 2, 2);
     }

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/config/TrellisConfigurationTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/config/TrellisConfigurationTest.java
@@ -54,6 +54,9 @@ class TrellisConfigurationTest {
         // Hub tests
         assertEquals("http://hub.example.com/", config.getHubUrl(), "Incorrect hubUrl");
 
+        // Relative IRI configuration
+        assertTrue(config.getUseRelativeIris(), "Incorrect relative IRI configuration");
+
         // Auth tests
         assertTrue(config.getAuth().getAdminUsers().contains("zoyd"), "zoyd missing from auth/adminUsers");
         assertTrue(config.getAuth().getAdminUsers().contains("wheeler"), "wheeler missing from auth/adminUsers");

--- a/components/dropwizard/src/test/resources/config1.yml
+++ b/components/dropwizard/src/test/resources/config1.yml
@@ -86,6 +86,8 @@ cors:
     maxAge: 180
     allowCredentials: true
 
+useRelativeIris: true
+
 cassandraAddress: my.cluster.address
 cassandraPort: 245994
 

--- a/components/dropwizard/src/test/resources/trellis-config.yml
+++ b/components/dropwizard/src/test/resources/trellis-config.yml
@@ -58,6 +58,8 @@ notifications:
     enabled: true
     type: NONE
 
+useRelativeIris: true
+
 # JSON-LD configuration
 jsonld:
     cacheSize: 10

--- a/components/test/src/main/java/org/trellisldp/test/TestUtils.java
+++ b/components/test/src/main/java/org/trellisldp/test/TestUtils.java
@@ -56,7 +56,7 @@ import org.trellisldp.vocabulary.PROV;
 public final class TestUtils {
 
     private static final IOService ioService = new JenaIOService(new NoopNamespaceService(), null,
-            new NoopProfileCache(), emptySet(), emptySet());
+            new NoopProfileCache(), emptySet(), emptySet(), false);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**

--- a/core/api/src/main/java/org/trellisldp/api/IOService.java
+++ b/core/api/src/main/java/org/trellisldp/api/IOService.java
@@ -37,9 +37,10 @@ public interface IOService {
      * @param triples the stream of triples
      * @param output the output stream
      * @param syntax the output format
+     * @param context the context to resolve relative IRIs
      * @param profiles additional profile information used for output
      */
-    void write(Stream<Triple> triples, OutputStream output, RDFSyntax syntax, IRI... profiles);
+    void write(Stream<Triple> triples, OutputStream output, RDFSyntax syntax, String context, IRI... profiles);
 
     /**
      * Read an input stream into a stream of triples.

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -321,7 +321,7 @@ public class GetHandler extends BaseLdpHandler {
             try (final Stream<Quad> stream = getResource().stream(getPreferredGraphs(prefer))) {
                 getServices().getIOService().write(stream.map(Quad::asTriple)
                                 .map(unskolemizeTriples(getServices().getResourceService(), getBaseUrl())), out,
-                        syntax, getJsonLdProfile(profile, syntax));
+                        syntax, getIdentifier(), getJsonLdProfile(profile, syntax));
             }
         });
     }

--- a/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
@@ -119,7 +119,7 @@ public final class MementoResource {
 
             return builder.type(syntax.mediaType()).entity((StreamingOutput) out ->
                 trellis.getIOService().write(trellis.getTimemapGenerator()
-                        .asRdf(identifier, allLinks), out, syntax, jsonldProfile));
+                        .asRdf(identifier, allLinks), out, syntax, baseUrl, jsonldProfile));
         }
 
         return builder.type(APPLICATION_LINK_FORMAT)

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -230,7 +230,7 @@ class MutatingLdpHandler extends BaseLdpHandler {
             violations.forEach(v -> err.link(v.getConstraint().getIRIString(), LDP.constrainedBy.getIRIString()));
             throw new ClientErrorException(err.entity((StreamingOutput) out ->
                     getServices().getIOService().write(violations.stream().flatMap(v2 -> v2.getTriples().stream()),
-                            out, syntax)).build());
+                            out, syntax, getIdentifier())).build());
         }
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -281,7 +281,7 @@ public class PatchHandler extends MutatingLdpHandler {
                         .type(outputSyntax.mediaType()).entity((StreamingOutput) out ->
                             getServices().getIOService().write(triples.stream()
                                         .map(unskolemizeTriples(getServices().getResourceService(), getBaseUrl())),
-                                        out, outputSyntax, profile));
+                                        out, outputSyntax, getIdentifier(), profile));
                 }
                 return builder.status(getResource() == null ? CREATED : NO_CONTENT);
             });

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
@@ -84,7 +84,8 @@ public class TrellisServiceBundler extends BaseServiceBundler {
                 config.getAssets().getTemplate(), config.getAssets().getCss(), config.getAssets().getJs(),
                 config.getAssets().getIcon());
         return new JenaIOService(namespaceService, htmlSerializer, profileCache,
-                config.getJsonld().getContextWhitelist(), config.getJsonld().getContextDomainWhitelist());
+                config.getJsonld().getContextWhitelist(), config.getJsonld().getContextDomainWhitelist(),
+                config.getUseRelativeIris());
     }
 
     private static BinaryService buildBinaryService(final AppConfiguration config) {

--- a/platform/server/src/docker/config.yml
+++ b/platform/server/src/docker/config.yml
@@ -72,6 +72,8 @@ cache:
     maxAge: ${TRELLIS_CACHE_MAX_AGE:-86400}
     mustRevalidate: ${TRELLIS_CACHE_MUST_REVALIDATE:-true}
 
+useRelativeIris: ${TRELLIS_IO_RELATIVE_IRIS:-false}
+
 notifications:
     enabled: ${TRELLIS_NOTIFICATIONS_ENABLED:-false}
     type: ${TRELLIS_NOTIFICATIONS_TYPE:-JMS}


### PR DESCRIPTION
Resolves #651

This changes the api for `IOService::write`, adding a `context` parameter, which is a breaking change for the API. This also adds a configuration value for controlling whether to use relative IRIs in Turtle output (default=false). The configuration property is `trellis.io.relative-iris`. A corresponding configuration value is added to the dropwizard config object.