### PR TITLE
Completely remove dependency on jjwt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ ext {
     jacksonVersion = "2.12.1"
     jdbiVersion = "3.18.0"
     jenaVersion = "3.17.0"
-    jjwtVersion = "0.11.2"
     jsonldVersion = "0.13.0"
     kafkaVersion = "2.7.0"
     liquibaseVersion = "4.2.2"

--- a/components/test/build.gradle
+++ b/components/test/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind"
     implementation "commons-codec:commons-codec:$commonsCodecVersion"
     implementation "commons-io:commons-io:$commonsIoVersion"
-    implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
+    implementation "io.smallrye:smallrye-jwt-build:$smallryeJwtVersion"
     implementation "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsApiVersion"
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
     implementation "org.apache.commons:commons-text:$commonsTextVersion"

--- a/components/test/src/main/java/module-info.java
+++ b/components/test/src/main/java/module-info.java
@@ -37,7 +37,7 @@ module org.trellisldp.test {
     requires jakarta.inject;
 
     requires awaitility;
-    requires jjwt.api;
+    requires smallrye.jwt.build;
 
     opens org.trellisldp.test;
 }

--- a/components/test/src/main/java/org/trellisldp/test/AbstractApplicationAuthTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AbstractApplicationAuthTests.java
@@ -57,12 +57,6 @@ public abstract class AbstractApplicationAuthTests {
     public abstract String getBaseURL();
 
     /**
-     * Get the JWT secret.
-     * @return the JWT secret
-     */
-    public abstract String getJwtSecret();
-
-    /**
      * Get the credentials for the first user.
      * @return the credentials
      */
@@ -84,7 +78,7 @@ public abstract class AbstractApplicationAuthTests {
 
         @Override
         public String getAuthorizationHeader() {
-            return buildJwt(getAdminWebId(), AbstractApplicationAuthTests.this.getJwtSecret());
+            return buildJwt(getAdminWebId());
         }
     }
 
@@ -92,8 +86,7 @@ public abstract class AbstractApplicationAuthTests {
 
         @Override
         public String getAuthorizationHeader() {
-            return buildJwt("https://people.apache.org/~acoburn/#i",
-                    AbstractApplicationAuthTests.this.getJwtSecret());
+            return buildJwt("https://people.apache.org/~acoburn/#i");
         }
     }
 
@@ -107,8 +100,7 @@ public abstract class AbstractApplicationAuthTests {
     public class OtherUserTests extends BasicTests implements AuthOtherUserTests {
         @Override
         public String getAuthorizationHeader() {
-            return buildJwt("https://madison.example.com/profile/#me",
-                    AbstractApplicationAuthTests.this.getJwtSecret());
+            return buildJwt("https://madison.example.com/profile/#me");
         }
     }
 
@@ -290,7 +282,7 @@ public abstract class AbstractApplicationAuthTests {
         public void setUp() {
             final String acl = "acl";
             final String prefixAcl = "PREFIX acl: <http://www.w3.org/ns/auth/acl#>\n\n";
-            final String jwt = buildJwt(getAdminWebId(), AbstractApplicationAuthTests.this.getJwtSecret());
+            final String jwt = buildJwt(getAdminWebId());
 
             final String containerContent = getResourceAsString("/basicContainer.ttl");
             final String container;

--- a/components/test/src/main/java/org/trellisldp/test/AuditTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/AuditTests.java
@@ -27,10 +27,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.trellisldp.common.HttpConstants.SLUG;
 import static org.trellisldp.common.RdfMediaType.APPLICATION_SPARQL_UPDATE;
 import static org.trellisldp.common.RdfMediaType.TEXT_TURTLE;
-import static org.trellisldp.test.TestUtils.buildJwt;
 import static org.trellisldp.test.TestUtils.getResourceAsString;
 import static org.trellisldp.test.TestUtils.readEntityAsGraph;
 import static org.trellisldp.vocabulary.RDF.type;
+
+import io.smallrye.jwt.build.Jwt;
 
 import java.util.stream.Stream;
 
@@ -55,12 +56,6 @@ import org.trellisldp.vocabulary.Trellis;
 public interface AuditTests extends CommonTests {
 
     /**
-     * Get the JWT secret.
-     * @return the JWT secret
-     */
-    String getJwtSecret();
-
-    /**
      * Get the location of the test resource.
      * @return the resource URL
      */
@@ -76,11 +71,11 @@ public interface AuditTests extends CommonTests {
      * Set up the test infrastructure.
      */
     default void setUp() {
-        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString(), getJwtSecret());
+        final String jwt = "Bearer " + Jwt.claims().claim("webid", Trellis.AdministratorAgent.getIRIString()).sign();
 
-        final String user1 = buildJwt("https://people.apache.org/~acoburn/#i", getJwtSecret());
+        final String user1 = "Bearer " + Jwt.claims().claim("webid", "https://people.apache.org/~acoburn/#i").sign();
 
-        final String user2 = buildJwt("https://madison.example.com/profile#me", getJwtSecret());
+        final String user2 = "Bearer " + Jwt.claims().claim("webid", "https://madison.example.com/profile#me").sign();
 
         final String container;
         final String containerContent = getResourceAsString("/basicContainer.ttl");

--- a/components/test/src/main/java/org/trellisldp/test/EventTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/EventTests.java
@@ -56,12 +56,6 @@ public interface EventTests extends CommonTests {
     String CHILD_RESOURCE_FILE = "/childResource.ttl";
 
     /**
-     * Get the JWT secret.
-     * @return the JWT secret
-     */
-    String getJwtSecret();
-
-    /**
      * Get the location of the test container.
      * @return the container URL
      */
@@ -120,7 +114,7 @@ public interface EventTests extends CommonTests {
      */
     default void setUp() {
 
-        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString(), getJwtSecret());
+        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString());
 
         final String containerContent = getResourceAsString("/basicContainer.ttl");
 
@@ -191,7 +185,7 @@ public interface EventTests extends CommonTests {
 
         // POST an LDP-RS
         try (final Response res = target(getContainerLocation()).request()
-                .header(AUTHORIZATION, buildJwt(agent, getJwtSecret())).post(entity("", TEXT_TURTLE))) {
+                .header(AUTHORIZATION, buildJwt(agent)).post(entity("", TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Verify a successful LDP-RS POST response");
             assertAll("Check the resource parent",
                     checkResourceParentLdpBC(res.getLocation().toString(), agent, AS.Create, LDP.RDFSource));
@@ -207,7 +201,7 @@ public interface EventTests extends CommonTests {
 
         // POST an LDP-RS
         try (final Response res = target(getContainerLocation()).request()
-                .header(AUTHORIZATION, buildJwt(agent1, getJwtSecret())).post(entity("", TEXT_TURTLE))) {
+                .header(AUTHORIZATION, buildJwt(agent1)).post(entity("", TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Verify a successful LDP-RS POST response");
             resource = res.getLocation().toString();
             assertAll("Check the resource parent",
@@ -217,8 +211,7 @@ public interface EventTests extends CommonTests {
         final String agent2 = "https://pat.example.com/profile#me";
 
         // DELETE the LDP-RS
-        try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2, getJwtSecret()))
-                .delete()) {
+        try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2)).delete()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Verify a successful LDP-RS DELETE response");
             assertAll("Check the LDP-BC parent", checkResourceParentLdpBC(resource, agent2, AS.Delete, LDP.RDFSource));
         }
@@ -232,7 +225,7 @@ public interface EventTests extends CommonTests {
 
         // POST an LDP-RS
         try (final Response res = target(getDirectContainerLocation()).request()
-                .header(AUTHORIZATION, buildJwt(agent, getJwtSecret())).post(entity("", TEXT_TURTLE))) {
+                .header(AUTHORIZATION, buildJwt(agent)).post(entity("", TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful POST response");
             assertAll("Check the LDP-DC parent", checkResourceParentLdpDC(res.getLocation().toString(), agent,
                         AS.Create, LDP.RDFSource, LDP.Container));
@@ -248,7 +241,7 @@ public interface EventTests extends CommonTests {
 
         // POST an LDP-RS
         try (final Response res = target(getDirectContainerLocation()).request()
-                .header(AUTHORIZATION, buildJwt(agent, getJwtSecret())).post(entity("", TEXT_TURTLE))) {
+                .header(AUTHORIZATION, buildJwt(agent)).post(entity("", TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful POST in an LDP-DC");
             resource = res.getLocation().toString();
             assertAll("Check the LDP-DC parent",
@@ -258,8 +251,7 @@ public interface EventTests extends CommonTests {
         final String agent2 = "https://pat.example.com/profile#me";
 
         // DELETE the LDP-RS
-        try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2, getJwtSecret()))
-                .delete()) {
+        try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2)).delete()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful LDP-RS DELETE");
             assertAll("Check the LDP-DC parent resource",
                     checkResourceParentLdpDC(resource, agent2, AS.Delete, LDP.RDFSource, LDP.Container));
@@ -274,7 +266,7 @@ public interface EventTests extends CommonTests {
 
         // POST an LDP-RS
         try (final Response res = target(getIndirectContainerLocation()).request()
-                .header(AUTHORIZATION, buildJwt(agent, getJwtSecret()))
+                .header(AUTHORIZATION, buildJwt(agent))
                 .post(entity(getResourceAsString(CHILD_RESOURCE_FILE), TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful POST in an LDP-IC");
             assertAll("Check the LDP-IC parent", checkResourceParentLdpIC(res.getLocation().toString(),
@@ -292,7 +284,7 @@ public interface EventTests extends CommonTests {
 
         // POST an LDP-RS
         try (final Response res = target(getIndirectContainerLocation()).request()
-                .header(AUTHORIZATION, buildJwt(agent, getJwtSecret())).post(entity(childContent, TEXT_TURTLE))) {
+                .header(AUTHORIZATION, buildJwt(agent)).post(entity(childContent, TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful POST to an LDP-IC");
             resource = res.getLocation().toString();
         }
@@ -303,7 +295,7 @@ public interface EventTests extends CommonTests {
         final String agent2 = "https://hayden.example.com/profile#me";
 
         // Replace the LDP-RS
-        try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2, getJwtSecret()))
+        try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2))
                 .put(entity(childContent + "\n<> a <http://example.com/Type3> .", TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful PUT in an LDP-IC");
         }
@@ -324,7 +316,7 @@ public interface EventTests extends CommonTests {
 
         // POST an LDP-RS
         try (final Response res = target(getIndirectContainerLocation()).request()
-                .header(AUTHORIZATION, buildJwt(agent, getJwtSecret())).post(entity(childContent, TEXT_TURTLE))) {
+                .header(AUTHORIZATION, buildJwt(agent)).post(entity(childContent, TEXT_TURTLE))) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful POST in an LDP-IC");
             resource = res.getLocation().toString();
             assertAll("Check the LDP-IC parent resource",
@@ -334,8 +326,7 @@ public interface EventTests extends CommonTests {
         final String agent2 = "https://daryl.example.com/profile#me";
 
         // DELETE the LDP-RS
-        try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2, getJwtSecret()))
-                .delete()) {
+        try (final Response res = target(resource).request().header(AUTHORIZATION, buildJwt(agent2)).delete()) {
             assertEquals(SUCCESSFUL, res.getStatusInfo().getFamily(), "Check for a successful DELETE in an LDP-IC");
             assertAll("Check the LDP-IC parent resource",
                     checkResourceParentLdpIC(resource, agent2, AS.Delete, LDP.RDFSource, LDP.Container));
@@ -345,7 +336,7 @@ public interface EventTests extends CommonTests {
 
     default void testReceiveCreateMessageACL() {
 
-        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString(), getJwtSecret());
+        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString());
 
         final String resourceContent = getResourceAsString(CHILD_RESOURCE_FILE);
 
@@ -377,7 +368,7 @@ public interface EventTests extends CommonTests {
 
     default void testReceiveUpdateMessageACL() {
 
-        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString(), getJwtSecret());
+        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString());
 
         final String resourceContent = getResourceAsString(CHILD_RESOURCE_FILE);
 
@@ -425,7 +416,7 @@ public interface EventTests extends CommonTests {
 
     default void testReceiveDeleteMessageACL() {
 
-        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString(), getJwtSecret());
+        final String jwt = buildJwt(Trellis.AdministratorAgent.getIRIString());
 
         final String resourceContent = getResourceAsString(CHILD_RESOURCE_FILE);
 

--- a/components/test/src/main/java/org/trellisldp/test/TestUtils.java
+++ b/components/test/src/main/java/org/trellisldp/test/TestUtils.java
@@ -15,7 +15,6 @@
  */
 package org.trellisldp.test;
 
-import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.now;
 import static java.util.Collections.emptySet;
@@ -27,7 +26,7 @@ import static org.trellisldp.vocabulary.RDF.type;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.jsonwebtoken.Jwts;
+import io.smallrye.jwt.build.Jwt;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,15 +60,14 @@ public final class TestUtils {
             new NoopProfileCache(), emptySet(), emptySet(), false);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+
     /**
-     * Build a JWT Token.
-     * @param webid the web ID
-     * @param secret the JWT secret
-     * @return the JWT token
+     * Get a bearer token for the given webid.
+     * @param webid the webid
+     * @return the bearer token
      */
-    public static String buildJwt(final String webid, final String secret) {
-        return "Bearer " + Jwts.builder().claim("webid", webid)
-            .signWith(hmacShaKeyFor(secret.getBytes(UTF_8))).compact();
+    public static String buildJwt(final String webid) {
+        return "Bearer " + Jwt.claims().claim("webid", webid).sign();
     }
 
     /**


### PR DESCRIPTION
Using smallrye-jwt is much better for token generation/validation. This removes the dependency on java-jjwt