### PR TITLE
Include a vary: origin header

### DIFF
--- a/core/common/src/main/java/org/trellisldp/common/HttpConstants.java
+++ b/core/common/src/main/java/org/trellisldp/common/HttpConstants.java
@@ -115,6 +115,9 @@ public final class HttpConstants {
     /** The name of the HTTP response code for a Precondition Required error. */
     public static final int PRECONDITION_REQUIRED = 428;
 
+    /** The name of the HTTP request header indicating a browser's origin. */
+    public static final String ORIGIN = "Origin";
+
     /** The name of the HTTP request header used to influence what information is included in responses. */
     public static final String PREFER = "Prefer";
 

--- a/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
+++ b/core/http/src/main/java/org/trellisldp/http/impl/GetHandler.java
@@ -47,6 +47,7 @@ import static org.trellisldp.common.HttpConstants.ACCEPT_POST;
 import static org.trellisldp.common.HttpConstants.ACCEPT_RANGES;
 import static org.trellisldp.common.HttpConstants.DESCRIPTION;
 import static org.trellisldp.common.HttpConstants.MEMENTO_DATETIME;
+import static org.trellisldp.common.HttpConstants.ORIGIN;
 import static org.trellisldp.common.HttpConstants.PREFER;
 import static org.trellisldp.common.HttpConstants.PREFERENCE_APPLIED;
 import static org.trellisldp.common.HttpConstants.RANGE;
@@ -391,6 +392,7 @@ public class GetHandler extends BaseLdpHandler {
     private String buildVaryHeader(final boolean isLdpRs) {
         final List<String> variants = new ArrayList<>();
         variants.add(ACCEPT);
+        variants.add(ORIGIN);
         if (!isMemento) {
             variants.add(ACCEPT_DATETIME);
         }


### PR DESCRIPTION
This will include a `Vary: Origin` header to help with CORS issues when browsing from multiple domains.