### PR TITLE
Revert "Better support for Unicode paths"

### DIFF
--- a/components/jena/src/main/java/org/trellisldp/jena/JenaIOService.java
+++ b/components/jena/src/main/java/org/trellisldp/jena/JenaIOService.java
@@ -74,7 +74,6 @@ import org.apache.jena.riot.web.HttpOp;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.update.UpdateException;
-import org.apache.jena.util.URIref;
 import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.trellisldp.api.CacheService;
@@ -235,7 +234,7 @@ public class JenaIOService implements IOService {
 
         try {
             if (RDFA.equals(syntax)) {
-                writeHTML(triples, output, encodeURI(baseUrl));
+                writeHTML(triples, output, baseUrl);
             } else {
                 final Lang lang = JenaCommonsRDF.toJena(syntax).orElseThrow(() ->
                         new TrellisRuntimeException("Invalid content type: " + syntax.mediaType()));
@@ -248,7 +247,7 @@ public class JenaIOService implements IOService {
                     stream.start();
                     nsService.getNamespaces().forEach(stream::prefix);
                     if (shouldUseRelativeIRIs(relativeIRIs, profiles)) {
-                        stream.base(encodeURI(baseUrl));
+                        stream.base(baseUrl);
                     }
                     triples.map(JenaCommonsRDF::toJena).forEachOrdered(stream::triple);
                     stream.finish();
@@ -330,7 +329,7 @@ public class JenaIOService implements IOService {
             final Lang lang = JenaCommonsRDF.toJena(syntax).orElseThrow(() ->
                     new TrellisRuntimeException("Unsupported RDF Syntax: " + syntax.mediaType()));
 
-            RDFParser.source(input).lang(lang).base(encodeURI(base)).parse(graph);
+            RDFParser.source(input).lang(lang).base(base).parse(graph);
 
             // Check the graph for any new namespace definitions
             final Set<String> namespaces = new HashSet<>(nsService.getNamespaces().values());
@@ -357,17 +356,10 @@ public class JenaIOService implements IOService {
 
         try {
             final org.apache.jena.graph.Graph g = JenaCommonsRDF.toJena(graph);
-            execute(create(update, encodeURI(base)), g);
+            execute(create(update, base), g);
         } catch (final UpdateException | QueryParseException ex) {
             throw new TrellisRuntimeException(ex);
         }
-    }
-
-    static String encodeURI(final String uri) {
-        if (uri != null) {
-            return URIref.encode(uri);
-        }
-        return uri;
     }
 
     static Set<String> intoSet(final String property) {


### PR DESCRIPTION
Reverts trellis-ldp/trellis#1123

It turns out that Trellis already supports unicode characters in paths. The problem had more to do with how cURL handles unicode characters.