### PR TITLE
Use a single no-arg ctor for JAX-RS Providers

### DIFF
--- a/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthFilterTest.java
+++ b/auth/oauth/src/test/java/org/trellisldp/auth/oauth/OAuthFilterTest.java
@@ -83,7 +83,8 @@ class OAuthFilterTest {
         when(mockCtx.getSecurityContext()).thenReturn(null);
         when(mockCtx.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
 
-        final OAuthFilter filter = new OAuthFilter(new JwtAuthenticator(key));
+        final OAuthFilter filter = new OAuthFilter();
+        filter.setAuthenticator(new JwtAuthenticator(key));
         filter.filter(mockCtx);
         verify(mockCtx).setSecurityContext(securityArgument.capture());
         assertEquals(WEBID1, securityArgument.getValue().getUserPrincipal().getName(), "Unexpected agent IRI!");
@@ -101,7 +102,8 @@ class OAuthFilterTest {
         when(mockSecurityContext.isSecure()).thenReturn(true);
         when(mockCtx.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
 
-        final OAuthFilter filter = new OAuthFilter(new JwtAuthenticator(key));
+        final OAuthFilter filter = new OAuthFilter();
+        filter.setAuthenticator(new JwtAuthenticator(key));
         filter.filter(mockCtx);
         verify(mockCtx).setSecurityContext(securityArgument.capture());
         assertEquals(WEBID1, securityArgument.getValue().getUserPrincipal().getName(), "Unexpected agent IRI!");
@@ -118,7 +120,8 @@ class OAuthFilterTest {
         when(mockCtx.getSecurityContext()).thenReturn(mockSecurityContext);
         when(mockCtx.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
 
-        final OAuthFilter filter = new OAuthFilter(new JwtAuthenticator(key));
+        final OAuthFilter filter = new OAuthFilter();
+        filter.setAuthenticator(new JwtAuthenticator(key));
         filter.filter(mockCtx);
         verify(mockCtx).setSecurityContext(securityArgument.capture());
         assertEquals(WEBID1, securityArgument.getValue().getUserPrincipal().getName(), "Unexpected agent IRI!");
@@ -134,7 +137,8 @@ class OAuthFilterTest {
         when(mockCtx.getSecurityContext()).thenReturn(mockSecurityContext);
         when(mockCtx.getHeaderString(AUTHORIZATION)).thenReturn(null);
 
-        final OAuthFilter filter = new OAuthFilter(new JwtAuthenticator(key));
+        final OAuthFilter filter = new OAuthFilter();
+        filter.setAuthenticator(new JwtAuthenticator(key));
         filter.filter(mockCtx);
         verify(mockCtx, never()).setSecurityContext(securityArgument.capture());
     }
@@ -145,7 +149,8 @@ class OAuthFilterTest {
         final String token = Jwts.builder().claim("webid", WEBID2).signWith(key).compact();
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
 
-        final OAuthFilter filter = new OAuthFilter(new JwtAuthenticator(key));
+        final OAuthFilter filter = new OAuthFilter();
+        filter.setAuthenticator(new JwtAuthenticator(key));
         filter.filter(mockContext);
         verify(mockContext).setSecurityContext(securityArgument.capture());
         assertEquals(WEBID2, securityArgument.getValue().getUserPrincipal().getName(), "Unexpected agent IRI!");
@@ -161,7 +166,10 @@ class OAuthFilterTest {
         final String token = Jwts.builder().claim("webid", WEBID2).signWith(key).compact();
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
 
-        final OAuthFilter filter = new OAuthFilter(new JwtAuthenticator(key), "trellis", singleton(WEBID2));
+        final OAuthFilter filter = new OAuthFilter();
+        filter.setAuthenticator(new JwtAuthenticator(key));
+        filter.setChallenge("Bearer realm=\"trellis\"");
+        filter.setAdmins(singleton(WEBID2));
         filter.filter(mockContext);
         verify(mockContext).setSecurityContext(securityArgument.capture());
         assertEquals(WEBID2, securityArgument.getValue().getUserPrincipal().getName(), "Unexpected agent IRI!");
@@ -178,8 +186,8 @@ class OAuthFilterTest {
         final String token = Jwts.builder().setSubject(WEBID1).signWith(hmacShaKeyFor(key.getBytes(UTF_8))).compact();
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
 
-        final OAuthFilter filter = new OAuthFilter(new JwtAuthenticator(hmacShaKeyFor(key.replaceFirst("B", "A")
-                        .getBytes())));
+        final OAuthFilter filter = new OAuthFilter();
+        filter.setAuthenticator(new JwtAuthenticator(hmacShaKeyFor(key.replaceFirst("B", "A").getBytes())));
         assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext));
     }
 
@@ -190,7 +198,8 @@ class OAuthFilterTest {
             .signWith(key).compact();
         when(mockContext.getHeaderString(AUTHORIZATION)).thenReturn("Bearer " + token);
 
-        final OAuthFilter filter = new OAuthFilter(new JwtAuthenticator(key));
+        final OAuthFilter filter = new OAuthFilter();
+        filter.setAuthenticator(new JwtAuthenticator(key));
         assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext));
     }
 

--- a/components/dropwizard/src/main/java/org/trellisldp/dropwizard/TrellisUtils.java
+++ b/components/dropwizard/src/main/java/org/trellisldp/dropwizard/TrellisUtils.java
@@ -94,11 +94,19 @@ final class TrellisUtils {
         final Set<String> admins = new HashSet<>(config.getAuth().getAdminUsers());
 
         if (auth.getJwt().getEnabled()) {
-            filters.add(new OAuthFilter(getJwtAuthenticator(auth.getJwt()), realm, admins));
+            final OAuthFilter filter = new OAuthFilter();
+            filter.setAuthenticator(getJwtAuthenticator(auth.getJwt()));
+            filter.setChallenge("Bearer realm=\"" + realm + "\"");
+            filter.setAdmins(admins);
+            filters.add(filter);
         }
 
         if (auth.getBasic().getEnabled() && auth.getBasic().getUsersFile() != null) {
-            filters.add(new BasicAuthFilter(new File(auth.getBasic().getUsersFile()), realm, admins));
+            final BasicAuthFilter filter = new BasicAuthFilter();
+            filter.setFile(new File(auth.getBasic().getUsersFile()));
+            filter.setChallenge("Basic realm=\"" + realm + "\"");
+            filter.setAdmins(admins);
+            filters.add(filter);
         }
 
         return filters;

--- a/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
+++ b/components/webac/src/test/java/org/trellisldp/webac/WebAcFilterTest.java
@@ -128,7 +128,8 @@ class WebAcFilterTest {
     void testFilterUnknownMethod() {
         when(mockContext.getMethod()).thenReturn("FOO");
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Exception thrown with unknown method!");
     }
 
@@ -138,7 +139,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("GET");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Read);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
 
@@ -163,7 +165,8 @@ class WebAcFilterTest {
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
         when(mockUriInfo.getPath()).thenReturn("container/");
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Read);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
 
@@ -182,7 +185,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("READ");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Read);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
 
@@ -201,7 +205,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("PUT");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Write);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Write ability!");
 
@@ -221,7 +226,8 @@ class WebAcFilterTest {
         when(mockContext.getHeaderString(eq(PREFER))).thenReturn("return=representation");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Write);
 
         assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
@@ -238,7 +244,8 @@ class WebAcFilterTest {
         when(mockContext.getHeaderString(eq(PREFER))).thenReturn("return=minimal");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Write);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Write ability!");
 
@@ -252,7 +259,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("WRITE");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Write);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Write ability!");
 
@@ -271,7 +279,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("POST");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Append);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Append ability!");
 
@@ -296,7 +305,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("APPEND");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Append);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Append ability!");
 
@@ -321,7 +331,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("GET");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Read);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
 
@@ -346,7 +357,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("GET");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Read);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
 
@@ -370,7 +382,8 @@ class WebAcFilterTest {
         when(mockContext.getMethod()).thenReturn("GET");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
         modes.add(ACL.Read);
         assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
 
@@ -391,12 +404,39 @@ class WebAcFilterTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
+    void testDeprecatedMethod() {
+        final Set<IRI> modes = new HashSet<>();
+        when(mockContext.getMethod()).thenReturn("GET");
+        when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(modes);
+
+        final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+        modes.add(ACL.Read);
+        assertDoesNotThrow(() -> filter.filter(mockContext), "Unexpected exception after adding Read ability!");
+
+        verify(mockContext).setProperty(eq(WebAcFilter.SESSION_WEBAC_MODES), modesArgument.capture());
+        assertTrue(modesArgument.getValue().contains(ACL.Read));
+        assertEquals(modes.size(), modesArgument.getValue().size());
+
+        modes.clear();
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
+                "No expception thrown when not authorized!");
+
+        when(mockContext.getSecurityContext()).thenReturn(mockSecurityContext);
+        assertThrows(ForbiddenException.class, () -> filter.filter(mockContext),
+                "No exception thrown!");
+    }
+
+    @Test
     void testFilterChallenges() {
         when(mockContext.getMethod()).thenReturn("POST");
         when(mockWebAcService.getAccessModes(any(IRI.class), any(Session.class))).thenReturn(emptySet());
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "my-scope",
-                "http://example.com/");
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
+        filter.setChallenges(asList("Foo realm=\"my-realm\" scope=\"my-scope\"",
+                    "Bar realm=\"my-realm\" scope=\"my-scope\""));
+        filter.setBaseUrl("http://example.com/");
 
         final List<Object> challenges = assertThrows(NotAuthorizedException.class, () -> filter.filter(mockContext),
                 "No auth exception thrown with no access modes!").getChallenges();
@@ -411,7 +451,8 @@ class WebAcFilterTest {
         when(mockResponseContext.getStatusInfo()).thenReturn(OK);
         when(mockResponseContext.getHeaders()).thenReturn(headers);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "", null);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);
@@ -430,7 +471,8 @@ class WebAcFilterTest {
         when(mockResponseContext.getStatusInfo()).thenReturn(OK);
         when(mockResponseContext.getHeaders()).thenReturn(headers);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "", null);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);
@@ -444,8 +486,8 @@ class WebAcFilterTest {
         when(mockResponseContext.getHeaders()).thenReturn(headers);
         when(mockUriInfo.getPath()).thenReturn("/path");
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "",
-                "http://example.com/");
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);
@@ -468,7 +510,8 @@ class WebAcFilterTest {
         when(mockUriInfo.getQueryParameters()).thenReturn(params);
         when(mockUriInfo.getPath()).thenReturn("path/");
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "", null);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);
@@ -486,7 +529,8 @@ class WebAcFilterTest {
         when(mockResponseContext.getStatusInfo()).thenReturn(FORBIDDEN);
         when(mockResponseContext.getHeaders()).thenReturn(headers);
 
-        final WebAcFilter filter = new WebAcFilter(mockWebAcService, asList("Foo", "Bar"), "my-realm", "", null);
+        final WebAcFilter filter = new WebAcFilter();
+        filter.setAccessService(mockWebAcService);
 
         assertTrue(headers.isEmpty());
         filter.filter(mockContext, mockResponseContext);
@@ -530,7 +574,8 @@ class WebAcFilterTest {
 
         try {
             System.setProperty(WebAcFilter.CONFIG_WEBAC_ENABED, "false");
-            final WebAcFilter filter = new WebAcFilter(mockWebAcService);
+            final WebAcFilter filter = new WebAcFilter();
+            filter.setAccessService(mockWebAcService);
 
             assertDoesNotThrow(() -> filter.filter(mockContext),
                     "No exception thrown when WebAC is disabled!");

--- a/components/webdav/src/main/java/org/trellisldp/webdav/TrellisWebDAVRequestFilter.java
+++ b/components/webdav/src/main/java/org/trellisldp/webdav/TrellisWebDAVRequestFilter.java
@@ -15,6 +15,7 @@
  */
 package org.trellisldp.webdav;
 
+import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.HttpMethod.DELETE;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.HttpMethod.PUT;
@@ -55,28 +56,30 @@ import org.trellisldp.vocabulary.LDP;
 @PreMatching
 public class TrellisWebDAVRequestFilter implements ContainerRequestFilter {
 
-    private final ServiceBundler services;
-    private final boolean createUncontained;
-    private final String baseUrl;
+
+    private boolean createUncontained;
+    private String baseUrl;
+    private ServiceBundler services;
+
+    /**
+     * Create a Trellis HTTP request filter for WebDAV.
+     */
+    public TrellisWebDAVRequestFilter() {
+        final Config config = getConfig();
+        this.createUncontained = config.getOptionalValue(CONFIG_HTTP_PUT_UNCONTAINED, Boolean.class)
+            .orElse(Boolean.FALSE);
+        this.baseUrl = config.getOptionalValue(CONFIG_HTTP_BASE_URL, String.class).orElse(null);
+    }
 
     /**
      * Create a Trellis HTTP request filter for WebDAV.
      *
      * @param services the Trellis application bundle
+     * @deprecated This constructor should not be used and will be removed in a future release
      */
-    @Inject
+    @Deprecated
     public TrellisWebDAVRequestFilter(final ServiceBundler services) {
         this(services, getConfig());
-    }
-
-    /**
-     * For use with RESTeasy and CDI proxies.
-     *
-     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
-     *          It should not be invoked directly in user code.
-     */
-    public TrellisWebDAVRequestFilter() {
-        this(null);
     }
 
     private TrellisWebDAVRequestFilter(final ServiceBundler services, final Config config) {
@@ -91,11 +94,38 @@ public class TrellisWebDAVRequestFilter implements ContainerRequestFilter {
      * @param services the Trellis application bundle
      * @param createUncontained whether the put-uncontained configuration is in effect
      * @param baseUrl the baseURL
+     * @deprecated This constructor should not be used and will be removed in a future release
      */
+    @Deprecated
     public TrellisWebDAVRequestFilter(final ServiceBundler services, final boolean createUncontained,
             final String baseUrl) {
         this.services = services;
         this.createUncontained = createUncontained;
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * Set the service bundler.
+     * @param services the services
+     */
+    @Inject
+    public void setServiceBundler(final ServiceBundler services) {
+        this.services = requireNonNull(services, "Services may not be null!");
+    }
+
+    /**
+     * Set the create-uncontained flag.
+     * @param createUncontained whether created resources should be uncontained by parent containers
+     */
+    public void setCreateUncontained(final boolean createUncontained) {
+        this.createUncontained = createUncontained;
+    }
+
+    /**
+     * Set the base URL.
+     * @param baseUrl the base URL
+     */
+    public void setBaseUrl(final String baseUrl) {
         this.baseUrl = baseUrl;
     }
 

--- a/components/webdav/src/test/java/org/trellisldp/webdav/TrellisWebDAVRequestFilterTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/TrellisWebDAVRequestFilterTest.java
@@ -92,7 +92,10 @@ class TrellisWebDAVRequestFilterTest {
         when(mockUriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
         when(mockPathSegment.getPath()).thenReturn(PATH);
 
-        filter = new TrellisWebDAVRequestFilter(mockBundler, true, null);
+        filter = new TrellisWebDAVRequestFilter();
+        filter.setServiceBundler(mockBundler);
+        filter.setCreateUncontained(true);
+        filter.setBaseUrl(null);
     }
 
     @Test
@@ -110,7 +113,8 @@ class TrellisWebDAVRequestFilterTest {
 
     @Test
     void testTestPutContainedMissing() {
-        final TrellisWebDAVRequestFilter filter2 = new TrellisWebDAVRequestFilter(mockBundler, false, null);
+        final TrellisWebDAVRequestFilter filter2 = new TrellisWebDAVRequestFilter();
+        filter2.setServiceBundler(mockBundler);
 
         filter2.filter(mockContext);
         verify(mockContext, never()).setMethod(eq(POST));

--- a/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVNoBaseUrlTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVNoBaseUrlTest.java
@@ -26,9 +26,11 @@ import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.SecurityContext;
 
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.TestInstance;
 import org.trellisldp.http.TrellisHttpResource;
+import org.trellisldp.http.core.ServiceBundler;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WebDAVNoBaseUrlTest extends AbstractWebDAVTest {
@@ -79,10 +81,16 @@ class WebDAVNoBaseUrlTest extends AbstractWebDAVTest {
 
         config.register(new DebugExceptionMapper());
         config.register(new TestAuthnFilter("testUser", ""));
-        config.register(new TrellisWebDAVRequestFilter(mockBundler));
+        config.register(new TrellisWebDAVRequestFilter());
         config.register(new TrellisWebDAVResponseFilter());
         config.register(new TrellisWebDAV(mockBundler));
         config.register(new TrellisHttpResource(mockBundler));
+        config.register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(mockBundler).to(ServiceBundler.class);
+            }
+        });
         return config;
     }
 }

--- a/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVTest.java
+++ b/components/webdav/src/test/java/org/trellisldp/webdav/WebDAVTest.java
@@ -20,9 +20,11 @@ import static org.trellisldp.http.core.HttpConstants.CONFIG_HTTP_BASE_URL;
 
 import javax.ws.rs.core.Application;
 
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.TestInstance;
 import org.trellisldp.http.TrellisHttpResource;
+import org.trellisldp.http.core.ServiceBundler;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WebDAVTest extends AbstractWebDAVTest {
@@ -37,10 +39,16 @@ class WebDAVTest extends AbstractWebDAVTest {
         try {
             System.setProperty(CONFIG_HTTP_BASE_URL, getBaseUri().toString());
             config.register(new DebugExceptionMapper());
-            config.register(new TrellisWebDAVRequestFilter(mockBundler));
+            config.register(new TrellisWebDAVRequestFilter());
             config.register(new TrellisWebDAVResponseFilter());
             config.register(new TrellisWebDAV(mockBundler));
             config.register(new TrellisHttpResource(mockBundler));
+            config.register(new AbstractBinder() {
+                @Override
+                protected void configure() {
+                    bind(mockBundler).to(ServiceBundler.class);
+                }
+            });
             return config;
         } finally {
             System.clearProperty(CONFIG_HTTP_BASE_URL);

--- a/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/TrellisHttpFilter.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Priority;
-import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Link;
@@ -55,24 +54,42 @@ import org.trellisldp.http.core.Version;
 @Priority(AUTHORIZATION - 20)
 public class TrellisHttpFilter implements ContainerRequestFilter {
 
-    private final List<String> mutatingMethods;
-    private final Map<String, IRI> extensions;
+    private List<String> mutatingMethods;
+    private Map<String, IRI> extensions;
 
     /**
      * Create a simple pre-matching filter.
      */
-    @Inject
     public TrellisHttpFilter() {
-        this(asList(POST, PUT, DELETE, PATCH), buildExtensionMapFromConfig(getConfig()));
+        this.mutatingMethods = asList(POST, PUT, DELETE, PATCH);
+        this.extensions = buildExtensionMapFromConfig(getConfig());
     }
 
     /**
      * Create a simple pre-matching filter with a custom method list.
      * @param mutatingMethods a list of mutating HTTP methods
      * @param extensions a map of named graph extensions
+     * @deprecated this constructor is deprecated and will be removed in a future release
      */
+    @Deprecated
     public TrellisHttpFilter(final List<String> mutatingMethods, final Map<String, IRI> extensions) {
         this.mutatingMethods = unmodifiableList(mutatingMethods);
+        this.extensions = extensions;
+    }
+
+    /**
+     * Set the mutating methods.
+     * @param mutatingMethods a list of mutating HTTP methods
+     */
+    public void setMutatingMethods(final List<String> mutatingMethods) {
+        this.mutatingMethods = mutatingMethods;
+    }
+
+    /**
+     * Set the extension map.
+     * @param extensions a map of named graph extensions
+     */
+    public void setExtensions(final Map<String, IRI> extensions) {
         this.extensions = extensions;
     }
 

--- a/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
+++ b/core/http/src/main/java/org/trellisldp/http/WebSubHeaderFilter.java
@@ -22,7 +22,6 @@ import static javax.ws.rs.core.Link.fromUri;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
 
-import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -40,22 +39,31 @@ public class WebSubHeaderFilter implements ContainerResponseFilter {
     /** The configuration key controlling the location of a web-sub-hub. */
     public static final String CONFIG_HTTP_WEB_SUB_HUB = "trellis.http.web-sub-hub";
 
-    private final String hub;
+    private String hub;
 
     /**
      * Create a new WebSub header Decorator.
      */
-    @Inject
     public WebSubHeaderFilter() {
-        this(getConfig().getOptionalValue(CONFIG_HTTP_WEB_SUB_HUB, String.class).orElse(null));
+        this.hub = getConfig().getOptionalValue(CONFIG_HTTP_WEB_SUB_HUB, String.class).orElse(null);
     }
 
     /**
      * Create a new WebSub Header Decorator.
      *
      * @param hub the location of the websub hub
+     * @deprecated this constructor is deprecated and will be removed in a future release
      */
+    @Deprecated
     public WebSubHeaderFilter(final String hub) {
+        this.hub = hub;
+    }
+
+    /**
+     * Set the hub value.
+     * @param hub the WebSubHub location
+     */
+    public void setHub(final String hub) {
         this.hub = hub;
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/BaseTrellisHttpResourceTest.java
@@ -57,6 +57,7 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
@@ -161,11 +162,17 @@ abstract class BaseTrellisHttpResourceTest extends JerseyTest {
 
     @BeforeEach
     void setUpMocks() {
+        System.setProperty(WebSubHeaderFilter.CONFIG_HTTP_WEB_SUB_HUB, HUB);
         setUpBundler();
         setUpResourceService();
         setUpMementoService();
         setUpBinaryService();
         setUpResources();
+    }
+
+    @AfterEach
+    void cleanUpProperties() {
+        System.clearProperty(WebSubHeaderFilter.CONFIG_HTTP_WEB_SUB_HUB);
     }
 
     private void setUpBundler() {

--- a/core/http/src/test/java/org/trellisldp/http/CacheControlFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/CacheControlFilterTest.java
@@ -53,7 +53,8 @@ class CacheControlFilterTest {
         when(mockRequest.getMethod()).thenReturn(GET);
         when(mockResponse.getStatusInfo()).thenReturn(OK);
 
-        final CacheControlFilter filter = new CacheControlFilter(0, true, false);
+        final CacheControlFilter filter = new CacheControlFilter();
+        filter.setMaxAge(0);
 
         filter.filter(mockRequest, mockResponse);
         verify(mockResponse, never()).getHeaders();
@@ -66,7 +67,10 @@ class CacheControlFilterTest {
         when(mockResponse.getStatusInfo()).thenReturn(OK);
         when(mockResponse.getHeaders()).thenReturn(mockHeaders);
 
-        final CacheControlFilter filter = new CacheControlFilter(180, true, false);
+        final CacheControlFilter filter = new CacheControlFilter();
+        filter.setMaxAge(180);
+        filter.setMustRevalidate(false);
+        filter.setNoCache(true);
 
         filter.filter(mockRequest, mockResponse);
         verify(mockResponse).getHeaders();

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceAdminTest.java
@@ -39,13 +39,14 @@ class TrellisHttpResourceAdminTest extends AbstractTrellisHttpResourceTest {
 
         initMocks(this);
 
+        System.setProperty(WebSubHeaderFilter.CONFIG_HTTP_WEB_SUB_HUB, HUB);
         final String baseUri = getBaseUri().toString();
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler, singletonMap(ACL, PreferAccessControl), baseUri));
         config.register(new TestAuthenticationFilter("testUser", ""));
         config.register(new CacheControlFilter());
-        config.register(new WebSubHeaderFilter(HUB));
+        config.register(new WebSubHeaderFilter());
         config.register(new TrellisHttpFilter());
         return config;
     }

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceBaseUrlTest.java
@@ -44,11 +44,13 @@ class TrellisHttpResourceBaseUrlTest extends AbstractTrellisHttpResourceTest {
         // Junit runner doesn't seem to work very well with JerseyTest
         initMocks(this);
 
+        System.setProperty(WebSubHeaderFilter.CONFIG_HTTP_WEB_SUB_HUB, HUB);
+
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler, singletonMap(ACL, PreferAccessControl), URL));
         config.register(new TestAuthenticationFilter("testUser", "group"));
         config.register(new CacheControlFilter());
-        config.register(new WebSubHeaderFilter(HUB));
+        config.register(new WebSubHeaderFilter());
         config.register(new TrellisHttpFilter());
         return config;
     }

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceNoAgentTest.java
@@ -40,12 +40,14 @@ class TrellisHttpResourceNoAgentTest extends AbstractTrellisHttpResourceTest {
         // Junit runner doesn't seem to work very well with JerseyTest
         initMocks(this);
 
+        System.setProperty(WebSubHeaderFilter.CONFIG_HTTP_WEB_SUB_HUB, HUB);
+
         final String baseUri = getBaseUri().toString();
 
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler, singletonMap(ACL, PreferAccessControl), baseUri));
         config.register(new CacheControlFilter());
-        config.register(new WebSubHeaderFilter(HUB));
+        config.register(new WebSubHeaderFilter());
         config.register(new TrellisHttpFilter());
         return config;
     }

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceTest.java
@@ -76,11 +76,13 @@ class TrellisHttpResourceTest extends AbstractTrellisHttpResourceTest {
 
         initMocks(this);
 
+        System.setProperty(WebSubHeaderFilter.CONFIG_HTTP_WEB_SUB_HUB, HUB);
+
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler, singletonMap(ACL, PreferAccessControl), null));
         config.register(new CacheControlFilter());
-        config.register(new WebSubHeaderFilter(HUB));
         config.register(new TrellisHttpFilter());
+        config.register(new WebSubHeaderFilter());
         return config;
     }
 

--- a/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUserTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/TrellisHttpResourceUserTest.java
@@ -32,11 +32,13 @@ class TrellisHttpResourceUserTest extends AbstractTrellisHttpResourceTest {
         // Junit runner doesn't seem to work very well with JerseyTest
         initMocks(this);
 
+        System.setProperty(WebSubHeaderFilter.CONFIG_HTTP_WEB_SUB_HUB, HUB);
+
         final ResourceConfig config = new ResourceConfig();
         config.register(new TrellisHttpResource(mockBundler));
         config.register(new TestAuthenticationFilter("testUser", "group"));
         config.register(new CacheControlFilter());
-        config.register(new WebSubHeaderFilter(HUB));
+        config.register(new WebSubHeaderFilter());
         config.register(new TrellisHttpFilter());
         return config;
     }

--- a/core/http/src/test/java/org/trellisldp/http/WebSubHeaderFilterTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/WebSubHeaderFilterTest.java
@@ -66,7 +66,8 @@ class WebSubHeaderFilterTest {
         when(mockResponse.getStatusInfo()).thenReturn(OK);
         when(mockResponse.getHeaders()).thenReturn(mockHeaders);
 
-        final WebSubHeaderFilter filter = new WebSubHeaderFilter("http://example.com");
+        final WebSubHeaderFilter filter = new WebSubHeaderFilter();
+        filter.setHub("http://example.com");
 
         filter.filter(mockRequest, mockResponse);
         verify(mockResponse).getHeaders();


### PR DESCRIPTION
Resolves: #819

JAX-RS providers should have a single no-arg constructor in order to be supported across JAX-RS implementations