### PR TITLE
Disable pmd analysis by default

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: ${{ matrix.java }}
 
     - name: Build with Gradle
-      run: ./gradlew check assemble javadoc -x pmdMain
+      run: ./gradlew check assemble javadoc
 
   docker:
     needs: [build]

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -42,7 +42,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Build with Gradle
-      run: ./gradlew check assemble javadoc -x pmdMain
+      run: ./gradlew check assemble javadoc
 
   security:
     needs: [validation]
@@ -84,7 +84,7 @@ jobs:
 
     - name: Build with Gradle
       shell: bash
-      run: ./gradlew.bat -x pmdMain check
+      run: ./gradlew.bat check
 
   osgi:
     needs: [validation]
@@ -105,7 +105,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Build with Gradle
-      run: ./gradlew -p platform/osgi -x pmdMain check -Posgi
+      run: ./gradlew -p platform/osgi check -Posgi
 
   jpms:
     needs: [validation]
@@ -126,5 +126,5 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Build with Gradle
-      run: ./gradlew check install -x pmdMain -Pjpms
+      run: ./gradlew check install -Pjpms
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
     - name: "Java 8"
       stage: test
       jdk: openjdk8
-      script: travis_retry ./gradlew check install jacocoRootReport -x pmdMain --scan
+      script: travis_retry ./gradlew check install jacocoRootReport --scan
       after_success: ./gradlew coveralls sonarqube
 
     # deploy JDK 8 builds to Sonatype

--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,9 @@ subprojects { subproj ->
         ruleSetConfig = resources.text.fromFile(rootProject.file('buildtools/src/main/resources/pmd/pmd.xml'))
     }
 
+    // Enable PMD analysis on request (e.g. ./gradlew build -P pmd)
+    pmdMain.enabled = project.hasProperty("pmd")
+
     checkstyle {
         configFile = rootProject.file('buildtools/src/main/resources/checkstyle/checkstyle.xml')
         configProperties.checkstyleConfigDir = rootProject.file('buildtools/src/main/resources/checkstyle/')


### PR DESCRIPTION
PMD analysis adds quite a bit of overhead/time to the build. This disables analysis from the default build but keeps it available if enabled via `gradle build -P pmd`