### PR TITLE
Use major versions for GH action dependencies

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -12,8 +12,8 @@ jobs:
     name: Gradle Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.3
-      - uses: gradle/wrapper-validation-action@v1.0.3
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
 
   build:
     name: Java 11 environment
@@ -32,11 +32,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Run Snyk to check for vulnerabilities
       env:
         PROJECT_PATH: /project/trellis
@@ -71,9 +71,9 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
     - name: Publish to Sonatype
@@ -88,9 +88,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -105,9 +105,9 @@ jobs:
 
     name: Deploy Docker containers to GitHub
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -123,9 +123,9 @@ jobs:
     if: contains(github.ref, 'trellis')
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -156,9 +156,9 @@ jobs:
     if: contains(github.ref, 'trellis')
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -169,7 +169,7 @@ jobs:
           mv docs/apidocs/$(./gradlew -q getVersion) docs/trellis/$(./gradlew -q getVersion)/apidocs
 
     - name: Sync to AWS S3
-      uses: jakejarvis/s3-sync-action@v0.5.1
+      uses: jakejarvis/s3-sync-action@v0.5
       with:
         args: --acl public-read
       env:

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -15,8 +15,8 @@ jobs:
     name: Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.3
-      - uses: gradle/wrapper-validation-action@v1.0.3
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
 
   build:
     name: Java ${{ matrix.java }} environment
@@ -38,14 +38,14 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
 
     - name: Cache
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -76,14 +76,14 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
     - name: Cache
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -104,13 +104,13 @@ jobs:
     needs: [validation]
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
     - name: Cache
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -127,9 +127,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -153,9 +153,9 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -172,9 +172,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -200,9 +200,9 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 
@@ -220,13 +220,13 @@ jobs:
     needs: [validation]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
     - name: Cache
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.3
+      uses: actions/checkout@v2
       with:
         fetch-depth: 2
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v1
       with:
         java-version: 11
 


### PR DESCRIPTION
This will make version management much easier.