### PR TITLE
Adjust CI for sonar analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ group: edge
 addons:
   sonarcloud:
     organization: trellis-ldp
+  postgresql: "9.4"
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -58,8 +59,8 @@ jobs:
         - QUARKUS_DATASOURCE_USERNAME=postgres
         - QUARKUS_DATASOURCE_PASSWORD=postgres
         - QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://localhost/trellis
-      script: travis_retry ./gradlew check install -Ptriplestore jacocoRootReport --scan
-      after_success: ./gradlew coveralls sonarqube
+      script: ./gradlew check install -Ptriplestore jacocoRootReport --scan
+      after_success: ./gradlew coveralls sonarqube -Ptriplestore
 
     # deploy JDK 8 builds to Sonatype
     - name: "Publish to Sonatype"


### PR DESCRIPTION
The sonar analysis requires the `-Ptriplestore` flag (or a fully-functional database)