### PR TITLE
Add RDFConnectionProvider class

### DIFF
--- a/components/triplestore/src/main/java/org/trellisldp/triplestore/RDFConnectionProvider.java
+++ b/components/triplestore/src/main/java/org/trellisldp/triplestore/RDFConnectionProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.triplestore;
+
+import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
+import static org.trellisldp.triplestore.TriplestoreResourceService.CONFIG_TRIPLESTORE_RDF_LOCATION;
+import static org.trellisldp.triplestore.TriplestoreResourceService.buildRDFConnection;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import org.apache.jena.rdfconnection.RDFConnection;
+
+@ApplicationScoped
+public class RDFConnectionProvider {
+
+    private final RDFConnection rdfConnection;
+
+    /**
+     * Create an RDFConnection bean.
+     */
+    public RDFConnectionProvider() {
+        this(buildRDFConnection(getConfig()
+                    .getOptionalValue(CONFIG_TRIPLESTORE_RDF_LOCATION, String.class).orElse(null)));
+    }
+
+    /**
+     * Create an RDFConnection provider with a user-supplied connection.
+     * @param rdfConnection the RDF connection
+     */
+    public RDFConnectionProvider(final RDFConnection rdfConnection) {
+        this.rdfConnection = rdfConnection;
+    }
+
+    @Produces
+    public RDFConnection getRdfConnection() {
+        return rdfConnection;
+    }
+}

--- a/components/triplestore/src/test/java/org/trellisldp/triplestore/RDFConnectionProviderTest.java
+++ b/components/triplestore/src/test/java/org/trellisldp/triplestore/RDFConnectionProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Aaron Coburn and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.triplestore;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+
+import org.apache.jena.rdfconnection.RDFConnectionLocal;
+import org.apache.jena.rdfconnection.RDFConnectionRemote;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class RDFConnectionProviderTest {
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty(TriplestoreResourceService.CONFIG_TRIPLESTORE_RDF_LOCATION);
+    }
+
+    @Test
+    void testRDFConnectionMemory() {
+        final RDFConnectionProvider provider = new RDFConnectionProvider();
+        assertTrue(provider.getRdfConnection() instanceof RDFConnectionLocal);
+    }
+
+    @Test
+    void testRDFConnectionRemote() {
+        System.setProperty(TriplestoreResourceService.CONFIG_TRIPLESTORE_RDF_LOCATION, "http://example.com/sparql");
+        final RDFConnectionProvider provider = new RDFConnectionProvider();
+        assertTrue(provider.getRdfConnection() instanceof RDFConnectionRemote);
+    }
+
+    @Test
+    void testRDFConnectionLocal() throws Exception {
+        final File dir = new File(new File(getClass().getResource("/logback-test.xml").toURI()).getParent(), "data2");
+        System.setProperty(TriplestoreResourceService.CONFIG_TRIPLESTORE_RDF_LOCATION, dir.getAbsolutePath());
+        final RDFConnectionProvider provider = new RDFConnectionProvider();
+        assertTrue(provider.getRdfConnection() instanceof RDFConnectionLocal);
+    }
+}

--- a/platform/openliberty/src/main/java/org/trellisldp/openliberty/TrellisServiceSupplier.java
+++ b/platform/openliberty/src/main/java/org/trellisldp/openliberty/TrellisServiceSupplier.java
@@ -15,14 +15,9 @@
  */
 package org.trellisldp.openliberty;
 
-import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
-import static org.trellisldp.triplestore.TriplestoreResourceService.CONFIG_TRIPLESTORE_RDF_LOCATION;
-import static org.trellisldp.triplestore.TriplestoreResourceService.buildRDFConnection;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
-import org.apache.jena.rdfconnection.RDFConnection;
 import org.trellisldp.api.*;
 import org.trellisldp.file.FileMementoService;
 
@@ -32,17 +27,9 @@ import org.trellisldp.file.FileMementoService;
 @ApplicationScoped
 public class TrellisServiceSupplier {
 
-    private RDFConnection rdfConnection = buildRDFConnection(getConfig()
-            .getOptionalValue(CONFIG_TRIPLESTORE_RDF_LOCATION, String.class).orElse(null));
-
     private EventService eventService = new NoopEventService();
 
     private MementoService mementoService = new FileMementoService();
-
-    @Produces
-    RDFConnection getRdfConnection() {
-        return rdfConnection;
-    }
 
     @Produces
     EventService getEventService() {

--- a/platform/quarkus/src/main/java/org/trellisldp/quarkus/ServiceProviders.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/quarkus/ServiceProviders.java
@@ -15,32 +15,19 @@
  */
 package org.trellisldp.quarkus;
 
-import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
-import static org.trellisldp.triplestore.TriplestoreResourceService.CONFIG_TRIPLESTORE_RDF_LOCATION;
-import static org.trellisldp.triplestore.TriplestoreResourceService.buildRDFConnection;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
-import org.apache.jena.rdfconnection.RDFConnection;
 import org.trellisldp.api.MementoService;
 import org.trellisldp.file.FileMementoService;
 
 @ApplicationScoped
 class ServiceProducers {
 
-    private RDFConnection rdfConnection = buildRDFConnection(getConfig()
-            .getOptionalValue(CONFIG_TRIPLESTORE_RDF_LOCATION, String.class).orElse(null));
-
     private MementoService mementoService = new FileMementoService();
 
     @Produces
     MementoService getMementoService() {
         return mementoService;
-    }
-
-    @Produces
-    RDFConnection getRdfConnection() {
-        return rdfConnection;
     }
 }


### PR DESCRIPTION
This adds a RDFConnection producer for CDI apps such as quarkus and openliberty, which makes the triplestore layer more swappable for other backends, which will make things more flexible for #837 