### PR TITLE
Adjust binary table columns

### DIFF
--- a/components/jdbc/src/main/resources/db/migration/V0.6__Trellis.sql
+++ b/components/jdbc/src/main/resources/db/migration/V0.6__Trellis.sql
@@ -3,12 +3,12 @@
 --
 
 CREATE TABLE public.binary (
-    resource_id bigint NOT NULL,
+    id character varying(1024) PRIMARY KEY,
     data bytea NOT NULL
 );
 
 COMMENT ON TABLE public.binary IS 'This table can be used to store binary data for a resource.';
 
-COMMENT ON COLUMN public.binary.resource_id IS 'This value points to the relevant row in the resource table.';
+COMMENT ON COLUMN public.binary.id IS 'This value is the unique identifier for the binary.';
 COMMENT ON COLUMN public.binary.data IS 'This holds the binary data itself, limited to 1GB in size';
 

--- a/components/jdbc/src/main/resources/org/trellisldp/jdbc/migrations.yml
+++ b/components/jdbc/src/main/resources/org/trellisldp/jdbc/migrations.yml
@@ -535,10 +535,11 @@ databaseChangeLog:
                 remarks: This table can be used to store binary data for a resource.
                 columns:
                     - column:
-                        name: resource_id
-                        type: BIGINT
-                        remarks: This value points to the relevant row in the resource table.
+                        name: id
+                        type: VARCHAR(${id.length})
+                        remarks: This value is the unique identifier for the binary.
                         constraints:
+                            primaryKey: true
                             nullable: false
                     - column:
                         name: data


### PR DESCRIPTION
The binary table should have an identifier that is decoupled from the resource table