### PR TITLE
Support binary deletes, add binary table to jdbc component

### DIFF
--- a/components/jdbc/src/main/java/org/trellisldp/jdbc/DBWrappedMementoService.java
+++ b/components/jdbc/src/main/java/org/trellisldp/jdbc/DBWrappedMementoService.java
@@ -88,12 +88,18 @@ public class DBWrappedMementoService implements MementoService {
 
     @Override
     public CompletionStage<Void> put(final Resource resource) {
+        if (svc instanceof NoopMementoService) {
+            return svc.put(resource);
+        }
         return svc.put(resource).thenAccept(future ->
                 putTime(resource.getIdentifier(), resource.getModified()));
     }
 
     @Override
     public CompletionStage<SortedSet<Instant>> mementos(final IRI identifier) {
+        if (svc instanceof NoopMementoService) {
+            return svc.mementos(identifier);
+        }
         return supplyAsync(() -> {
             final SortedSet<Instant> instants = new TreeSet<>();
             jdbi.useHandle(handle -> handle

--- a/components/jdbc/src/main/resources/db/migration/V0.6__Trellis.sql
+++ b/components/jdbc/src/main/resources/db/migration/V0.6__Trellis.sql
@@ -1,0 +1,14 @@
+--
+-- binary TABLE
+--
+
+CREATE TABLE public.binary (
+    resource_id bigint NOT NULL,
+    data bytea NOT NULL
+);
+
+COMMENT ON TABLE public.binary IS 'This table can be used to store binary data for a resource.';
+
+COMMENT ON COLUMN public.binary.resource_id IS 'This value points to the relevant row in the resource table.';
+COMMENT ON COLUMN public.binary.data IS 'This holds the binary data itself, limited to 1GB in size';
+

--- a/components/jdbc/src/main/resources/org/trellisldp/jdbc/migrations.yml
+++ b/components/jdbc/src/main/resources/org/trellisldp/jdbc/migrations.yml
@@ -526,4 +526,24 @@ databaseChangeLog:
                 newColumnName: ext
                 columnDataType: VARCHAR(255)
                 remarks: Rename this to a non-reserved name.
+    - changeSet:
+        id: 6
+        author: acoburn
+        changes:
+            - createTable:
+                tableName: binary
+                remarks: This table can be used to store binary data for a resource.
+                columns:
+                    - column:
+                        name: resource_id
+                        type: BIGINT
+                        remarks: This value points to the relevant row in the resource table.
+                        constraints:
+                            nullable: false
+                    - column:
+                        name: data
+                        type: BLOB
+                        remarks: This holds the binary data itself.
+                        constraints:
+                            nullable: false
 

--- a/components/jdbc/src/test/java/org/trellisldp/jdbc/DBWrappedMementoServiceTest.java
+++ b/components/jdbc/src/test/java/org/trellisldp/jdbc/DBWrappedMementoServiceTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.slf4j.Logger;
 import org.trellisldp.api.MementoService;
+import org.trellisldp.api.NoopMementoService;
 import org.trellisldp.api.RDFFactory;
 import org.trellisldp.api.Resource;
 import org.trellisldp.file.FileMementoService;
@@ -127,6 +128,45 @@ class DBWrappedMementoServiceTest {
     void testNoArgCtor() {
         assertDoesNotThrow(() -> new DBWrappedMementoService());
     }
+
+    @Test
+    void testNoOpMementoService() {
+        final String dir = DBWrappedMementoService.class.getResource("/mementos").getFile();
+        final MementoService svc = new DBWrappedMementoService(pg.getPostgresDatabase(),
+                new NoopMementoService());
+
+        final Instant time = now();
+        final IRI identifier = rdf.createIRI("trellis:data/resource");
+
+        final Resource mockResource = mock(Resource.class);
+
+        when(mockResource.getIdentifier()).thenReturn(identifier);
+        when(mockResource.getInteractionModel()).thenReturn(LDP.RDFSource);
+        when(mockResource.getModified()).thenReturn(time);
+        when(mockResource.getContainer()).thenReturn(of(root));
+        when(mockResource.stream()).thenAnswer(inv -> Stream.of(
+                    rdf.createQuad(Trellis.PreferUserManaged, identifier, DC.title, rdf.createLiteral("Title"))));
+        when(mockResource.getBinaryMetadata()).thenReturn(empty());
+        when(mockResource.getMemberOfRelation()).thenReturn(empty());
+        when(mockResource.getMemberRelation()).thenReturn(empty());
+        when(mockResource.getMembershipResource()).thenReturn(empty());
+        when(mockResource.getInsertedContentRelation()).thenReturn(empty());
+
+        assertDoesNotThrow(svc.put(mockResource).toCompletableFuture()::join);
+        assertDoesNotThrow(svc.put(mockResource).toCompletableFuture()::join);
+
+        when(mockResource.getModified()).thenReturn(time.plusSeconds(2L));
+        assertDoesNotThrow(svc.put(mockResource).toCompletableFuture()::join);
+
+        when(mockResource.getModified()).thenReturn(time.plusSeconds(4L));
+        assertDoesNotThrow(svc.put(mockResource).toCompletableFuture()::join);
+
+        assertTrue(svc.mementos(identifier).toCompletableFuture().join().isEmpty());
+
+        assertEquals(Resource.SpecialResources.MISSING_RESOURCE,
+                svc.get(identifier, time).toCompletableFuture().join());
+    }
+
 
     @Test
     void testMementoUtils() {

--- a/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
+++ b/core/http/src/main/java/org/trellisldp/http/core/HttpConstants.java
@@ -82,6 +82,9 @@ public final class HttpConstants {
     /** Configuration key defining whether PUT-on-create generates contained or uncontained resources. */
     public static final String CONFIG_HTTP_PUT_UNCONTAINED = "trellis.http.put-uncontained";
 
+    /** Configuration key to purge binaries on delete. */
+    public static final String CONFIG_HTTP_PURGE_BINARY_ON_DELETE = "trelis.http.purge-binary-on-delete";
+
     /** Configuration key defining whether versions are created in the HTTP layer. */
     public static final String CONFIG_HTTP_VERSIONING = "trellis.http.versioning";
 

--- a/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/DeleteHandlerTest.java
@@ -23,6 +23,7 @@ import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.trellisldp.http.core.HttpConstants.ACL;
+import static org.trellisldp.http.core.HttpConstants.CONFIG_HTTP_PURGE_BINARY_ON_DELETE;
 import static org.trellisldp.http.core.RdfMediaType.TEXT_TURTLE;
 import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
 
@@ -34,6 +35,7 @@ import javax.ws.rs.core.Response;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.trellisldp.api.AuditService;
 import org.trellisldp.api.Metadata;
@@ -45,8 +47,25 @@ import org.trellisldp.vocabulary.LDP;
  */
 class DeleteHandlerTest extends BaseTestHandler {
 
+    @AfterEach
+    void cleanup() {
+        System.clearProperty(CONFIG_HTTP_PURGE_BINARY_ON_DELETE);
+    }
+
     @Test
     void testDelete() {
+        System.setProperty(CONFIG_HTTP_PURGE_BINARY_ON_DELETE, "true");
+        final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, extensions, null);
+        try (final Response res = handler.deleteResource(handler.initialize(mockParent, mockResource))
+                .toCompletableFuture().join().build()) {
+            assertEquals(NO_CONTENT, res.getStatusInfo(), ERR_RESPONSE_CODE);
+        }
+    }
+
+    @Test
+    void testDeleteWithBinaryPurge() {
+        System.setProperty(CONFIG_HTTP_PURGE_BINARY_ON_DELETE, "true");
+        when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         final DeleteHandler handler = new DeleteHandler(mockTrellisRequest, mockBundler, extensions, null);
         try (final Response res = handler.deleteResource(handler.initialize(mockParent, mockResource))
                 .toCompletableFuture().join().build()) {


### PR DESCRIPTION
This adds a `binary` table to the JDBC component structure, makes binary deletes configurable and improves support for no-op Memento service in the JDBC component.