### PR TITLE
Improved support for Link header handling

### DIFF
--- a/core/common/src/main/java/org/trellisldp/common/TrellisRequest.java
+++ b/core/common/src/main/java/org/trellisldp/common/TrellisRequest.java
@@ -15,6 +15,7 @@
  */
 package org.trellisldp.common;
 
+import static java.util.Collections.emptyList;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static org.trellisldp.common.HttpConstants.ACCEPT_DATETIME;
@@ -33,6 +34,8 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+
+import org.trellisldp.vocabulary.LDP;
 
 /**
  * A class representing an HTTP request with various LDP-related headers and query parameters.
@@ -110,14 +113,19 @@ public class TrellisRequest {
     }
 
     /**
-     * Get the Link header.
+     * Get the first LDP Link header.
      *
-     * @return the Link header
+     * @return the first LDP Link header
      */
     public Link getLink() {
-        final String link = headers.getFirst(LINK);
-        if (link != null) {
-            return Link.valueOf(link);
+        for (final String header : headers.getOrDefault(LINK, emptyList())) {
+            final Link link = Link.valueOf(header);
+            if (Link.TYPE.equals(link.getRel())) {
+                final String uri = link.getUri().toString();
+                if (uri.startsWith(LDP.getNamespace()) && !uri.equals(LDP.Resource.getIRIString())) {
+                    return link;
+                }
+            }
         }
         return null;
     }

--- a/core/common/src/test/java/org/trellisldp/common/TrellisRequestTest.java
+++ b/core/common/src/test/java/org/trellisldp/common/TrellisRequestTest.java
@@ -208,6 +208,9 @@ class TrellisRequestTest {
         final URI uri = create("http://example.com/");
         final MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         final MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add("Link", "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\"");
+        headers.add("Link", "<http://example.com/SomeType>; rel=\"type\"");
+        headers.add("Link", "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"about\"");
         final String rawLink = "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"";
         headers.add("Link", rawLink);
         final MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
@@ -223,5 +226,28 @@ class TrellisRequestTest {
 
         final TrellisRequest req = new TrellisRequest(mockRequest, mockUriInfo, mockHeaders);
         assertEquals(Link.valueOf(rawLink), req.getLink());
+    }
+
+    @Test
+    void testSkippedLinkHeaders() {
+        final URI uri = create("http://example.com/");
+        final MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        final MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add("Link", "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\"");
+        headers.add("Link", "<http://example.com/SomeType>; rel=\"type\"");
+        headers.add("Link", "<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"about\"");
+        final MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+        pathParams.add("path", "resource");
+
+        when(mockUriInfo.getPath()).thenReturn("resource");
+        when(mockUriInfo.getPathParameters()).thenReturn(pathParams);
+        when(mockUriInfo.getQueryParameters()).thenReturn(queryParams);
+        when(mockUriInfo.getBaseUri()).thenReturn(uri);
+        when(mockHeaders.getRequestHeaders()).thenReturn(headers);
+        when(mockRequest.getMethod()).thenReturn(GET);
+        when(mockHeaders.getAcceptableMediaTypes()).thenReturn(singletonList(RdfMediaType.TEXT_TURTLE_TYPE));
+
+        final TrellisRequest req = new TrellisRequest(mockRequest, mockUriInfo, mockHeaders);
+        assertNull(req.getLink());
     }
 }

--- a/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PostHandler.java
@@ -119,14 +119,8 @@ public class PostHandler extends MutatingLdpHandler {
     }
 
     private static IRI getLdpType(final Link link, final RDFSyntax syntax, final String contentType) {
-        if (link != null && Link.TYPE.equals(link.getRel())) {
-            final String uri = link.getUri().toString();
-            if (uri.startsWith(LDP.getNamespace())) {
-                final IRI iri = rdf.createIRI(uri);
-                if (!LDP.Resource.equals(iri)) {
-                    return iri;
-                }
-            }
+        if (link != null) {
+            return rdf.createIRI(link.getUri().toString());
         }
         return contentType != null && syntax == null ? LDP.NonRDFSource : LDP.RDFSource;
     }

--- a/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PutHandler.java
@@ -212,11 +212,8 @@ public class PutHandler extends MutatingLdpHandler {
             return getResource().getInteractionModel();
         }
         final Link link = getRequest().getLink();
-        if (link != null && Link.TYPE.equals(link.getRel())) {
-            final String uri = link.getUri().toString();
-            if (uri.startsWith(LDP.getNamespace()) && !uri.equals(LDP.Resource.getIRIString())) {
-                return rdf.createIRI(uri);
-            }
+        if (link != null) {
+            return rdf.createIRI(link.getUri().toString());
         }
         if (getResource() != null) {
             return getResource().getInteractionModel();

--- a/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PostHandlerTest.java
@@ -130,7 +130,7 @@ class PostHandlerTest extends BaseTestHandler {
 
     @Test
     void testDefaultType3() throws IOException {
-        when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel(TYPE).build());
+        when(mockTrellisRequest.getLink()).thenReturn(null);
 
         final PostHandler handler = buildPostHandler(RESOURCE_EMPTY, NEW_RESOURCE, null);
         try (final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))
@@ -144,7 +144,7 @@ class PostHandlerTest extends BaseTestHandler {
     @Test
     void testDefaultType4() throws IOException {
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
-        when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel(TYPE).build());
+        when(mockTrellisRequest.getLink()).thenReturn(null);
 
         final PostHandler handler = buildPostHandler(RESOURCE_SIMPLE, NEW_RESOURCE, null);
         try (final Response res = handler.createResource(handler.initialize(mockParent, MISSING_RESOURCE))

--- a/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/PutHandlerTest.java
@@ -145,10 +145,10 @@ class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    void testPutLdpResourceDefaultType() {
+    void testPutNoLdpLinkType() {
         when(mockTrellisRequest.getPath()).thenReturn(RESOURCE_NAME);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_TURTLE);
-        when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel(TYPE).build());
+        when(mockTrellisRequest.getLink()).thenReturn(null);
 
         final PutHandler handler = buildPutHandler(RESOURCE_TURTLE, null, false);
         try (final Response res = handler.setResource(handler.initialize(mockParent, mockResource))
@@ -214,10 +214,10 @@ class PutHandlerTest extends BaseTestHandler {
     }
 
     @Test
-    void testPutLdpBinaryResourceWithLdprLink() {
+    void testPutLdpBinaryResourceNoLdpLink() {
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getContentType()).thenReturn(TEXT_PLAIN);
-        when(mockTrellisRequest.getLink()).thenReturn(fromUri(LDP.Resource.getIRIString()).rel(TYPE).build());
+        when(mockTrellisRequest.getLink()).thenReturn(null);
 
         final PutHandler handler = buildPutHandler(RESOURCE_SIMPLE, null);
         try (final Response res = handler.setResource(handler.initialize(mockParent, mockResource))


### PR DESCRIPTION
Resolves #1125

This makes it possible for clients to send multiple Link headers while not having to worry about ordering. Only the first _relevant_ LDP link header will be used by the HTTP layer.