### PR TITLE
Deprecate notification connectors

### DIFF
--- a/notifications/amqp/src/main/java/org/trellisldp/amqp/AmqpNotificationService.java
+++ b/notifications/amqp/src/main/java/org/trellisldp/amqp/AmqpNotificationService.java
@@ -35,7 +35,10 @@ import org.trellisldp.api.NotificationService;
 /**
  * An AMQP message producer capable of publishing messages to an AMQP broker such as
  * RabbitMQ or Qpid.
+ *
+ * @deprecated Please use the trellis-reactive project instead
  */
+@Deprecated
 public class AmqpNotificationService implements NotificationService {
 
     private static final Logger LOGGER = getLogger(AmqpNotificationService.class);

--- a/notifications/jms/src/main/java/org/trellisldp/jms/JmsNotificationService.java
+++ b/notifications/jms/src/main/java/org/trellisldp/jms/JmsNotificationService.java
@@ -33,7 +33,9 @@ import org.trellisldp.api.NotificationService;
  * A JMS message producer capable of publishing messages to a JMS broker such as ActiveMQ.
  *
  * @author acoburn
+ * @deprecated Please use the trellis-reactive project instead
  */
+@Deprecated
 public class JmsNotificationService implements NotificationService {
 
     /** The configuration key controlling the JMS queue name. */

--- a/notifications/kafka/src/main/java/org/trellisldp/kafka/KafkaNotificationService.java
+++ b/notifications/kafka/src/main/java/org/trellisldp/kafka/KafkaNotificationService.java
@@ -31,7 +31,10 @@ import org.trellisldp.api.NotificationService;
 
 /**
  * A Kafka message producer capable of publishing messages to a Kafka cluster.
+ *
+ * @deprecated Please use the trellis-reactive project instead
  */
+@Deprecated
 public class KafkaNotificationService implements NotificationService {
 
     private static final Logger LOGGER = getLogger(KafkaNotificationService.class);


### PR DESCRIPTION
Related to #1277

The features provided by these projects can all be achieved with `trellis-reactive`