### PR TITLE
Make versioning more configurable

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
@@ -77,6 +77,9 @@ public final class HttpConstants {
     /** Configuration key defining whether PUT-on-create generates contained or uncontained resources. */
     public static final String CONFIG_HTTP_PUT_UNCONTAINED = "trellis.http.put-uncontained";
 
+    /** Configuration key defining whether versions are created in the HTTP layer. */
+    public static final String CONFIG_HTTP_VERSIONING = "trellis.http.versioning";
+
     /** The Trellis query parameter for extended features of a given resource. */
     public static final String EXT = "ext";
 

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/AppConfiguration.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/AppConfiguration.java
@@ -31,6 +31,8 @@ class AppConfiguration extends TrellisConfiguration {
     @NotNull
     private String namespaces;
 
+    private boolean isVersioningEnabled = true;
+
     private int levels = 3;
 
     private int length =  2;
@@ -53,6 +55,24 @@ class AppConfiguration extends TrellisConfiguration {
     @JsonProperty
     public void setMementos(final String config) {
         this.mementos = config;
+    }
+
+    /**
+     * Get whether versioning is enabled.
+     * @return true if memento versioning is enabled; false otherwise
+     */
+    @JsonProperty
+    public boolean getIsVersioningEnabled() {
+        return isVersioningEnabled;
+    }
+
+    /**
+     * Set whether mementos are enabled.
+     * @param isVersioningEnabled whether versioning is enabled
+     */
+    @JsonProperty
+    public void setIsVersioningEnabled(final boolean isVersioningEnabled) {
+        this.isVersioningEnabled = isVersioningEnabled;
     }
 
     /**

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
@@ -56,7 +56,7 @@ public class TrellisServiceBundler extends BaseServiceBundler {
      */
     public TrellisServiceBundler(final AppConfiguration config, final Environment environment) {
         auditService = new DefaultAuditService();
-        mementoService = new FileMementoService(config.getMementos());
+        mementoService = new FileMementoService(config.getMementos(), config.getIsVersioningEnabled());
         timemapGenerator = new DefaultTimemapGenerator();
         constraintServices = new DefaultConstraintServices(singletonList(new LdpConstraintService()));
         resourceService = buildResourceService(config, environment);

--- a/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/TrellisConfigurationTest.java
+++ b/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/TrellisConfigurationTest.java
@@ -44,6 +44,7 @@ class TrellisConfigurationTest {
         assertFalse(config.getCache().getNoCache(), "Incorrect cache/noCache value!");
         assertEquals(10L, config.getJsonld().getCacheSize(), "Incorrect jsonld/cacheSize value!");
         assertEquals(48L, config.getJsonld().getCacheExpireHours(), "Incorrect jsonld/cacheExpireHours value!");
+        assertFalse(config.getIsVersioningEnabled(), "Incorrect versioning value!");
         assertTrue(config.getJsonld().getContextDomainWhitelist().isEmpty(), "Incorrect jsonld/contextDomainWhitelist");
         assertTrue(config.getJsonld().getContextWhitelist().contains("http://example.org/context.json"),
                 "Incorrect jsonld/contextWhitelist value!");

--- a/platform/dropwizard/src/test/resources/config1.yml
+++ b/platform/dropwizard/src/test/resources/config1.yml
@@ -86,6 +86,7 @@ cors:
 
 binaryHierarchyLevels: 2
 binaryHierarchyLength: 1
+isVersioningEnabled: false
 
 cassandraAddress: my.cluster.node
 cassandraPort: 245993

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -3,16 +3,16 @@ plugins {
 }
 
 repositories {
+    mavenLocal() {
+        content {
+            includeGroup "org.trellisldp"
+        }
+    }
     mavenCentral()
     // This is required for snyk integration with the quarkus project
     // Once quarkus has better support for multi-project builds, this can be removed
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots"
-    }
-    mavenLocal() {
-        content {
-            includeGroup "org.trellisldp"
-        }
     }
 }
 

--- a/platform/quarkus/src/main/resources/application.properties
+++ b/platform/quarkus/src/main/resources/application.properties
@@ -31,6 +31,7 @@ trellis.http.jsonld-profile=
 trellis.http.precondition-required=false
 trellis.http.patch-create=true
 trellis.http.put-uncontained=false
+trellis.http.versioning=true
 trellis.http.weak-etag=false
 trellis.http.web-sub-hub=
 
@@ -46,6 +47,7 @@ trellis.namespaces.mapping=
 # Trellis file
 trellis.file.binary-path=data/binaries
 trellis.file.memento-path=data/mementos
+trellis.file.versioning=true
 
 # CORS
 quarkus.http.cors=true


### PR DESCRIPTION
Resolves #681

This adds two new configuration properties: 

`trellis.http.versioning` -- this accepts true/false values (default=true) and controls whether the HTTP layer takes responsibility for creating Mementos
`trellis.file.versioning` -- this accepts true/false values (default=true) and controls whether the FileMemento component is enabled