### PR TITLE
Adjust handling of OPTIONS requests

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -256,7 +256,7 @@ public class TrellisHttpResource {
             @Context final HttpHeaders headers) {
         final TrellisRequest req = new TrellisRequest(request, uriInfo, headers);
         final OptionsHandler optionsHandler = new OptionsHandler(req, trellis, extensions);
-        return supplyAsync(() -> optionsHandler.ldpOptions()).thenApply(ResponseBuilder::build)
+        return supplyAsync(optionsHandler::ldpOptions).thenApply(ResponseBuilder::build)
             .exceptionally(this::handleException);
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -14,6 +14,7 @@
 package org.trellisldp.http;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.Resource.SpecialResources.*;
@@ -67,7 +68,6 @@ import org.trellisldp.http.core.PATCH;
 import org.trellisldp.http.core.ServiceBundler;
 import org.trellisldp.http.core.TrellisExtensions;
 import org.trellisldp.http.core.TrellisRequest;
-import org.trellisldp.http.core.Version;
 import org.trellisldp.http.impl.DeleteHandler;
 import org.trellisldp.http.impl.GetConfiguration;
 import org.trellisldp.http.impl.GetHandler;
@@ -255,13 +255,8 @@ public class TrellisHttpResource {
     public CompletionStage<Response> options(@Context final Request request, @Context final UriInfo uriInfo,
             @Context final HttpHeaders headers) {
         final TrellisRequest req = new TrellisRequest(request, uriInfo, headers);
-        final String urlBase = getBaseUrl(req);
-        final IRI identifier = rdf.createIRI(TRELLIS_DATA_PREFIX + req.getPath());
-        final OptionsHandler optionsHandler = new OptionsHandler(req, trellis, extensions, req.getVersion() != null,
-                urlBase);
-
-        return fetchTrellisResource(identifier, req.getVersion()).thenApply(optionsHandler::initialize)
-            .thenApply(optionsHandler::ldpOptions).thenApply(ResponseBuilder::build)
+        final OptionsHandler optionsHandler = new OptionsHandler(req, trellis, extensions);
+        return supplyAsync(() -> optionsHandler.ldpOptions()).thenApply(ResponseBuilder::build)
             .exceptionally(this::handleException);
     }
 
@@ -442,12 +437,6 @@ public class TrellisHttpResource {
             return slug;
         }
         return trellis.getResourceService().generateIdentifier();
-    }
-    private CompletionStage<? extends Resource> fetchTrellisResource(final IRI identifier, final Version version) {
-        if (version != null) {
-            return trellis.getMementoService().get(identifier, version.getInstant());
-        }
-        return trellis.getResourceService().get(identifier);
     }
 
     private Response handleException(final Throwable err) {

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -870,9 +870,9 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         try (final Response res = target(RESOURCE_PATH).request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
-            assertAll(CHECK_LDP_LINKS, checkLdpTypeHeaders(res, LDP.RDFSource));
-            assertAll(CHECK_ALLOWED_METHODS, checkAllowedMethods(res,
-                        asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS)));
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS, POST)));
             assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
         }
     }
@@ -882,23 +882,21 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         try (final Response res = target(BINARY_PATH).request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
             assertAll(CHECK_ALLOWED_METHODS,
-                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS)));
-            assertAll(CHECK_LDP_LINKS, checkLdpTypeHeaders(res, LDP.NonRDFSource));
-            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, asList(ACCEPT_POST, MEMENTO_DATETIME)));
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS, POST)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
         }
     }
 
     @Test
     void testOptionsLDPC() {
-        when(mockResource.getInteractionModel()).thenReturn(LDP.Container);
         try (final Response res = target(RESOURCE_PATH).request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
             assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
             assertAll(CHECK_ALLOWED_METHODS,
                     checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS, POST)));
-            assertAll(CHECK_LDP_LINKS, checkLdpTypeHeaders(res, LDP.Container));
             assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
 
             final List<String> acceptPost = asList(res.getHeaderString(ACCEPT_POST).split(","));
@@ -915,9 +913,10 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
         try (final Response res = target(RESOURCE_PATH).queryParam(EXT, ACL_PARAM).request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
             assertAll(CHECK_ALLOWED_METHODS,
-                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS)));
-            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, asList(ACCEPT_POST, MEMENTO_DATETIME)));
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
         }
     }
 
@@ -927,29 +926,45 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
             assertAll(CHECK_ALLOWED_METHODS,
-                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS)));
-            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, asList(ACCEPT_POST, MEMENTO_DATETIME)));
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
         }
     }
 
     @Test
     void testOptionsNonexistent() {
         try (final Response res = target(NON_EXISTENT_PATH).request().options()) {
-            assertEquals(SC_NOT_FOUND, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
         }
     }
 
     @Test
     void testOptionsVersionNotFound() {
         try (final Response res = target(NON_EXISTENT_PATH).queryParam(VAL_VERSION, "1496260729").request().options()) {
-            assertEquals(SC_NOT_FOUND, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
         }
     }
 
     @Test
     void testOptionsGone() {
         try (final Response res = target(DELETED_PATH).request().options()) {
-            assertEquals(SC_GONE, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
         }
     }
 
@@ -957,33 +972,35 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     void testOptionsSlash() {
         try (final Response res = target(RESOURCE_PATH + "/").request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
-            assertAll(CHECK_ALLOWED_METHODS, checkAllowedMethods(res,
-                        asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS)));
-            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, asList(ACCEPT_POST, MEMENTO_DATETIME)));
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
         }
     }
 
     @Test
     void testOptionsTimemap() {
-        when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
-                ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
-
         try (final Response res = target(RESOURCE_PATH).queryParam(EXT, TIMEMAP).request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
-            assertAll(CHECK_ALLOWED_METHODS, checkAllowedMethods(res, asList(GET, HEAD, OPTIONS)));
-            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, asList(ACCEPT_POST, ACCEPT_PATCH, MEMENTO_DATETIME)));
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
         }
     }
 
     @Test
     void testOptionsTimemapBinary() {
-        when(mockMementoService.mementos(eq(identifier))).thenReturn(completedFuture(new TreeSet<>(asList(
-                ofEpochSecond(timestamp - 2000), ofEpochSecond(timestamp - 1000), time))));
         try (final Response res = target(BINARY_PATH).queryParam(EXT, TIMEMAP).request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
-            assertAll(CHECK_ALLOWED_METHODS, checkAllowedMethods(res, asList(GET, HEAD, OPTIONS)));
-            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, asList(ACCEPT_POST, ACCEPT_PATCH, MEMENTO_DATETIME)));
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
         }
     }
 
@@ -991,8 +1008,11 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     void testOptionsVersion() {
         try (final Response res = target(RESOURCE_PATH).queryParam(VAL_VERSION, timestamp).request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
-            assertAll(CHECK_ALLOWED_METHODS, checkAllowedMethods(res, asList(GET, HEAD, OPTIONS)));
-            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, asList(ACCEPT_PATCH, ACCEPT_POST)));
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
         }
     }
 
@@ -1000,18 +1020,11 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     void testOptionsVersionBinary() {
         try (final Response res = target(BINARY_PATH).queryParam(VAL_VERSION, timestamp).request().options()) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
-            assertAll(CHECK_ALLOWED_METHODS, checkAllowedMethods(res, asList(GET, HEAD, OPTIONS)));
-            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, asList(ACCEPT_PATCH, ACCEPT_POST)));
-        }
-    }
-
-    @Test
-    void testOptionsException() {
-        when(mockResourceService.get(eq(identifier))).thenAnswer(inv -> supplyAsync(() -> {
-            throw new RuntimeTrellisException(EXPECTED_EXCEPTION);
-        }));
-        try (final Response res = target(RESOURCE_PATH).request().options()) {
-            assertEquals(SC_INTERNAL_SERVER_ERROR, res.getStatus(), ERR_RESPONSE_CODE);
+            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
+            assertAll(CHECK_ALLOWED_METHODS,
+                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, POST, OPTIONS)));
+            assertAll(CHECK_NULL_HEADERS, checkNullHeaders(res, singletonList(MEMENTO_DATETIME)));
+            assertNotNull(res.getHeaderString(ACCEPT_POST), "Missing Accept-Post header!");
         }
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
@@ -35,7 +35,6 @@ import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE;
 import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
-import org.trellisldp.vocabulary.LDP;
 
 /**
  * @author acoburn
@@ -46,27 +45,11 @@ class OptionsHandlerTest extends BaseTestHandler {
     private static final String CHECK_ALLOW = "Check Allow headers";
 
     @Test
-    void testOptionsLdprs() {
-        when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
-
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
-                false, null);
-        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
-            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
-            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
-            assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header!");
-            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
-        }
-    }
-
-    @Test
-    void testOptionsLdpc() {
-        when(mockResource.getInteractionModel()).thenReturn(LDP.IndirectContainer);
+    void testOptionsLdpr() {
         when(mockIoService.supportedWriteSyntaxes()).thenReturn(asList(TURTLE, JSONLD, NTRIPLES));
 
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
-                false, baseUrl);
-        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
+        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions);
+        try (final Response res = optionsHandler.ldpOptions().build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
 
@@ -80,41 +63,14 @@ class OptionsHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    void testOptionsLdpnr() {
-        when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
-
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
-                false, null);
-        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
-            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
-            assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
-            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
-        }
-    }
-
-    @Test
     void testOptionsAcl() {
         when(mockTrellisRequest.getExt()).thenReturn("acl");
 
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
-                false, baseUrl);
-        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
+        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions);
+        try (final Response res = optionsHandler.ldpOptions().build()) {
             assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
             assertEquals(APPLICATION_SPARQL_UPDATE, res.getHeaderString(ACCEPT_PATCH), ERR_ACCEPT_PATCH);
-            assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header!");
-            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS, PUT, DELETE, PATCH)));
-        }
-    }
-
-    @Test
-    void testOptionsMemento() {
-        final OptionsHandler optionsHandler = new OptionsHandler(mockTrellisRequest, mockBundler, extensions,
-                true, null);
-        try (final Response res = optionsHandler.ldpOptions(optionsHandler.initialize(mockResource)).build()) {
-            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
-            assertNull(res.getHeaderString(ACCEPT_POST), "Unexpected Accept-Post header on Memento!");
-            assertNull(res.getHeaderString(ACCEPT_PATCH), "Unexpected Accept-Patch header on Memento!");
-            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS)));
+            assertAll(CHECK_ALLOW, checkAllowHeader(res, asList(GET, HEAD, OPTIONS, POST, PUT, DELETE, PATCH)));
         }
     }
 }


### PR DESCRIPTION
Resolves #705

Now, responses to OPTIONS requests have nothing to do with the presence/absence or LDP type of a resource, which is in line with how (esp. JavaScript) clients use OPTIONS requests.