### PR TITLE
Use Java11 for OSGi tests

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -89,13 +89,13 @@ jobs:
   osgi:
     needs: [validation]
     runs-on: ubuntu-latest
-    name: Java 8 OSGi environment
+    name: Java 11 OSGi environment
     steps:
     - uses: actions/checkout@v2.1.0
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1.3.0
       with:
-        java-version: 8
+        java-version: 11
     - name: Cache
       uses: actions/cache@v1.1.2
       with:

--- a/platform/osgi/build.gradle
+++ b/platform/osgi/build.gradle
@@ -124,12 +124,6 @@ test {
     systemProperty 'karaf.rmiServer.port', randomPort()
     systemProperty 'karaf.rmiRegistry.port', randomPort()
 
-    if (project.hasProperty("osgi") && JavaVersion.current().isJava9Compatible()) {
-        println "--------------------------------------------------"
-        println "OSGi tests are not guaranteed to succeed on JDK 9+"
-        println "   Please run OSGi tests on a JDK 8 environment   "
-        println "--------------------------------------------------"
-    }
     enabled = project.hasProperty("osgi")
 }
 


### PR DESCRIPTION
The OSGi tests are now suitably stable for Java 11