### PR TITLE
Use correct URL for extension graph update events

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/MutatingLdpHandler.java
@@ -198,8 +198,9 @@ class MutatingLdpHandler extends BaseLdpHandler {
      */
     protected CompletionStage<Void> emitEvent(final IRI identifier, final IRI activityType, final IRI resourceType) {
         // Always notify about updates for the resource in question
+        final IRI eventResourceType = getExtensionGraphName() != null ? LDP.RDFSource : resourceType;
         getServices().getEventService().emit(new SimpleEvent(getUrl(identifier, resourceType), getSession().getAgent(),
-                    asList(PROV.Activity, activityType), ldpResourceTypes(resourceType).collect(toList())));
+                    asList(PROV.Activity, activityType), ldpResourceTypes(eventResourceType).collect(toList())));
 
         // Further notifications are only relevant for non-extension resources
         if (getExtensionGraphName() == null) {

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -276,7 +276,7 @@ public class PatchHandler extends MutatingLdpHandler {
 
         return createOrReplace(metadata, mutable, immutable)
             .thenCompose(future -> emitEvent(metadata.getIdentifier(), getResource() == null ? AS.Create : AS.Update,
-                        getExtensionGraphName() != null ? LDP.RDFSource : getLdpType()))
+                        getLdpType()))
             .thenApply(future -> {
                 final RDFSyntax outputSyntax = getSyntax(getServices().getIOService(),
                         getRequest().getAcceptableMediaTypes(), null);

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -303,8 +303,7 @@ public class PutHandler extends MutatingLdpHandler {
     }
 
     private CompletionStage<Void> handleUpdateEvent(final IRI ldpType) {
-        return emitEvent(getInternalId(), getResource() == null ? AS.Create : AS.Update,
-                getExtensionGraphName() != null ? LDP.RDFSource : ldpType);
+        return emitEvent(getInternalId(), getResource() == null ? AS.Create : AS.Update, ldpType);
     }
 
     private IRI effectiveLdpType(final IRI ldpType) {


### PR DESCRIPTION
Extension graph events for containers report non-container URLs. This ensures that events for containers use the correct URL.