### PR TITLE
The apiguardian version does not need to be managed independently of JUnit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ ext {
     postgresVersion = "42.2.18"
 
     // Testing
-    apiguardianVersion = "1.1.0"
     awaitilityVersion = "4.0.3"
     bouncycastleVersion = "1.66"
     commonsTextVersion = "1.9"


### PR DESCRIPTION
This is just minor clean-up.