### PR TITLE
Adjust copyright license year

### DIFF
--- a/auth/basic/src/main/java/module-info.java
+++ b/auth/basic/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthUtils.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicAuthUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicPrincipal.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/BasicPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/Credentials.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/basic/src/main/java/org/trellisldp/auth/basic/package-info.java
+++ b/auth/basic/src/main/java/org/trellisldp/auth/basic/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthFilterTest.java
+++ b/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthUtilsTest.java
+++ b/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicAuthUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicPrincipalTest.java
+++ b/auth/basic/src/test/java/org/trellisldp/auth/basic/BasicPrincipalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/jwt/src/main/java/module-info.java
+++ b/auth/jwt/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/jwt/src/main/java/org/trellisldp/auth/jwt/JwtAuthFilter.java
+++ b/auth/jwt/src/main/java/org/trellisldp/auth/jwt/JwtAuthFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/jwt/src/main/java/org/trellisldp/auth/jwt/WebIdPrincipal.java
+++ b/auth/jwt/src/main/java/org/trellisldp/auth/jwt/WebIdPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/jwt/src/main/java/org/trellisldp/auth/jwt/WebIdSecurityContext.java
+++ b/auth/jwt/src/main/java/org/trellisldp/auth/jwt/WebIdSecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/jwt/src/main/java/org/trellisldp/auth/jwt/package-info.java
+++ b/auth/jwt/src/main/java/org/trellisldp/auth/jwt/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/jwt/src/test/java/org/trellisldp/auth/jwt/JwtAuthFilterTest.java
+++ b/auth/jwt/src/test/java/org/trellisldp/auth/jwt/JwtAuthFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/jwt/src/test/java/org/trellisldp/auth/jwt/WebIdPrincipalTest.java
+++ b/auth/jwt/src/test/java/org/trellisldp/auth/jwt/WebIdPrincipalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/jwt/src/test/java/org/trellisldp/auth/jwt/WebIdSecurityContextTest.java
+++ b/auth/jwt/src/test/java/org/trellisldp/auth/jwt/WebIdSecurityContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/module-info.java
+++ b/auth/oauth/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/Authenticator.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/Authenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/FederatedJwtAuthenticator.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/FederatedJwtAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/JwksAuthenticator.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/JwksAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/JwtAuthenticator.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/JwtAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/NullAuthenticator.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/NullAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/OAuthFilter.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/OAuthFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/OAuthPrincipal.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/OAuthPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/OAuthUtils.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/OAuthUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/main/java/org/trellisldp/auth/oauth/package-info.java
+++ b/auth/oauth/src/main/java/org/trellisldp/auth/oauth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/FederatedJwtAuthenticatorTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/FederatedJwtAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/JwksAuthenticatorTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/JwksAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/JwtAuthenticatorTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/JwtAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/NullAuthenticatorTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/NullAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthFilterTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthPrincipalTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthPrincipalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthUtilsTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildtools/src/main/resources/license/HEADER.txt
+++ b/buildtools/src/main/resources/license/HEADER.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+Copyright (c) 2020 Aaron Coburn and individual contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/components/app/src/main/java/module-info.java
+++ b/components/app/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/main/java/org/trellisldp/app/AppUtils.java
+++ b/components/app/src/main/java/org/trellisldp/app/AppUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/main/java/org/trellisldp/app/BaseServiceBundler.java
+++ b/components/app/src/main/java/org/trellisldp/app/BaseServiceBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/main/java/org/trellisldp/app/ConstraintServices.java
+++ b/components/app/src/main/java/org/trellisldp/app/ConstraintServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/main/java/org/trellisldp/app/DefaultConstraintServices.java
+++ b/components/app/src/main/java/org/trellisldp/app/DefaultConstraintServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/main/java/org/trellisldp/app/package-info.java
+++ b/components/app/src/main/java/org/trellisldp/app/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/test/java/org/trellisldp/app/AppUtilsTest.java
+++ b/components/app/src/test/java/org/trellisldp/app/AppUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/test/java/org/trellisldp/app/CDIConstraintServices.java
+++ b/components/app/src/test/java/org/trellisldp/app/CDIConstraintServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/test/java/org/trellisldp/app/CDIServiceBundlerTest.java
+++ b/components/app/src/test/java/org/trellisldp/app/CDIServiceBundlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/test/java/org/trellisldp/app/DefaultConstraintServicesTest.java
+++ b/components/app/src/test/java/org/trellisldp/app/DefaultConstraintServicesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/app/src/test/java/org/trellisldp/app/TestServices.java
+++ b/components/app/src/test/java/org/trellisldp/app/TestServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/audit/src/main/java/module-info.java
+++ b/components/audit/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/audit/src/main/java/org/trellisldp/audit/DefaultAuditService.java
+++ b/components/audit/src/main/java/org/trellisldp/audit/DefaultAuditService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/audit/src/main/java/org/trellisldp/audit/package-info.java
+++ b/components/audit/src/main/java/org/trellisldp/audit/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/audit/src/test/java/org/trellisldp/audit/DefaultAuditServiceTest.java
+++ b/components/audit/src/test/java/org/trellisldp/audit/DefaultAuditServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/cache/src/main/java/module-info.java
+++ b/components/cache/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/cache/src/main/java/org/trellisldp/cache/TrellisCache.java
+++ b/components/cache/src/main/java/org/trellisldp/cache/TrellisCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/cache/src/main/java/org/trellisldp/cache/package-info.java
+++ b/components/cache/src/main/java/org/trellisldp/cache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/cache/src/test/java/org/trellisldp/cache/TrellisCacheTest.java
+++ b/components/cache/src/test/java/org/trellisldp/cache/TrellisCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/cdi/src/main/java/module-info.java
+++ b/components/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/cdi/src/main/java/org/trellisldp/cdi/CDIConstraintServices.java
+++ b/components/cdi/src/main/java/org/trellisldp/cdi/CDIConstraintServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/cdi/src/main/java/org/trellisldp/cdi/package-info.java
+++ b/components/cdi/src/main/java/org/trellisldp/cdi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/cdi/src/test/java/org/trellisldp/cdi/CDIConstraintServicesTest.java
+++ b/components/cdi/src/test/java/org/trellisldp/cdi/CDIConstraintServicesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/constraint-rules/src/main/java/module-info.java
+++ b/components/constraint-rules/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/constraint-rules/src/main/java/org/trellisldp/constraint/LdpConstraintService.java
+++ b/components/constraint-rules/src/main/java/org/trellisldp/constraint/LdpConstraintService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/constraint-rules/src/main/java/org/trellisldp/constraint/package-info.java
+++ b/components/constraint-rules/src/main/java/org/trellisldp/constraint/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/constraint-rules/src/test/java/org/trellisldp/constraint/LdpConstraintServiceTest.java
+++ b/components/constraint-rules/src/test/java/org/trellisldp/constraint/LdpConstraintServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/AbstractTrellisApplication.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/AbstractTrellisApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/CrossOriginResourceSharingFilter.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/CrossOriginResourceSharingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/TrellisUtils.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/TrellisUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/AssetConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/AssetConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/AuthConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/AuthConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/BasicAuthConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/BasicAuthConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/CORSConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/CORSConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/CacheConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/CacheConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/JsonLdConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/JsonLdConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/JwtAuthConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/JwtAuthConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/NotificationsConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/NotificationsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/TrellisConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/TrellisConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/WebacConfiguration.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/WebacConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/package-info.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/package-info.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/AnyOriginTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/AnyOriginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/NoInitTrellisApplicationTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/NoInitTrellisApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleNoInitTrellisApp.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleNoInitTrellisApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleServiceBundler.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleServiceBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleTrellisApp.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SimpleTrellisApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SpecificOriginTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/SpecificOriginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisApplicationTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisUtilsTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/TrellisUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/dropwizard/src/test/java/org/trellisldp/dropwizard/config/TrellisConfigurationTest.java
+++ b/components/dropwizard/src/test/java/org/trellisldp/dropwizard/config/TrellisConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/main/java/module-info.java
+++ b/components/file/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/main/java/org/trellisldp/file/FileBinary.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileBinaryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileMementoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/main/java/org/trellisldp/file/FileNamespaceService.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileNamespaceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/main/java/org/trellisldp/file/FileResource.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/main/java/org/trellisldp/file/FileUtils.java
+++ b/components/file/src/main/java/org/trellisldp/file/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/main/java/org/trellisldp/file/package-info.java
+++ b/components/file/src/main/java/org/trellisldp/file/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileBinaryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileMementoServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/test/java/org/trellisldp/file/FileNamespaceServiceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileNamespaceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/file/src/test/java/org/trellisldp/file/FileUtilsTest.java
+++ b/components/file/src/test/java/org/trellisldp/file/FileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/io-jena/src/main/java/module-info.java
+++ b/components/io-jena/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/io-jena/src/main/java/org/trellisldp/io/JenaIOService.java
+++ b/components/io-jena/src/main/java/org/trellisldp/io/JenaIOService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/io-jena/src/main/java/org/trellisldp/io/NoopProfileCache.java
+++ b/components/io-jena/src/main/java/org/trellisldp/io/NoopProfileCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/io-jena/src/main/java/org/trellisldp/io/package-info.java
+++ b/components/io-jena/src/main/java/org/trellisldp/io/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/io-jena/src/test/java/org/trellisldp/io/JenaIOServiceTest.java
+++ b/components/io-jena/src/test/java/org/trellisldp/io/JenaIOServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/io-jena/src/test/java/org/trellisldp/io/NoopProfileCacheTest.java
+++ b/components/io-jena/src/test/java/org/trellisldp/io/NoopProfileCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/namespaces/src/main/java/module-info.java
+++ b/components/namespaces/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/namespaces/src/main/java/org/trellisldp/namespaces/SimpleNamespaceService.java
+++ b/components/namespaces/src/main/java/org/trellisldp/namespaces/SimpleNamespaceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/namespaces/src/main/java/org/trellisldp/namespaces/package-info.java
+++ b/components/namespaces/src/main/java/org/trellisldp/namespaces/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/namespaces/src/test/java/org/trellisldp/namespaces/SimpleNamespaceServiceTest.java
+++ b/components/namespaces/src/test/java/org/trellisldp/namespaces/SimpleNamespaceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/rdfa/src/main/java/module-info.java
+++ b/components/rdfa/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/rdfa/src/main/java/org/trellisldp/rdfa/DefaultRdfaWriterService.java
+++ b/components/rdfa/src/main/java/org/trellisldp/rdfa/DefaultRdfaWriterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/rdfa/src/main/java/org/trellisldp/rdfa/HtmlData.java
+++ b/components/rdfa/src/main/java/org/trellisldp/rdfa/HtmlData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/rdfa/src/main/java/org/trellisldp/rdfa/LabelledTriple.java
+++ b/components/rdfa/src/main/java/org/trellisldp/rdfa/LabelledTriple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/rdfa/src/main/java/org/trellisldp/rdfa/package-info.java
+++ b/components/rdfa/src/main/java/org/trellisldp/rdfa/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/rdfa/src/test/java/org/trellisldp/rdfa/DefaultRdfaWriterServiceTest.java
+++ b/components/rdfa/src/test/java/org/trellisldp/rdfa/DefaultRdfaWriterServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/rdfa/src/test/java/org/trellisldp/rdfa/LabelledTripleTest.java
+++ b/components/rdfa/src/test/java/org/trellisldp/rdfa/LabelledTripleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/module-info.java
+++ b/components/test/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AbstractApplicationAuditTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AbstractApplicationAuditTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AbstractApplicationAuthTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AbstractApplicationAuthTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AbstractApplicationEventTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AbstractApplicationEventTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AbstractApplicationLdpTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AbstractApplicationLdpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AbstractApplicationMementoTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AbstractApplicationMementoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AbstractResourceServiceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AbstractResourceServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AuditTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuditTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AuthAdministratorTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuthAdministratorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AuthAnonymousTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuthAnonymousTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AuthCommonTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuthCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AuthOtherUserTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuthOtherUserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/AuthUserTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuthUserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/CommonTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/CommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/EventTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/EventTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/InMemoryBinaryService.java
+++ b/components/test/src/main/java/org/trellisldp/test/InMemoryBinaryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/InMemoryResourceService.java
+++ b/components/test/src/main/java/org/trellisldp/test/InMemoryResourceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/LdpBasicContainerTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpBasicContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/LdpDirectContainerTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpDirectContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/LdpIndirectContainerTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpIndirectContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/LdpRdfTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpRdfTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/MementoBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoBinaryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/MementoCommonTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoResourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/MementoTimeGateTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoTimeGateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/MementoTimeMapTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/MementoTimeMapTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/ResourceServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/TestUtils.java
+++ b/components/test/src/main/java/org/trellisldp/test/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/main/java/org/trellisldp/test/package-info.java
+++ b/components/test/src/main/java/org/trellisldp/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/test/java/org/trellisldp/test/InMemoryBinaryServiceTest.java
+++ b/components/test/src/test/java/org/trellisldp/test/InMemoryBinaryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/test/java/org/trellisldp/test/InMemoryResourceServiceTest.java
+++ b/components/test/src/test/java/org/trellisldp/test/InMemoryResourceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/test/src/test/java/org/trellisldp/test/TestUtilsTest.java
+++ b/components/test/src/test/java/org/trellisldp/test/TestUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/main/java/module-info.java
+++ b/components/triplestore/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreHealthCheck.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreResourceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreUtils.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/TriplestoreUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/package-info.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/ResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/ResourceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreHealthCheckTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreHealthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreUtilsTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/TriplestoreUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webac/src/main/java/module-info.java
+++ b/components/webac/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webac/src/main/java/org/trellisldp/webac/Authorization.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/Authorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webac/src/main/java/org/trellisldp/webac/WebAcFilter.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebAcFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/WebAcService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webac/src/main/java/org/trellisldp/webac/package-info.java
+++ b/components/webac/src/main/java/org/trellisldp/webac/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webac/src/test/java/org/trellisldp/webac/AuthorizationTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/AuthorizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcServiceTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/module-info.java
+++ b/components/webdav/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/COPY.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/COPY.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/Depth.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/Depth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/MOVE.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/MOVE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/PROPFIND.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/PROPFIND.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/PROPPATCH.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/PROPPATCH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/TrellisWebDAV.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/TrellisWebDAV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/TrellisWebDAVRequestFilter.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/TrellisWebDAVRequestFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/TrellisWebDAVResponseFilter.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/TrellisWebDAVResponseFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/impl/WebDAVUtils.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/impl/WebDAVUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/impl/package-info.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/package-info.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavAllProp.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavAllProp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavMultiStatus.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavMultiStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavProp.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavProp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavPropFind.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavPropFind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavPropName.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavPropName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavPropStat.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavPropStat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavPropertyUpdate.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavPropertyUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavRemove.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavResponse.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavSet.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavUtils.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/DavUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/main/java/org/trellisldp/webdav/xml/package-info.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/xml/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/test/java/org/trellisldp/webdav/AbstractWebDAVTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/AbstractWebDAVTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/test/java/org/trellisldp/webdav/DebugExceptionMapper.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/DebugExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/test/java/org/trellisldp/webdav/DepthTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/DepthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/test/java/org/trellisldp/webdav/TrellisWebDAVRequestFilterTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/TrellisWebDAVRequestFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVNoBaseUrlTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVNoBaseUrlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/webdav/src/test/java/org/trellisldp/webdav/impl/WebDAVUtilsTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/impl/WebDAVUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/module-info.java
+++ b/core/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/AuditService.java
+++ b/core/api/src/main/java/org/trellisldp/api/AuditService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/Binary.java
+++ b/core/api/src/main/java/org/trellisldp/api/Binary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/BinaryMetadata.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/BinaryService.java
+++ b/core/api/src/main/java/org/trellisldp/api/BinaryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/CacheService.java
+++ b/core/api/src/main/java/org/trellisldp/api/CacheService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/ConstraintService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ConstraintService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/ConstraintViolation.java
+++ b/core/api/src/main/java/org/trellisldp/api/ConstraintViolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/DefaultIdentifierService.java
+++ b/core/api/src/main/java/org/trellisldp/api/DefaultIdentifierService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/Event.java
+++ b/core/api/src/main/java/org/trellisldp/api/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/EventSerializationService.java
+++ b/core/api/src/main/java/org/trellisldp/api/EventSerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/EventService.java
+++ b/core/api/src/main/java/org/trellisldp/api/EventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/IOService.java
+++ b/core/api/src/main/java/org/trellisldp/api/IOService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/IdentifierService.java
+++ b/core/api/src/main/java/org/trellisldp/api/IdentifierService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/MementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/MementoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/Metadata.java
+++ b/core/api/src/main/java/org/trellisldp/api/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NamespaceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NamespaceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NoopAuditService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopAuditService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NoopCacheService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopCacheService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NoopEventSerializationService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopEventSerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NoopEventService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NoopImplementation.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopMementoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NoopNamespaceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopNamespaceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/NoopResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/NoopResourceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/RDFFactory.java
+++ b/core/api/src/main/java/org/trellisldp/api/RDFFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/RDFaWriterService.java
+++ b/core/api/src/main/java/org/trellisldp/api/RDFaWriterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/Resource.java
+++ b/core/api/src/main/java/org/trellisldp/api/Resource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/ResourceService.java
+++ b/core/api/src/main/java/org/trellisldp/api/ResourceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/RetrievalService.java
+++ b/core/api/src/main/java/org/trellisldp/api/RetrievalService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/RuntimeTrellisException.java
+++ b/core/api/src/main/java/org/trellisldp/api/RuntimeTrellisException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/Session.java
+++ b/core/api/src/main/java/org/trellisldp/api/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/Syntax.java
+++ b/core/api/src/main/java/org/trellisldp/api/Syntax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
+++ b/core/api/src/main/java/org/trellisldp/api/TrellisUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/main/java/org/trellisldp/api/package-info.java
+++ b/core/api/src/main/java/org/trellisldp/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/AuditServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/AuditServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/BinaryMetadataTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/BinaryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/ConstraintServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ConstraintServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/ConstraintViolationTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ConstraintViolationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/DefaultIdentifierServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/DefaultIdentifierServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/MetadataTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/MetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/NoopCacheServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopCacheServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/NoopEventSerializationServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopEventSerializationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/NoopEventServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopEventServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/NoopMementoServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopMementoServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/NoopNamespaceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopNamespaceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/NoopResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/NoopResourceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/RDFFactoryTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/RDFFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/ResourceTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/ResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/RuntimeTrellisExceptionTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/RuntimeTrellisExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/SyntaxTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/SyntaxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/TrellisUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/module-info.java
+++ b/core/http/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/CacheControlFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/CacheControlFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/AcceptDatetime.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/AcceptDatetime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/DefaultTimemapGenerator.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/DefaultTimemapGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/Forwarded.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Forwarded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/HttpSession.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/PATCH.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/PATCH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/Prefer.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Prefer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/Range.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Range.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/RdfMediaType.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/RdfMediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/ServiceBundler.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/ServiceBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/SimpleEvent.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/SimpleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/Slug.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Slug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/TimemapGenerator.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/TimemapGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/TrellisExtensions.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/TrellisExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/TrellisRequest.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/TrellisRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/Version.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/core/package-info.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/BaseLdpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetConfiguration.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/HttpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MementoResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/OptionsHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/OptionsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/impl/package-info.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/main/java/org/trellisldp/http/package-info.java
+++ b/core/http/src/main/java/org/trellisldp/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/CacheControlFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CacheControlFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/TestAuthenticationFilter.java
+++ b/core/http/src/test/java/org/trellisldp/http/TestAuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUserTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/WebSubHeaderFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/WebSubHeaderFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/AcceptDatetimeTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/AcceptDatetimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/DefaultTimemapGeneratorTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/DefaultTimemapGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/ForwardedTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/ForwardedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/HttpSessionTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/HttpSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/PreferTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/PreferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/RangeTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/RangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/SimpleEventTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/SimpleEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/SlugTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/SlugTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/TrellisExtensionsTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/TrellisExtensionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/TrellisRequestTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/TrellisRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/core/VersionTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/core/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/BaseTestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/HttpUtilsTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/HttpUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/MementoResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/MementoResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/OptionsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PatchHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/module-info.java
+++ b/core/vocabulary/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/ACL.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/ACL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/AS.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/AS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/DC.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/DC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/FOAF.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/FOAF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/JSONLD.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/JSONLD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/LDP.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/LDP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/Memento.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/Memento.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/OA.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/OA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/PROV.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/PROV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/RDF.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/RDF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/RDFS.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/RDFS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/SKOS.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/SKOS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/Time.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/Time.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/Trellis.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/Trellis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/VCARD.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/VCARD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/VocabUtils.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/VocabUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/XSD.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/XSD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/main/java/org/trellisldp/vocabulary/package-info.java
+++ b/core/vocabulary/src/main/java/org/trellisldp/vocabulary/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/ACLTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/ACLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/ASTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/ASTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/AbstractVocabularyTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/AbstractVocabularyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/DCTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/DCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/FOAFTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/FOAFTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/JSONLDTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/JSONLDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/LDPTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/LDPTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/MementoTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/MementoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/OATest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/OATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/PROVTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/PROVTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/RDFSTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/RDFSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/RDFTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/RDFTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/SKOSTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/SKOSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TimeTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TrellisTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TrellisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/VCARDTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/VCARDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/XSDTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/XSDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/amqp/src/main/java/module-info.java
+++ b/notifications/amqp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/amqp/src/main/java/org/trellisldp/amqp/AmqpEventService.java
+++ b/notifications/amqp/src/main/java/org/trellisldp/amqp/AmqpEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/amqp/src/main/java/org/trellisldp/amqp/package-info.java
+++ b/notifications/amqp/src/main/java/org/trellisldp/amqp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/amqp/src/test/java/org/trellisldp/amqp/AmqpEventServiceTest.java
+++ b/notifications/amqp/src/test/java/org/trellisldp/amqp/AmqpEventServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jackson/src/main/java/module-info.java
+++ b/notifications/event-jackson/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jackson/src/main/java/org/trellisldp/event/jackson/ActivityStreamMessage.java
+++ b/notifications/event-jackson/src/main/java/org/trellisldp/event/jackson/ActivityStreamMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jackson/src/main/java/org/trellisldp/event/jackson/DefaultEventSerializationService.java
+++ b/notifications/event-jackson/src/main/java/org/trellisldp/event/jackson/DefaultEventSerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jackson/src/main/java/org/trellisldp/event/jackson/package-info.java
+++ b/notifications/event-jackson/src/main/java/org/trellisldp/event/jackson/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jackson/src/test/java/org/trellisldp/event/jackson/DefaultEventSerializationServiceTest.java
+++ b/notifications/event-jackson/src/test/java/org/trellisldp/event/jackson/DefaultEventSerializationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jsonb/src/main/java/module-info.java
+++ b/notifications/event-jsonb/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/ActivityStreamMessage.java
+++ b/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/ActivityStreamMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/DefaultEventSerializationService.java
+++ b/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/DefaultEventSerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/package-info.java
+++ b/notifications/event-jsonb/src/main/java/org/trellisldp/event/jsonb/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/event-jsonb/src/test/java/org/trellisldp/event/jsonb/DefaultEventSerializationServiceTest.java
+++ b/notifications/event-jsonb/src/test/java/org/trellisldp/event/jsonb/DefaultEventSerializationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/jms/src/main/java/module-info.java
+++ b/notifications/jms/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/jms/src/main/java/org/trellisldp/jms/JmsEventService.java
+++ b/notifications/jms/src/main/java/org/trellisldp/jms/JmsEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/jms/src/main/java/org/trellisldp/jms/package-info.java
+++ b/notifications/jms/src/main/java/org/trellisldp/jms/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/jms/src/test/java/org/trellisldp/jms/JmsEventServiceTest.java
+++ b/notifications/jms/src/test/java/org/trellisldp/jms/JmsEventServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/kafka/src/main/java/module-info.java
+++ b/notifications/kafka/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/kafka/src/main/java/org/trellisldp/kafka/KafkaEventService.java
+++ b/notifications/kafka/src/main/java/org/trellisldp/kafka/KafkaEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/kafka/src/main/java/org/trellisldp/kafka/package-info.java
+++ b/notifications/kafka/src/main/java/org/trellisldp/kafka/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/kafka/src/test/java/org/trellisldp/kafka/KafkaEventServiceTest.java
+++ b/notifications/kafka/src/test/java/org/trellisldp/kafka/KafkaEventServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/reactive/src/main/java/module-info.java
+++ b/notifications/reactive/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/reactive/src/main/java/org/trellisldp/reactive/ReactiveEventService.java
+++ b/notifications/reactive/src/main/java/org/trellisldp/reactive/ReactiveEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/reactive/src/main/java/org/trellisldp/reactive/package-info.java
+++ b/notifications/reactive/src/main/java/org/trellisldp/reactive/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/reactive/src/test/java/org/trellisldp/reactive/ReactiveEventServiceTest.java
+++ b/notifications/reactive/src/test/java/org/trellisldp/reactive/ReactiveEventServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/reactive/src/test/java/org/trellisldp/reactive/TestCollector.java
+++ b/notifications/reactive/src/test/java/org/trellisldp/reactive/TestCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/AppConfiguration.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/AppConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/AppUtils.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/AppUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/RDFConnectionHealthCheck.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/RDFConnectionHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/TrellisApplication.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/TrellisApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/TrellisServiceBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/package-info.java
+++ b/platform/dropwizard/src/main/java/org/trellisldp/app/triplestore/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/AppUtilsTest.java
+++ b/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/AppUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/RDFConnectionHealthCheckTest.java
+++ b/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/RDFConnectionHealthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/TrellisApplicationTest.java
+++ b/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/TrellisApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/TrellisConfigurationTest.java
+++ b/platform/dropwizard/src/test/java/org/trellisldp/app/triplestore/TrellisConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/openliberty/src/main/java/org/trellisldp/openliberty/TrellisServiceSupplier.java
+++ b/platform/openliberty/src/main/java/org/trellisldp/openliberty/TrellisServiceSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/openliberty/src/main/java/org/trellisldp/openliberty/WebApplication.java
+++ b/platform/openliberty/src/main/java/org/trellisldp/openliberty/WebApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/openliberty/src/main/java/org/trellisldp/openliberty/package-info.java
+++ b/platform/openliberty/src/main/java/org/trellisldp/openliberty/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/openliberty/src/test/java/org/trellisldp/openliberty/TrellisApplicationTest.java
+++ b/platform/openliberty/src/test/java/org/trellisldp/openliberty/TrellisApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
+++ b/platform/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/quarkus/src/main/java/org/trellisldp/quarkus/AuthorizationCache.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/quarkus/AuthorizationCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/quarkus/src/main/java/org/trellisldp/quarkus/ProfileCache.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/quarkus/ProfileCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/quarkus/src/main/java/org/trellisldp/quarkus/ServiceProviders.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/quarkus/ServiceProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/quarkus/src/main/java/org/trellisldp/quarkus/TrellisApplication.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/quarkus/TrellisApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/quarkus/src/main/java/org/trellisldp/quarkus/package-info.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/quarkus/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/quarkus/src/test/java/org/trellisldp/quarkus/ApplicationTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/quarkus/ApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/quarkus/src/test/java/org/trellisldp/quarkus/LdpTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/quarkus/LdpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform/quarkus/src/test/java/org/trellisldp/quarkus/MementoTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/quarkus/MementoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2020 Aaron Coburn and individual contributors
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This simplifies the copyright year, making it more in line with standard conventions.