### PR TITLE
Support client identifiers in session data structures

### DIFF
--- a/core/api/src/main/java/org/trellisldp/api/Session.java
+++ b/core/api/src/main/java/org/trellisldp/api/Session.java
@@ -48,7 +48,18 @@ public interface Session {
      *
      * @return the user who delegated access
      */
-    Optional<IRI> getDelegatedBy();
+    default Optional<IRI> getDelegatedBy() {
+        return Optional.empty();
+    }
+
+    /**
+     * Get the client identifier, if one exists.
+     *
+     * @return the client identifier
+     */
+    default Optional<String> getClientIdentifier() {
+        return Optional.empty();
+    }
 
     /**
      * Get the date when the session was created.

--- a/core/api/src/test/java/org/trellisldp/api/SessionTest.java
+++ b/core/api/src/test/java/org/trellisldp/api/SessionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Aaron Coburn and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SessionTest {
+
+    @Mock
+    private Session mockSession;
+
+    @Test
+    void testSession() {
+        doCallRealMethod().when(mockSession).getDelegatedBy();
+        doCallRealMethod().when(mockSession).getClientIdentifier();
+
+        assertFalse(mockSession.getDelegatedBy().isPresent());
+        assertFalse(mockSession.getClientIdentifier().isPresent());
+    }
+}


### PR DESCRIPTION
This makes it possible to represent client identifiers in `Session` data structures.