### PR TITLE
Restrict PATCH to binary descriptions

### DIFF
--- a/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/DeleteHandler.java
@@ -27,6 +27,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static org.trellisldp.api.Resource.SpecialResources.DELETED_RESOURCE;
 import static org.trellisldp.api.Resource.SpecialResources.MISSING_RESOURCE;
 import static org.trellisldp.common.HttpConstants.CONFIG_HTTP_PURGE_BINARY_ON_DELETE;
+import static org.trellisldp.common.HttpConstants.DESCRIPTION;
 import static org.trellisldp.http.impl.HttpUtils.closeDataset;
 import static org.trellisldp.http.impl.HttpUtils.skolemizeQuads;
 import static org.trellisldp.vocabulary.Trellis.UnsupportedInteractionModel;
@@ -131,7 +132,7 @@ public class DeleteHandler extends MutatingLdpHandler {
     }
 
     private CompletionStage<Void> handleDeletion(final Dataset mutable, final Dataset immutable) {
-        if (getExtensionGraphName() != null) {
+        if (getExtensionGraphName() != null || DESCRIPTION.equals(getRequest().getExt())) {
             return handleSubGraphDeletion(mutable, immutable).thenCompose(future ->
                 emitNotification(getInternalId(), AS.Delete, getResource().getInteractionModel(),
                     getResource().getRevision()));

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -290,6 +290,12 @@ public class GetHandler extends BaseLdpHandler {
             builder.header(ALLOW, join(",", GET, HEAD, OPTIONS));
         } else if (getExtensionGraphName() != null) {
             builder.header(ALLOW, join(",", GET, HEAD, OPTIONS, PATCH));
+        } else if (getResource().getInteractionModel().equals(LDP.NonRDFSource)) {
+            if (getRequest().getExt() != null) {
+                builder.header(ALLOW, join(",", GET, HEAD, OPTIONS, PATCH, PUT, DELETE));
+            } else {
+                builder.header(ALLOW, join(",", GET, HEAD, OPTIONS, PUT, DELETE));
+            }
         } else if (getResource().getInteractionModel().equals(LDP.RDFSource)) {
             builder.header(ALLOW, join(",", GET, HEAD, OPTIONS, PATCH, PUT, DELETE));
         } else {

--- a/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/PatchHandler.java
@@ -16,6 +16,7 @@
 package org.trellisldp.http.impl;
 
 import static java.util.stream.Collectors.toList;
+import static javax.ws.rs.HttpMethod.*;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
@@ -48,6 +49,7 @@ import java.util.stream.Stream;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.NotAllowedException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Link;
@@ -144,6 +146,10 @@ public class PatchHandler extends MutatingLdpHandler {
         }
         // Check the cache headers
         if (exists(resource)) {
+            if (LDP.NonRDFSource.equals(resource.getInteractionModel()) && getRequest().getExt() == null) {
+                throw new NotAllowedException(GET, new String[]{HEAD, OPTIONS, PUT, DELETE});
+            }
+
             checkCache(resource.getModified(), generateEtag(resource.getRevision()));
 
             setResource(resource);

--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -410,9 +410,9 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
             assertTrue(res.getMediaType().isCompatible(TEXT_TURTLE_TYPE), ERR_CONTENT_TYPE + res.getMediaType());
             assertNull(res.getHeaderString(ACCEPT_RANGES), "Unexpected Accept-Ranges header!");
             assertNull(res.getHeaderString(MEMENTO_DATETIME), ERR_MEMENTO_DATETIME);
-            assertAll(CHECK_VARY_HEADERS, checkVary(res, asList(ACCEPT_DATETIME, PREFER)));
+            assertAll(CHECK_VARY_HEADERS, checkVary(res, List.of(ACCEPT_DATETIME, PREFER)));
             assertAll(CHECK_ALLOWED_METHODS,
-                    checkAllowedMethods(res, asList(PATCH, PUT, DELETE, GET, HEAD, OPTIONS, POST)));
+                    checkAllowedMethods(res, List.of(PATCH, PUT, DELETE, GET, HEAD, OPTIONS)));
             assertAll(CHECK_LDP_LINKS, checkLdpTypeHeaders(res, LDP.RDFSource));
         }
     }
@@ -2184,6 +2184,14 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     @Test
     void testPatchExistingBinary() {
         try (final Response res = target(BINARY_PATH).request()
+                .method(PATCH, entity(INSERT_TITLE, APPLICATION_SPARQL_UPDATE))) {
+            assertEquals(SC_METHOD_NOT_ALLOWED, res.getStatus(), ERR_RESPONSE_CODE);
+        }
+    }
+
+    @Test
+    void testPatchExistingBinaryDescription() {
+        try (final Response res = target(BINARY_PATH).queryParam("ext", "description").request()
                 .method(PATCH, entity(INSERT_TITLE, APPLICATION_SPARQL_UPDATE))) {
             assertEquals(SC_NO_CONTENT, res.getStatus(), ERR_RESPONSE_CODE);
             assertAll(CHECK_LDP_LINKS, checkLdpTypeHeaders(res, LDP.RDFSource));


### PR DESCRIPTION
This adjusts the behavior of LDP-NR resources such that they can no longer be the target of a PATCH. The associated description _can_ be the target of a PATCH