### PR TITLE
Adjust OSGi tests for JDK 11

### DIFF
--- a/platform/osgi/build.gradle
+++ b/platform/osgi/build.gradle
@@ -9,9 +9,6 @@ repositories {
     }
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 def static randomPort() {
     try {
         ServerSocket server = new ServerSocket()
@@ -129,8 +126,3 @@ rootProject.childProjects.findAll { n, p -> p != project }.each { n, p ->
         tasks.test.dependsOn p.tasks.install
     }
 }
-
-java {
-    disableAutoTargetJvm()
-}
-

--- a/platform/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
+++ b/platform/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
@@ -40,6 +40,7 @@ import org.ops4j.pax.exam.ConfigurationManager;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
+import org.ops4j.pax.exam.options.extra.VMOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.BundleContext;
@@ -93,7 +94,24 @@ public class OSGiTest {
                     "https://repo1.maven.org/maven2@id=central"),
             editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiRegistryPort", rmiRegistryPort),
             editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiServerPort", rmiServerPort),
-            editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", sshPort)
+            editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", sshPort),
+
+            new VMOption("--add-opens"),
+            new VMOption("java.base/java.security=ALL-UNNAMED"),
+            new VMOption("--add-opens"),
+            new VMOption("java.base/java.net=ALL-UNNAMED"),
+            new VMOption("--add-opens"),
+            new VMOption("java.base/java.lang=ALL-UNNAMED"),
+            new VMOption("--add-opens"),
+            new VMOption("java.base/java.util=ALL-UNNAMED"),
+            new VMOption("--add-opens"),
+            new VMOption("java.naming/javax.naming.spi=ALL-UNNAMED"),
+            new VMOption("--add-opens"),
+            new VMOption("java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED"),
+            new VMOption("--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED"),
+            new VMOption("--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED"),
+            new VMOption("--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"),
+            new VMOption("--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED")
        };
     }
 


### PR DESCRIPTION
This allows the OSGi tests to use a JDK 11 target