### PR TITLE
Make vocab testing strict

### DIFF
--- a/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TrellisTest.java
+++ b/core/vocabulary/src/test/java/org/trellisldp/vocabulary/TrellisTest.java
@@ -22,12 +22,6 @@ package org.trellisldp.vocabulary;
 class TrellisTest extends AbstractVocabularyTest {
 
     @Override
-    boolean isStrict() {
-        // TODO remove this once the new vocab has been published
-        return false;
-    }
-
-    @Override
     String namespace() {
         return "http://www.trellisldp.org/ns/trellis#";
     }


### PR DESCRIPTION
Now that the new Trellis vocabulary has been published, we can do strict enforcement on the terms.