### PR TITLE
Use correct content negotiation for NonRDF resources

### DIFF
--- a/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
+++ b/core/http/src/test/java/org/trellisldp/http/AbstractTrellisHttpResourceTest.java
@@ -432,6 +432,13 @@ abstract class AbstractTrellisHttpResourceTest extends BaseTrellisHttpResourceTe
     }
 
     @Test
+    void testGetBinaryBadConneg() throws IOException {
+        try (final Response res = target(BINARY_PATH).request().header(ACCEPT, "text/turtle").get()) {
+            assertEquals(SC_NOT_ACCEPTABLE, res.getStatus(), ERR_RESPONSE_CODE);
+        }
+    }
+
+    @Test
     void testGetBinaryHeaders() {
         try (final Response res = target(BINARY_PATH).request().head()) {
             assertEquals(SC_OK, res.getStatus(), ERR_RESPONSE_CODE);


### PR DESCRIPTION
This addresses a bug for which content-negotiated LDP-NRs should return a 406 Not Acceptable error when an RDF syntax is requested.

In other words, given an LDP-NR at `/image`:

```http
GET /image
Accept: text/turtle
```

Should return a `406 Not Acceptable`

```http
GET /image
Accept: text/turtle, image/*
```

Should return a `200 OK`