### PR TITLE
Redirect on binary content negotiation

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -155,6 +155,10 @@ public class GetHandler extends BaseLdpHandler {
         if (ext != null && !resource.stream(ext).findAny().isPresent()) {
             LOGGER.trace("No stream for extention: {}", ext);
             throw new NotFoundException();
+        } else if (getRequest().getExt() == null && syntax != null &&
+                LDP.NonRDFSource.equals(resource.getInteractionModel())) {
+            throw new RedirectionException(303,
+                    UriBuilder.fromUri(getIdentifier()).queryParam("ext", DESCRIPTION).build());
         }
 
         setResource(resource);

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -400,10 +400,12 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     @Test
     void testGetBinaryDescription() {
         try (final Response res = target(BINARY_PATH).request().accept("application/trig, text/turtle").get()) {
+            // ignore redirects to example.com
+            assumeTrue(res.getStatus() != 404);
             assertEquals(SC_OK, res.getStatus(), ERR_RESPONSE_CODE);
             assertTrue(getLinks(res).stream().anyMatch(hasLink(rdf.createIRI(HUB), HUB_PARAM)), ERR_HUB);
-            assertTrue(getLinks(res).stream().anyMatch(hasLink(rdf.createIRI(getBaseUrl() + BINARY_PATH), SELF)),
-                    "Missing rel=self header!");
+            assertTrue(getLinks(res).stream().anyMatch(hasLink(rdf.createIRI(getBaseUrl() + BINARY_PATH +
+                                "?ext=description"), SELF)), "Missing rel=self header!");
             assertTrue(res.getMediaType().isCompatible(TEXT_TURTLE_TYPE), ERR_CONTENT_TYPE + res.getMediaType());
             assertNull(res.getHeaderString(ACCEPT_RANGES), "Unexpected Accept-Ranges header!");
             assertNull(res.getHeaderString(MEMENTO_DATETIME), ERR_MEMENTO_DATETIME);
@@ -810,6 +812,7 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     @Test
     void testGetBinaryDescriptionLinks() {
         try (final Response res = target(BINARY_PATH).request().accept("text/turtle").get()) {
+            assumeTrue(res.getStatus() != 404);
             assertEquals(SC_OK, res.getStatus(), ERR_RESPONSE_CODE);
             assertTrue(getLinks(res).stream().anyMatch(l -> l.getRel().equals(DESCRIBES)), "Missing rel=describes");
             assertFalse(getLinks(res).stream().anyMatch(l -> l.getRel().equals(DESCRIBEDBY)),

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -42,6 +42,7 @@ import static javax.ws.rs.core.MediaType.WILDCARD_TYPE;
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.SEE_OTHER;
 import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
 import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
 import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
@@ -74,6 +75,7 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.RedirectionException;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
@@ -333,9 +335,10 @@ class GetHandlerTest extends BaseTestHandler {
 
         final GetConfiguration config = new GetConfiguration(false, true, true, null, null);
         final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, config);
-        try (final Response res = handler.getRepresentation(handler.standardHeaders(handler.initialize(mockResource)))
-                        .toCompletableFuture().join().build()) {
-            assertAll("Check binary description", checkBinaryDescription(res));
+
+        try (final Response res = assertThrows(RedirectionException.class, () -> handler.initialize(mockResource),
+                "No error thrown when content-negotiating a binary!").getResponse()) {
+            assertEquals(SEE_OTHER, res.getStatusInfo(), ERR_RESPONSE_CODE);
         }
     }
 


### PR DESCRIPTION
Binary content negotiation for RDF will now redirect to the description resource URL.