### PR TITLE
WebACL default statements do not require acl:accessTo predicates

### DIFF
--- a/auth/webac/src/main/java/org/trellisldp/webac/WebAcService.java
+++ b/auth/webac/src/main/java/org/trellisldp/webac/WebAcService.java
@@ -315,7 +315,8 @@ public class WebAcService {
                             authorizations.stream().filter(getInheritedAuth(resource.getIdentifier())));
                 }
                 // If not inheriting, just return the relevant Authorizations
-                return new Authorizations(resource.getIdentifier(), authorizations.stream());
+                return new Authorizations(resource.getIdentifier(), authorizations.stream()
+                        .filter(auth -> auth.getAccessTo().contains(resource.getIdentifier())));
             } catch (final Exception ex) {
                 throw new TrellisRuntimeException("Error closing graph", ex);
             }
@@ -335,7 +336,9 @@ public class WebAcService {
                 } catch (final Exception ex) {
                     throw new TrellisRuntimeException("Error closing graph", ex);
                 }
-            }).filter(auth -> auth.getAccessTo().contains(identifier)).collect(toList());
+            })
+        .filter(auth -> auth.getAccessTo().contains(identifier) || auth.getDefault().contains(identifier))
+        .collect(toList());
     }
 
     static class Authorizations {

--- a/auth/webac/src/test/java/org/trellisldp/webac/WebAcServiceTest.java
+++ b/auth/webac/src/test/java/org/trellisldp/webac/WebAcServiceTest.java
@@ -714,7 +714,7 @@ class WebAcServiceTest {
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.mode, ACL.Read),
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.agentGroup, groupIRI2),
                 rdf.createQuad(PreferAccessControl, authIRI3, ACL.accessTo, childIRI),
-                rdf.createQuad(PreferAccessControl, authIRI2, ACL.default_, childIRI),
+                rdf.createQuad(PreferAccessControl, authIRI3, ACL.default_, childIRI),
 
                 rdf.createQuad(PreferAccessControl, authIRI4, ACL.agentGroup, groupIRI2),
                 rdf.createQuad(PreferAccessControl, authIRI4, type, ACL.Authorization)));
@@ -906,7 +906,6 @@ class WebAcServiceTest {
                 rdf.createQuad(PreferAccessControl, authIRI1, type, ACL.Authorization),
                 rdf.createQuad(PreferAccessControl, authIRI1, ACL.mode, ACL.Read),
                 rdf.createQuad(PreferAccessControl, authIRI1, ACL.agent, addisonIRI),
-                rdf.createQuad(PreferAccessControl, authIRI1, ACL.accessTo, childIRI),
                 rdf.createQuad(PreferAccessControl, authIRI1, ACL.default_, childIRI),
 
                 rdf.createQuad(PreferAccessControl, authIRI2, ACL.mode, ACL.Read),


### PR DESCRIPTION
Resolves #1027