### PR TITLE
Remove description negotiation on LDP-NRs

### DIFF
--- a/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
+++ b/components/test/src/main/java/org/trellisldp/test/LdpBinaryTests.java
@@ -19,7 +19,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static javax.ws.rs.client.Entity.entity;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static javax.ws.rs.core.Response.Status.Family.REDIRECTION;
 import static org.apache.commons.rdf.api.RDFSyntax.TURTLE;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
@@ -108,26 +107,13 @@ public interface LdpBinaryTests extends CommonTests {
         final EntityTag etag = getETag(getResourceLocation());
 
         // Fetch the description
-        try (final Response res = target(getResourceLocation()).request().accept(TEXT_TURTLE).get()) {
-
-            if (REDIRECTION.equals(res.getStatusInfo().getFamily())) {
-                try (final Response redirect = target(res.getLocation().toString()).request().accept(TEXT_TURTLE)
-                            .get();
-                        final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
-                    assertAll("Check binary description", checkRdfResponse(redirect, LDP.RDFSource, TEXT_TURTLE_TYPE));
-                    assertTrue(g.size() >= 0L, "Assert that the graph isn't empty");
-                    assertTrue(redirect.getEntityTag().isWeak(), "Check for a weak ETag");
-                    assertNotEquals(etag, redirect.getEntityTag(), "Check for different ETag values");
-
-                }
-            } else {
-                try (final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
+        try (final Response res = target(getResourceLocation()).queryParam("ext", "description")
+                .request().accept(TEXT_TURTLE).get();
+             final Graph g = readEntityAsGraph(res.getEntity(), getBaseURL(), TURTLE)) {
                     assertAll("Check binary description", checkRdfResponse(res, LDP.RDFSource, TEXT_TURTLE_TYPE));
                     assertTrue(g.size() >= 0L, "Assert that the graph isn't empty");
                     assertTrue(res.getEntityTag().isWeak(), "Check for a weak ETag");
                     assertNotEquals(etag, res.getEntityTag(), "Check for different ETag values");
-                }
-            }
         }
     }
 

--- a/core/common/src/main/java/org/trellisldp/common/SimpleNotification.java
+++ b/core/common/src/main/java/org/trellisldp/common/SimpleNotification.java
@@ -90,7 +90,7 @@ public class SimpleNotification implements Notification {
 
     @Override
     public Optional<String> getObjectState() {
-        return Optional.of(objectState);
+        return Optional.ofNullable(objectState);
     }
 
     @Override

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -146,19 +146,17 @@ public class GetHandler extends BaseLdpHandler {
 
         LOGGER.debug("Acceptable media types: {}", getRequest().getAcceptableMediaTypes());
 
-        this.syntax = getSyntax(getServices().getIOService(),
-            getRequest().getAcceptableMediaTypes(), resource.getBinaryMetadata()
-                .filter(b -> !DESCRIPTION.equals(getRequest().getExt()))
-                .map(b -> b.getMimeType().orElse(APPLICATION_OCTET_STREAM)).orElse(null));
+        if (!LDP.NonRDFSource.equals(resource.getInteractionModel()) || getRequest().getExt() != null) {
+            this.syntax = getSyntax(getServices().getIOService(),
+                getRequest().getAcceptableMediaTypes(), resource.getBinaryMetadata()
+                    .filter(b -> !DESCRIPTION.equals(getRequest().getExt()))
+                    .map(b -> b.getMimeType().orElse(APPLICATION_OCTET_STREAM)).orElse(null));
+        }
 
         final IRI ext = getExtensionGraphName();
         if (ext != null && !resource.stream(ext).findAny().isPresent()) {
             LOGGER.trace("No stream for extention: {}", ext);
             throw new NotFoundException();
-        } else if (getRequest().getExt() == null && syntax != null &&
-                LDP.NonRDFSource.equals(resource.getInteractionModel())) {
-            throw new RedirectionException(303,
-                    UriBuilder.fromUri(getIdentifier()).queryParam("ext", DESCRIPTION).build());
         }
 
         setResource(resource);

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -399,7 +399,8 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     void testGetBinaryDescription() {
-        try (final Response res = target(BINARY_PATH).request().accept("application/trig, text/turtle").get()) {
+        try (final Response res = target(BINARY_PATH).queryParam("ext", "description").request()
+                .accept("application/trig, text/turtle").get()) {
             // ignore redirects to example.com
             assumeTrue(res.getStatus() != 404);
             assertEquals(SC_OK, res.getStatus(), ERR_RESPONSE_CODE);
@@ -811,7 +812,8 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
 
     @Test
     void testGetBinaryDescriptionLinks() {
-        try (final Response res = target(BINARY_PATH).request().accept("text/turtle").get()) {
+        try (final Response res = target(BINARY_PATH).queryParam("ext", "description").request()
+                .accept("text/turtle").get()) {
             assumeTrue(res.getStatus() != 404);
             assertEquals(SC_OK, res.getStatus(), ERR_RESPONSE_CODE);
             assertTrue(getLinks(res).stream().anyMatch(l -> l.getRel().equals(DESCRIBES)), "Missing rel=describes");

--- a/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/impl/GetHandlerTest.java
@@ -42,7 +42,6 @@ import static javax.ws.rs.core.MediaType.WILDCARD_TYPE;
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
-import static javax.ws.rs.core.Response.Status.SEE_OTHER;
 import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
 import static org.apache.commons.rdf.api.RDFSyntax.JSONLD;
 import static org.apache.commons.rdf.api.RDFSyntax.NTRIPLES;
@@ -75,7 +74,6 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import javax.ws.rs.NotAcceptableException;
-import javax.ws.rs.RedirectionException;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
@@ -330,20 +328,6 @@ class GetHandlerTest extends BaseTestHandler {
 
     @Test
     void testGetBinaryDescription() {
-        when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
-        when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
-
-        final GetConfiguration config = new GetConfiguration(false, true, true, null, null);
-        final GetHandler handler = new GetHandler(mockTrellisRequest, mockBundler, extensions, config);
-
-        try (final Response res = assertThrows(RedirectionException.class, () -> handler.initialize(mockResource),
-                "No error thrown when content-negotiating a binary!").getResponse()) {
-            assertEquals(SEE_OTHER, res.getStatusInfo(), ERR_RESPONSE_CODE);
-        }
-    }
-
-    @Test
-    void testGetBinaryDescription2() {
         when(mockResource.getBinaryMetadata()).thenReturn(of(testBinary));
         when(mockResource.getInteractionModel()).thenReturn(LDP.NonRDFSource);
         when(mockTrellisRequest.getExt()).thenReturn(DESCRIPTION);


### PR DESCRIPTION
This removes content negotiation on LDP-NR resources, which is not something that LDP describes.