### PR TITLE
Adjust pmd configuration for task graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,8 +313,8 @@ subprojects { subproj ->
         ruleSetConfig = resources.text.fromFile(rootProject.file('buildtools/src/main/resources/pmd/pmd.xml'))
     }
 
-    // Enable PMD analysis on request (e.g. ./gradlew build -P pmd)
-    pmdMain.enabled = project.hasProperty("pmd")
+    // Enable PMD analysis on request (e.g. ./gradlew build -P pmdAnalysis)
+    pmdMain.enabled = project.hasProperty("pmdAnalysis")
 
     checkstyle {
         configFile = rootProject.file('buildtools/src/main/resources/checkstyle/checkstyle.xml')


### PR DESCRIPTION
It turns out that `property.hasProperty("pmd")` is always true