### PR TITLE
Use sonar for coverage stats

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -229,7 +229,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Build with Gradle
-      run: ./gradlew check jacocoRootReport coveralls sonarqube -Dsonar.host.url=https://sonarcloud.io
+      run: ./gradlew check jacocoRootReport sonarqube -Dsonar.host.url=https://sonarcloud.io
       env:
         QUARKUS_DATASOURCE_USERNAME: postgres
         QUARKUS_DATASOURCE_PASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 A scalable platform for building [linked data](https://www.w3.org/TR/ldp/) applications.
 
 ![Build Status](https://github.com/trellis-ldp/trellis/workflows/GitHub%20CI/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/trellis-ldp/trellis/badge.svg?branch=master)](https://coveralls.io/github/trellis-ldp/trellis?branch=master)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/cd0f09e025ce4a9e9c00fd7b04fb66fb)](https://www.codacy.com/gh/trellis-ldp/trellis?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=trellis-ldp/trellis&amp;utm_campaign=Badge_Grade)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=org.trellisldp%3Atrellis&metric=coverage)](https://sonarcloud.io/dashboard?id=org.trellisldp%3Atrellis)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/trellis-ldp/trellis.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/trellis-ldp/trellis/alerts/)
 ![Maven Central](https://img.shields.io/maven-central/v/org.trellisldp/trellis-api.svg)
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
 plugins {
     id 'com.github.ben-manes.versions' version "0.28.0"
     id 'com.github.hierynomus.license' version "0.15.0"
-    id 'com.github.kt3k.coveralls' version "2.10.1"
     id 'net.researchgate.release' version "2.8.1"
     id 'org.gradle.test-retry' version "1.1.5"
     id 'org.owasp.dependencycheck' version "5.3.2.1"
@@ -605,18 +604,9 @@ configure(rootProject) {
         }
     }
 
-    coveralls {
-        sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
-        jacocoReportPath = "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
-    }
-
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
-    }
-
-    tasks.coveralls {
-        dependsOn 'jacocoRootReport'
     }
 
     task getVersion {


### PR DESCRIPTION
This removes the use of coveralls for code coverage stats, relying instead on Sonar