### PR TITLE
Change name of non-RDF table

### DIFF
--- a/components/jdbc/src/main/resources/db/migration/V0.6__Trellis.sql
+++ b/components/jdbc/src/main/resources/db/migration/V0.6__Trellis.sql
@@ -2,13 +2,13 @@
 -- binary TABLE
 --
 
-CREATE TABLE public.binary (
+CREATE TABLE public.nonrdf (
     id character varying(1024) PRIMARY KEY,
     data bytea NOT NULL
 );
 
-COMMENT ON TABLE public.binary IS 'This table can be used to store binary data for a resource.';
+COMMENT ON TABLE public.nonrdf IS 'This table can be used to store non-RDF data for a resource.';
 
-COMMENT ON COLUMN public.binary.id IS 'This value is the unique identifier for the binary.';
-COMMENT ON COLUMN public.binary.data IS 'This holds the binary data itself, limited to 1GB in size';
+COMMENT ON COLUMN public.nonrdf.id IS 'This value is the unique identifier for the non-RDF resource.';
+COMMENT ON COLUMN public.nonrdf.data IS 'This holds the non-RDF data itself, limited to 1GB in size';
 

--- a/components/jdbc/src/main/resources/org/trellisldp/jdbc/migrations.yml
+++ b/components/jdbc/src/main/resources/org/trellisldp/jdbc/migrations.yml
@@ -531,20 +531,20 @@ databaseChangeLog:
         author: acoburn
         changes:
             - createTable:
-                tableName: binary
-                remarks: This table can be used to store binary data for a resource.
+                tableName: nonrdf
+                remarks: This table can be used to store non-RDF data for a resource.
                 columns:
                     - column:
                         name: id
                         type: VARCHAR(${id.length})
-                        remarks: This value is the unique identifier for the binary.
+                        remarks: This value is the unique identifier for the non-RDF resource.
                         constraints:
                             primaryKey: true
                             nullable: false
                     - column:
                         name: data
                         type: BLOB
-                        remarks: This holds the binary data itself.
+                        remarks: This holds the non-RDF data itself.
                         constraints:
                             nullable: false
 


### PR DESCRIPTION
The name `binary` doesn't work so well as a table name.