### PR TITLE
include trellis-common in BOM

### DIFF
--- a/platform/bom/build.gradle
+++ b/platform/bom/build.gradle
@@ -1,6 +1,7 @@
 
 dependencies {
     implementation project(':trellis-api')
+    implementation project(':trellis-common')
     implementation project(':trellis-http')
     implementation project(':trellis-vocabulary')
 


### PR DESCRIPTION
The trellis-common module is missing from the trellis-bom component