### PR TITLE
Better JSON-LD support with Quarkus

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/LdpRdfTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpRdfTests.java
@@ -64,6 +64,7 @@ public interface LdpRdfTests extends CommonTests {
     String SIMPLE_RESOURCE = "/simpleResource.ttl";
     String BASIC_CONTAINER = "/basicContainer.ttl";
     String ANNOTATION_RESOURCE = "/annotation.ttl";
+    String SHEX_JSONLD = "/shex.jsonld";
 
     /**
      * Set the location of the test resource.
@@ -108,6 +109,7 @@ public interface LdpRdfTests extends CommonTests {
                 this::testGetNTriples,
                 this::testGetRDF,
                 this::testRdfContainment,
+                this::testPostJsonLd,
                 this::testInvalidRDF);
     }
 
@@ -317,6 +319,19 @@ public interface LdpRdfTests extends CommonTests {
             assertTrue(res.getMediaType().isCompatible(TEXT_TURTLE_TYPE), "Check that the container is RDF");
             assertTrue(g.contains(rdf.createIRI(getBaseURL()), LDP.contains,
                     rdf.createIRI(getResourceLocation())), "Check for an ldp:contains property");
+        }
+    }
+
+    /**
+     * Verify that POSTing JSON-LD is supported.
+     */
+    default void testPostJsonLd() {
+        final String rdf = getResourceAsString(SHEX_JSONLD);
+
+        // POST an LDP-RS
+        try (final Response res = target().request().header(SLUG, generateRandomValue(getClass().getSimpleName()))
+                .post(entity(rdf, APPLICATION_LD_JSON_TYPE))) {
+            assertAll("Check POSTing an RDF resource", checkRdfResponse(res, LDP.RDFSource, null));
         }
     }
 

--- a/components/test/src/main/resources/org/trellisldp/test/shex.jsonld
+++ b/components/test/src/main/resources/org/trellisldp/test/shex.jsonld
@@ -1,4 +1,4 @@
-{ "@context": "https://www.w3.org/ns/shex.jsonld",
+{ "@context": "http://www.w3.org/ns/shex.jsonld",
   "type": "Schema",
   "shapes": [
     { "id": "http://school.example/#enrolleeAge",

--- a/components/test/src/main/resources/org/trellisldp/test/shex.jsonld
+++ b/components/test/src/main/resources/org/trellisldp/test/shex.jsonld
@@ -1,0 +1,16 @@
+{ "@context": "https://www.w3.org/ns/shex.jsonld",
+  "type": "Schema",
+  "shapes": [
+    { "id": "http://school.example/#enrolleeAge",
+      "type": "NodeConstraint",
+      "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+      "mininclusive": 13, "maxinclusive": 20 },
+    { "id": "http://school.example/#Enrollee",
+      "type": "Shape",
+      "expression": {
+        "type": "TripleConstraint", "min": 1, "max": 2,
+        "predicate": "http://ex.example/#hasGuardian",
+        "valueExpr": {
+          "type": "NodeConstraint",
+          "nodeKind": "iri" } } }
+  ] }

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -26,6 +26,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.http.core.HttpConstants.CONFIG_HTTP_VERSIONING;
 import static org.trellisldp.http.impl.HttpUtils.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +41,7 @@ import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.StreamingOutput;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
@@ -169,14 +172,17 @@ class MutatingLdpHandler extends BaseLdpHandler {
      * @param dataset the dataset
      */
     protected void readEntityIntoDataset(final IRI graphName, final RDFSyntax syntax, final Dataset dataset) {
-        try {
-            getServices().getIOService().read(entity, syntax, getIdentifier())
+        try (final InputStream in = new ByteArrayInputStream(IOUtils.toByteArray(entity))) {
+            getServices().getIOService().read(in, syntax, getIdentifier())
                 .map(skolemizeTriples(getServices().getResourceService(), getBaseUrl()))
                 .filter(triple -> !RDF.type.equals(triple.getPredicate())
                         || !triple.getObject().ntriplesString().startsWith("<" + LDP.getNamespace()))
                 .filter(triple -> !LDP.contains.equals(triple.getPredicate())).map(triple ->
                         rdf.createQuad(graphName, triple.getSubject(), triple.getPredicate(), triple.getObject()))
                 .forEachOrdered(dataset::add);
+        } catch (final IOException ex) {
+            LOGGER.debug("Error reading input", ex);
+            throw new BadRequestException("Error handling input stream: " + ex.getMessage(), ex);
         } catch (final RuntimeTrellisException ex) {
             LOGGER.debug("Could not parse incoming RDF", ex);
             throw new BadRequestException("Invalid RDF content: " + ex.getMessage(), ex);

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -181,10 +181,8 @@ class MutatingLdpHandler extends BaseLdpHandler {
                         rdf.createQuad(graphName, triple.getSubject(), triple.getPredicate(), triple.getObject()))
                 .forEachOrdered(dataset::add);
         } catch (final IOException ex) {
-            LOGGER.debug("Error reading input", ex);
             throw new BadRequestException("Error handling input stream: " + ex.getMessage(), ex);
         } catch (final RuntimeTrellisException ex) {
-            LOGGER.debug("Could not parse incoming RDF", ex);
             throw new BadRequestException("Invalid RDF content: " + ex.getMessage(), ex);
         }
     }

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
 
+    implementation "com.github.jsonld-java:jsonld-java:$jsonldVersion"
     implementation "com.github.spullara.mustache.java:compiler:$mustacheVersion"
     implementation "com.google.guava:guava:$guavaVersion"
     implementation "org.apache.jena:jena-arq:$jenaVersion"


### PR DESCRIPTION
In multi-threaded contexts, JSON-LD input streams can be prematurely closed. This buffers those streams in a better structure for incoming RDF.